### PR TITLE
Add ProxyFetch::CancelOutstanding and FollowFlushes option

### DIFF
--- a/net/instaweb/rewriter/public/rewrite_options.h
+++ b/net/instaweb/rewriter/public/rewrite_options.h
@@ -271,6 +271,7 @@ class RewriteOptions {
   static const char kFinderPropertiesCacheRefreshTimeMs[];
   static const char kFlushBufferLimitBytes[];
   static const char kFlushHtml[];
+  static const char kFollowFlushes[];
   static const char kFlushMoreResourcesEarlyIfTimePermits[];
   static const char kGoogleFontCssInlineMaxBytes[];
   static const char kForbidAllDisabledFilters[];
@@ -1777,6 +1778,9 @@ class RewriteOptions {
 
   void set_flush_html(bool x) { set_option(x, &flush_html_); }
   bool flush_html() const { return flush_html_.value(); }
+
+  void set_follow_flushes(bool x) { set_option(x, &follow_flushes_); }
+  bool follow_flushes() const { return follow_flushes_.value(); }
 
   void set_serve_split_html_in_two_chunks(bool x) {
     set_option(x, &serve_split_html_in_two_chunks_);
@@ -3700,6 +3704,9 @@ class RewriteOptions {
   Option<bool> respect_vary_;
   Option<bool> respect_x_forwarded_proto_;
   Option<bool> flush_html_;
+  // If set to true, ProxyFetch will request a flush on its RewriteDriver when
+  // Flush() is called on it.
+  Option<bool> follow_flushes_;
   // Should we serve the split html response in two chunks - above the fold and
   // below the fold. If set to false, we serve the above the fold and below the
   // fold in a single response.

--- a/net/instaweb/rewriter/rewrite_options.cc
+++ b/net/instaweb/rewriter/rewrite_options.cc
@@ -136,6 +136,7 @@ const char RewriteOptions::kFinderPropertiesCacheRefreshTimeMs[] =
     "FinderPropertiesCacheRefreshTimeMs";
 const char RewriteOptions::kFlushBufferLimitBytes[] = "FlushBufferLimitBytes";
 const char RewriteOptions::kFlushHtml[] = "FlushHtml";
+const char RewriteOptions::kFollowFlushes[] = "FollowFlushes";
 const char RewriteOptions::kFlushMoreResourcesEarlyIfTimePermits[] =
     "FlushMoreResourcesEarlyIfTimePermits";
 const char RewriteOptions::kForbidAllDisabledFilters[] =
@@ -1577,6 +1578,10 @@ void RewriteOptions::AddProperties() {
       false, &RewriteOptions::flush_html_, "fh", kFlushHtml,
       kDirectoryScope,
       NULL, true);  // TODO(jmarantz): implement for mod_pagespeed.
+  AddBaseProperty(
+      false, &RewriteOptions::follow_flushes_, "ff", kFollowFlushes,
+      kDirectoryScope,
+      NULL, false);
   AddBaseProperty(
       false, &RewriteOptions::css_preserve_urls_, "cpu",
       kCssPreserveURLs,

--- a/net/instaweb/rewriter/server_context.cc
+++ b/net/instaweb/rewriter/server_context.cc
@@ -884,9 +884,33 @@ void ServerContext::ShutDownDrivers() {
     if (RunningOnValgrind()) {
       timeout_ms *= 20;
     }
+
+    // It is possible that there's still a RewriteContext associated which has
+    // a call scheduled to run, which will drop the last reference and bring
+    // the reference count to 0. That will cause SignalIfRequired to DCHECK if
+    // there is a pending BoundedWaitFor on the driver. To avoid that, add a
+    // user-reference here to pin the driver. Note that in this case, there will
+    // be no user-references left on the driver originally.
+    active->AddUserReference();
     active->BoundedWaitFor(RewriteDriver::kWaitForShutDown, timeout_ms);
     active->Cleanup();  // Note: only cleans up if the rewrites are complete.
     // TODO(jmarantz): rename RewriteDriver::Cleanup to CleanupIfDone.
+  }
+
+  // It's possible that during the BoundedWaitFor the last reference was dropped
+  // in which case the active driver should now be contained in the deferred set.
+  // If it isn't, we need to call Cleanup here. We iterate again here, because
+  // in the earlier iteration other threads may be finishing up drivers and thus
+  // accessing the deferred set.
+  for (RewriteDriverSet::iterator i = active_rewrite_drivers_.begin();
+       i != active_rewrite_drivers_.end(); ++i) {
+    RewriteDriver* driver = *i;
+    if (deferred_release_rewrite_drivers_.find(driver)
+        == deferred_release_rewrite_drivers_.end()) {
+      driver->Cleanup();
+      DCHECK(deferred_release_rewrite_drivers_.find(driver)
+             != deferred_release_rewrite_drivers_.end());
+    }
   }
 }
 

--- a/pagespeed/automatic/proxy_fetch.h
+++ b/pagespeed/automatic/proxy_fetch.h
@@ -89,6 +89,11 @@ class ProxyFetchFactory {
       ProxyFetchPropertyCallbackCollector* property_callback,
       AsyncFetch* original_content_fetch);
 
+  // Calls Done(false) on all outstanding ProxyFetch instances, and waits for
+  // those to round up. Meant to be called before shutting down the rewrite
+  // driver factory when the server doesn't give a chance to do so otherwise.
+  void CancelOutstanding();
+
   // Initiates the PropertyCache lookup.  See ngx_pagespeed.cc or
   // proxy_interface.cc for example usage.
   static ProxyFetchPropertyCallbackCollector* InitiatePropertyCacheLookup(
@@ -117,6 +122,9 @@ class ProxyFetchFactory {
 
   scoped_ptr<AbstractMutex> outstanding_proxy_fetches_mutex_;
   std::set<ProxyFetch*> outstanding_proxy_fetches_;
+  // Tracks the number of ProxyFetch instances that have Done() called but have
+  // not been destructed yet.
+  AtomicInt32 proxy_fetches_done_in_flight_;
 
   DISALLOW_COPY_AND_ASSIGN(ProxyFetchFactory);
 };


### PR DESCRIPTION
- Adds ProxyFetch::CancelOutstanding() which helps ngx_pagespeed
  with shutting down quickly by calling Done(false) on all
  live ProxyFetch instances.
- Adds follow_flushes option, which makes ProxyFetch forward
  Flush calls to the RewriteDriver when set.

These changes are needed for: https://github.com/pagespeed/ngx_pagespeed/pull/936
