### PR TITLE
Add newlines when missing at ends of combined CSS files,

### DIFF
--- a/net/instaweb/rewriter/css_inline_filter_test.cc
+++ b/net/instaweb/rewriter/css_inline_filter_test.cc
@@ -428,7 +428,7 @@ TEST_F(CssInlineFilterTest, InlineCombined) {
   GoogleString html_input =
       StrCat("<link rel=stylesheet href=\"", kCssUrl, "\">",
              "<link rel=stylesheet href=\"", kCssUrl, "\">");
-  GoogleString html_output = StrCat("<style>", kCss, kCss, "</style>");
+  GoogleString html_output = StrCat("<style>", kCss, "\n", kCss, "</style>");
 
   ValidateExpected("inline_combined", html_input, html_output);
   ValidateExpected("inline_combined", html_input, html_output);

--- a/net/instaweb/rewriter/js_combine_filter.cc
+++ b/net/instaweb/rewriter/js_combine_filter.cc
@@ -183,7 +183,7 @@ class JsCombineFilter::JsCombiner : public ResourceCombiner {
     return &kContentTypeJavascript;
   }
 
-  virtual bool WritePiece(int index, const Resource* input,
+  virtual bool WritePiece(int index, int num_pieces, const Resource* input,
                           OutputResource* combination, Writer* writer,
                           MessageHandler* handler);
 
@@ -450,8 +450,8 @@ class JsCombineFilter::Context : public RewriteContext {
 };
 
 bool JsCombineFilter::JsCombiner::WritePiece(
-    int index, const Resource* input, OutputResource* combination,
-    Writer* writer, MessageHandler* handler) {
+    int index, int num_pieces, const Resource* input,
+    OutputResource* combination, Writer* writer, MessageHandler* handler) {
   // Minify if needed.
   StringPiece not_escaped = input->ExtractUncompressedContents();
 

--- a/net/instaweb/rewriter/public/resource_combiner.h
+++ b/net/instaweb/rewriter/public/resource_combiner.h
@@ -115,8 +115,9 @@ class ResourceCombiner {
   // Override this to alter how pieces are processed when included inside
   // a combination. Returns whether successful. The default implementation
   // writes input->contents() to the writer without any alteration.
-  // 'index' is the position of this piece in the combination.
-  virtual bool WritePiece(int index, const Resource* input,
+  // 'index' is the position of this piece in the combination, while
+  // num_pieces is the total number of pieces.
+  virtual bool WritePiece(int index, int num_pieces, const Resource* input,
                           OutputResource* combination, Writer* writer,
                           MessageHandler* handler);
 

--- a/net/instaweb/rewriter/public/rewrite_context_test_base.h
+++ b/net/instaweb/rewriter/public/rewrite_context_test_base.h
@@ -295,12 +295,12 @@ class CombiningFilter : public RewriteFilter {
       return WriteCombination(in, out, rewrite_driver_->message_handler());
     }
 
-    virtual bool WritePiece(int index, const Resource* input,
+    virtual bool WritePiece(int index, int num_pieces, const Resource* input,
                             OutputResource* combination,
                             Writer* writer, MessageHandler* handler) {
       writer->Write(prefix_, handler);
       return ResourceCombiner::WritePiece(
-          index, input, combination, writer, handler);
+          index, num_pieces, input, combination, writer, handler);
     }
 
     void set_prefix(const GoogleString& prefix) { prefix_ = prefix; }

--- a/net/instaweb/rewriter/resource_combiner.cc
+++ b/net/instaweb/rewriter/resource_combiner.cc
@@ -261,7 +261,8 @@ bool ResourceCombiner::WriteCombination(
   StringWriter writer(&combined_contents);
   for (int i = 0, n = combine_resources.size(); written && (i < n); ++i) {
     ResourcePtr input(combine_resources[i]);
-    written = WritePiece(i, input.get(), combination.get(), &writer, handler);
+    written = WritePiece(i, n, input.get(),
+                         combination.get(), &writer, handler);
   }
   if (written) {
     // Intersect the response headers from each input.
@@ -289,6 +290,7 @@ bool ResourceCombiner::WriteCombination(
 }
 
 bool ResourceCombiner::WritePiece(int index,
+                                  int num_pieces,
                                   const Resource* input,
                                   OutputResource* /*combination*/,
                                   Writer* writer,

--- a/net/instaweb/rewriter/resource_combiner_test.cc
+++ b/net/instaweb/rewriter/resource_combiner_test.cc
@@ -89,10 +89,11 @@ class TestCombineFilter : public RewriteFilter {
     }
 
    protected:
-    virtual bool WritePiece(int index, const Resource* input,
+    virtual bool WritePiece(int index, int num_pieces, const Resource* input,
                             OutputResource* combination, Writer* writer,
                             MessageHandler* handler) {
-      ResourceCombiner::WritePiece(index, input, combination, writer, handler);
+      ResourceCombiner::WritePiece(index, num_pieces, input,
+                                   combination, writer, handler);
       writer->Write("|", handler);
       return true;
     }


### PR DESCRIPTION
in order to be more robust against problems involving unmatched
quotes.

See https://github.com/pagespeed/mod_pagespeed/issues/1165
