### PR TITLE
fix build of boringssl with newer compilers (gcc5)

### DIFF
--- a/third_party/serf/openssl.gyp
+++ b/third_party/serf/openssl.gyp
@@ -60,6 +60,9 @@
       'sources': [
         '<@(boringssl_lib_sources)',
       ],
+      'cflags': [
+        '-D_POSIX_C_SOURCE=200112L',
+      ],
       'defines': [ 'BORINGSSL_IMPLEMENTATION' ],
       'conditions': [
         ['component == "shared_library"', {


### PR DESCRIPTION
getaddrinfo is a POSIX extension.

newer compilers (gcc5?) require additional cflags to use getaddrinfo and
friends.
