### PR TITLE
nps-1015: IPRO+MPD support in ngx_pagespeed

### DIFF
--- a/pagespeed/apache/system_test.sh
+++ b/pagespeed/apache/system_test.sh
@@ -982,60 +982,6 @@ OUT=$($CURL --include --silent $URL)
 check_from "$OUT" fgrep -q "200 OK"
 check_from "$OUT" fgrep -q "$CONTENTS"
 
-# TODO(jefftk): All these MapProxyDomain/ipro tests need to move to
-# system/system_test.sh once ngx_pagespeed supports that combination.
-# See https://github.com/pagespeed/ngx_pagespeed/issues/1015
-
-start_test proxying from external domain should optimize images in-place.
-# Keep fetching this until it's headers include the string "PSA-aj" which
-# means rewriting has finished.
-URL="$PRIMARY_SERVER/modpagespeed_http/Puzzle.jpg"
-fetch_until -save $URL "grep -c PSA-aj" 1 "--save-headers"
-
-# We should see the origin etag in the wget output due to -save.  Note that
-# the cache-control will start at 5 minutes -- the default on modpagespeed.com,
-# and descend as time expires from when we strobed the image.  However, we
-# provide a non-trivial etag with the content hash, but we'll just match the
-# common prefix.
-check_from "$(extract_headers $FETCH_UNTIL_OUTFILE)" fgrep -q 'Etag: W/"PSA-aj-'
-
-# Ideally this response should not have a 'chunked' encoding, because
-# once we were able to optimize it, we know its length.
-check_from "$(extract_headers $FETCH_UNTIL_OUTFILE)" fgrep -q 'Content-Length:'
-check_not_from "$(extract_headers $FETCH_UNTIL_OUTFILE)" \
-    fgrep -q 'Transfer-Encoding: chunked'
-
-# Now add set jpeg compression to 75 and we expect 73238, but will test for 90k.
-# Note that wc -c will include the headers.
-start_test Proxying image from another domain, customizing image compression.
-URL+="?PageSpeedJpegRecompressionQuality=75"
-fetch_until -save $URL "wc -c" 90000 "--save-headers" "-lt"
-check_from "$(extract_headers $FETCH_UNTIL_OUTFILE)" fgrep -q 'Etag: W/"PSA-aj-'
-
-echo Ensure that rewritten images strip cookies present at origin
-check_not_from "$(extract_headers $FETCH_UNTIL_OUTFILE)" fgrep -qi 'Set-Cookie'
-$WGET -O $FETCH_UNTIL_OUTFILE --save-headers \
-  http://$PAGESPEED_TEST_HOST/do_not_modify/Puzzle.jpg
-ORIGINAL_HEADERS=$(extract_headers $FETCH_UNTIL_OUTFILE)
-check_from "$ORIGINAL_HEADERS" fgrep -q -i 'Set-Cookie'
-
-start_test proxying HTML from external domain should not work
-URL="$PRIMARY_SERVER/modpagespeed_http/evil.html"
-OUT=$(check_error_code 8 $WGET_DUMP $URL)
-check_not_from "$OUT" fgrep -q 'Set-Cookie:'
-
-start_test Fetching the HTML directly from the origin is fine including cookie.
-URL="http://$PAGESPEED_TEST_HOST/do_not_modify/evil.html"
-OUT=$($WGET_DUMP $URL)
-check_from "$OUT" fgrep -q -i 'Set-Cookie: test-cookie'
-
-start_test Ipro transcode to webp from MapProxyDomain
-URL="$PRIMARY_SERVER/modpagespeed_http/Puzzle.jpg"
-URL+="?PageSpeedFilters=+in_place_optimize_for_browser"
-WGET_ARGS="--user-agent webp --header Accept:image/webp"
-fetch_until "$URL" "grep -c image/webp" 1 --save-headers
-URL=""
-
 function scrape_secondary_stat {
   http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP \
     http://secondary.example.com/mod_pagespeed_statistics/ | \

--- a/pagespeed/automatic/proxy_fetch.h
+++ b/pagespeed/automatic/proxy_fetch.h
@@ -342,7 +342,7 @@ class ProxyFetch : public SharedAsyncFetch {
   //
   // This is used only for testing.
   static const int kTestSignalTimeoutMs = 200;
-
+  void set_trusted_input(bool trusted_input) { trusted_input_ = trusted_input; }
  protected:
   // protected interface from AsyncFetch.
   virtual void HandleHeadersComplete();
@@ -513,6 +513,10 @@ class ProxyFetch : public SharedAsyncFetch {
 
   // Set to true if this proxy_fetch is the result of a distributed fetch.
   bool distributed_fetch_;
+  
+  // Set to true if this proxy_fetch is actually operating on trusted
+  // (non-proxied) content.
+  bool trusted_input_;
 
   DISALLOW_COPY_AND_ASSIGN(ProxyFetch);
 };


### PR DESCRIPTION
- Move the Apache tests for IPRO + MPD to system/system_test.sh
- Add a flag 'trusted_input_' in ProxyFetch to allow ngx_pagespeed
  to transform html but not proxy external html fetched via MPD.

MPS-side of the fix for:
https://github.com/pagespeed/ngx_pagespeed/issues/1015
