### PR TITLE
headers sanitization: additional hop-by-hop header handling

### DIFF
--- a/net/instaweb/rewriter/css_filter.cc
+++ b/net/instaweb/rewriter/css_filter.cc
@@ -73,13 +73,6 @@
 #include "pagespeed/opt/logging/enums.pb.h"
 #include "webutil/css/parser.h"
 
-#include "base/at_exit.h"
-
-namespace {
-
-base::AtExitManager* at_exit_manager = NULL;
-
-}  // namespace
 
 namespace net_instaweb {
 
@@ -894,8 +887,6 @@ T* MergeArrays(const T* a, int a_size, const T* b, int b_size, int* out_size) {
 }  // namespace
 
 void CssFilter::Initialize() {
-  InitializeAtExitManager();
-
   CHECK(merged_filters_ == NULL);
 #ifndef NDEBUG
   for (int i = 1; i < kRelatedFiltersSize; ++i) {
@@ -917,12 +908,6 @@ void CssFilter::Initialize() {
 }
 
 void CssFilter::Terminate() {
-  // Note: This is not thread-safe, but I don't believe we need it to be.
-  if (at_exit_manager != NULL) {
-    delete at_exit_manager;
-    at_exit_manager = NULL;
-  }
-
   CHECK(merged_filters_ != NULL);
   delete [] merged_filters_;
   merged_filters_ = NULL;
@@ -934,13 +919,6 @@ void CssFilter::Terminate() {
 void CssFilter::AddRelatedOptions(StringPieceVector* target) {
   for (int i = 0, n = arraysize(kRelatedOptions); i < n; ++i) {
     target->push_back(kRelatedOptions[i]);
-  }
-}
-
-void CssFilter::InitializeAtExitManager() {
-  // Note: This is not thread-safe, but I don't believe we need it to be.
-  if (at_exit_manager == NULL) {
-    at_exit_manager = new base::AtExitManager;
   }
 }
 

--- a/net/instaweb/rewriter/process_context.cc
+++ b/net/instaweb/rewriter/process_context.cc
@@ -16,6 +16,7 @@
 
 #include "net/instaweb/rewriter/public/process_context.h"
 
+#include "base/at_exit.h"
 #include "base/logging.h"
 #include "pagespeed/kernel/http/google_url.h"
 #include "pagespeed/kernel/html/html_keywords.h"
@@ -37,6 +38,8 @@ int construction_count = 0;
 
 namespace net_instaweb {
 
+base::AtExitManager* at_exit_manager = NULL;
+
 ProcessContext::ProcessContext()
     : js_tokenizer_patterns_(new pagespeed::js::JsTokenizerPatterns) {
   ++construction_count;
@@ -50,6 +53,9 @@ ProcessContext::ProcessContext()
   // thread-unsafe way and so it must be explicitly initialized prior to thread
   // creation, and explicitly terminated after thread quiescence.
   url::Initialize();
+  if (at_exit_manager == NULL) {
+    at_exit_manager = new base::AtExitManager;
+  }
 }
 
 ProcessContext::~ProcessContext() {
@@ -62,6 +68,10 @@ ProcessContext::~ProcessContext() {
 
   url::Shutdown();
   HtmlKeywords::ShutDown();
+  if (at_exit_manager != NULL) {
+    delete at_exit_manager;
+    at_exit_manager = NULL;
+  }
 }
 
 }  // namespace net_instaweb

--- a/net/instaweb/rewriter/public/css_filter.h
+++ b/net/instaweb/rewriter/public/css_filter.h
@@ -94,11 +94,6 @@ class CssFilter : public RewriteFilter {
   // Add this filters related options to the given vector.
   static void AddRelatedOptions(StringPieceVector* target);
 
-  // Note: AtExitManager needs to be initialized or you get a nasty error:
-  // Check failed: false. Tried to RegisterCallback without an AtExitManager.
-  // This is called by Initialize.
-  static void InitializeAtExitManager();
-
   virtual void StartDocumentImpl();
   virtual void StartElementImpl(HtmlElement* element);
   virtual void Characters(HtmlCharactersNode* characters);

--- a/pagespeed/kernel/http/headers.cc
+++ b/pagespeed/kernel/http/headers.cc
@@ -274,6 +274,7 @@ bool IsCommaSeparatedField(const StringPiece& name) {
   if (StringCaseEqual(name, HttpAttributes::kAccept) ||
       StringCaseEqual(name, HttpAttributes::kCacheControl) ||
       StringCaseEqual(name, HttpAttributes::kContentEncoding) ||
+      StringCaseEqual(name, HttpAttributes::kConnection) ||
       StringCaseEqual(name, HttpAttributes::kVary)) {
     return true;
   } else {

--- a/pagespeed/kernel/http/http_names.cc
+++ b/pagespeed/kernel/http/http_names.cc
@@ -19,6 +19,8 @@
 #include "pagespeed/kernel/http/http_names.h"
 
 
+#include "base/at_exit.h"
+#include "base/lazy_instance.h"
 #include "base/logging.h"
 #include "pagespeed/kernel/base/string_util.h"
 
@@ -33,6 +35,8 @@ const char HttpAttributes::kAccessControlAllowCredentials[] =
     "Access-Control-Allow-Credentials";
 const char HttpAttributes::kAge[] = "Age";
 const char HttpAttributes::kAllow[] = "Allow";
+const char HttpAttributes::kAltSvc[] = "Alt-Svc";
+const char HttpAttributes::kAlternateProtocol[] = "Alternate-Protocol";
 const char HttpAttributes::kAttachment[] = "attachment";
 const char HttpAttributes::kAuthorization[] = "Authorization";
 const char HttpAttributes::kCacheControl[] = "Cache-Control";
@@ -189,43 +193,138 @@ const char* HttpStatus::GetReasonPhrase(HttpStatus::Code rc) {
   return "";
 }
 
-StringPieceVector HttpAttributes::SortedHopByHopHeaders() {
-  // http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
-  const int kReserveSize = 10;
-  int index = 0;
-  StringPieceVector names(kReserveSize);
+namespace {
 
-  // This exact mechanism of initializing the names is used because it allows
-  // populating a StringPieceVector from locally defined string constants
-  // without having runtime calls to strlen to find the length.
-  names[index++] = StringPiece(HttpAttributes::kConnection);
-  names[index++] = StringPiece(HttpAttributes::kKeepAlive);
-  names[index++] = StringPiece(HttpAttributes::kProxyAuthenticate);
-  names[index++] = StringPiece(HttpAttributes::kProxyAuthorization);
-  names[index++] = StringPiece(HttpAttributes::kSetCookie);
-  names[index++] = StringPiece(HttpAttributes::kSetCookie2);
-  names[index++] = StringPiece(HttpAttributes::kTE);
-  names[index++] = StringPiece(HttpAttributes::kTrailers);
-  names[index++] = StringPiece(HttpAttributes::kTransferEncoding);
-  names[index++] = StringPiece(HttpAttributes::kUpgrade);
-  DCHECK_EQ(kReserveSize, index);
-  return names;
+class EndToEndHeadersContainer {
+ public:
+  EndToEndHeadersContainer() {
+    BuildEndToEnd();
+    BuildHopByHop();
+    BuildCachingHeadersToBeRemoved();
+  }
+
+  void BuildEndToEnd() {
+    // See http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.5.1
+    const int kReserveSize = 36;
+    int index = 0;
+    StringPieceVector names(kReserveSize);
+
+    names[index++] = StringPiece(HttpAttributes::kAccept);
+    names[index++] = StringPiece(HttpAttributes::kAcceptEncoding);
+    names[index++] = StringPiece(HttpAttributes::kAccessControlAllowOrigin);
+    names[index++] = StringPiece(HttpAttributes::kAccessControlAllowCredentials);
+    names[index++] = StringPiece(HttpAttributes::kAge);
+    names[index++] = StringPiece(HttpAttributes::kAllow);
+    names[index++] = StringPiece(HttpAttributes::kAuthorization);
+    names[index++] = StringPiece(HttpAttributes::kCacheControl);
+    names[index++] = StringPiece(HttpAttributes::kContentDisposition);
+    names[index++] = StringPiece(HttpAttributes::kContentEncoding);
+    names[index++] = StringPiece(HttpAttributes::kContentLanguage);
+    names[index++] = StringPiece(HttpAttributes::kContentLength);
+    names[index++] = StringPiece(HttpAttributes::kContentType);
+    names[index++] = StringPiece(HttpAttributes::kCookie);
+    names[index++] = StringPiece(HttpAttributes::kCookie2);
+    names[index++] = StringPiece(HttpAttributes::kDate);
+    names[index++] = StringPiece(HttpAttributes::kEtag);
+    names[index++] = StringPiece(HttpAttributes::kExpires);
+    names[index++] = StringPiece(HttpAttributes::kHost);
+    names[index++] = StringPiece(HttpAttributes::kIfModifiedSince);
+    names[index++] = StringPiece(HttpAttributes::kIfNoneMatch);
+    names[index++] = StringPiece(HttpAttributes::kLastModified);
+    names[index++] = StringPiece(HttpAttributes::kLink);
+    names[index++] = StringPiece(HttpAttributes::kLocation);
+    names[index++] = StringPiece(HttpAttributes::kOrigin);
+    names[index++] = StringPiece(HttpAttributes::kPragma);
+    names[index++] = StringPiece(HttpAttributes::kPurpose);
+    names[index++] = StringPiece(HttpAttributes::kReferer);
+    names[index++] = StringPiece(HttpAttributes::kRefresh);
+    names[index++] = StringPiece(HttpAttributes::kServer);
+    names[index++] = StringPiece(HttpAttributes::kSetCookie2);
+    names[index++] = StringPiece(HttpAttributes::kSetCookie);
+    names[index++] = StringPiece(HttpAttributes::kUserAgent);
+    names[index++] = StringPiece(HttpAttributes::kVary);
+    names[index++] = StringPiece(HttpAttributes::kVia);
+    names[index++] = StringPiece(HttpAttributes::kWarning);
+
+    DCHECK_EQ(kReserveSize, index);
+    end_to_end_ = names;
+  }
+  void BuildHopByHop() {
+    // http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
+    const int kReserveSize = 12;
+    int index = 0;
+    StringPieceVector names(kReserveSize);
+
+    // This exact mechanism of initializing the names is used because it allows
+    // populating a StringPieceVector from locally defined string constants
+    // without having runtime calls to strlen to find the length.
+    names[index++] = StringPiece(HttpAttributes::kAltSvc);
+    names[index++] = StringPiece(HttpAttributes::kAlternateProtocol);
+    names[index++] = StringPiece(HttpAttributes::kConnection);
+    names[index++] = StringPiece(HttpAttributes::kKeepAlive);
+    names[index++] = StringPiece(HttpAttributes::kProxyAuthenticate);
+    names[index++] = StringPiece(HttpAttributes::kProxyAuthorization);
+    names[index++] = StringPiece(HttpAttributes::kSetCookie);
+    names[index++] = StringPiece(HttpAttributes::kSetCookie2);
+    names[index++] = StringPiece(HttpAttributes::kTE);
+    names[index++] = StringPiece(HttpAttributes::kTrailers);
+    names[index++] = StringPiece(HttpAttributes::kTransferEncoding);
+    names[index++] = StringPiece(HttpAttributes::kUpgrade);
+    DCHECK_EQ(kReserveSize, index);
+    hop_by_hop_ = names;
+  }
+
+  void BuildCachingHeadersToBeRemoved() {
+    // http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
+    const int kReserveSize = 3;
+    int index = 0;
+    StringPieceVector names(kReserveSize);
+
+    // This exact mechanism of initializing the names is used because it allows
+    // populating a StringPieceVector from locally defined string constants
+    // without having runtime calls to strlen to find the length.
+    names[index++] = StringPiece(HttpAttributes::kLastModified);
+    names[index++] = StringPiece(HttpAttributes::kExpires);
+    names[index++] = StringPiece(HttpAttributes::kEtag);
+    DCHECK_EQ(kReserveSize, index);
+    caching_headers_to_be_removed_ = names;
+  }
+
+  const StringPieceVector& end_to_end() {
+    return end_to_end_;
+  }
+
+  const StringPieceVector& hop_by_hop() {
+    return hop_by_hop_;
+  }
+
+  const StringPieceVector& caching_headers_to_be_removed() {
+    return caching_headers_to_be_removed_;
+  }
+
+ private:
+  StringPieceVector end_to_end_;
+  StringPieceVector hop_by_hop_;
+  StringPieceVector caching_headers_to_be_removed_;
+};
+
+// TODO(oschaaf): motivate using LazyInstance here.
+base::LazyInstance<EndToEndHeadersContainer>
+    headers_container = LAZY_INSTANCE_INITIALIZER;
+
+}  // namespace
+
+
+const StringPieceVector& HttpAttributes::SortedEndToEndHeaders() {
+  return headers_container.Get().end_to_end();
 }
 
-StringPieceVector HttpAttributes::CachingHeadersToBeRemoved() {
-  // http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
-  const int kReserveSize = 3;
-  int index = 0;
-  StringPieceVector names(kReserveSize);
+const StringPieceVector& HttpAttributes::SortedHopByHopHeaders() {
+  return headers_container.Get().hop_by_hop();
+}
 
-  // This exact mechanism of initializing the names is used because it allows
-  // populating a StringPieceVector from locally defined string constants
-  // without having runtime calls to strlen to find the length.
-  names[index++] = StringPiece(HttpAttributes::kLastModified);
-  names[index++] = StringPiece(HttpAttributes::kExpires);
-  names[index++] = StringPiece(HttpAttributes::kEtag);
-  DCHECK_EQ(kReserveSize, index);
-  return names;
+const StringPieceVector& HttpAttributes::CachingHeadersToBeRemoved() {
+  return headers_container.Get().caching_headers_to_be_removed();
 }
 
 }  // namespace net_instaweb

--- a/pagespeed/kernel/http/http_names.h
+++ b/pagespeed/kernel/http/http_names.h
@@ -37,6 +37,8 @@ struct HttpAttributes {
   static const char kAccessControlAllowCredentials[];
   static const char kAge[];
   static const char kAllow[];
+  static const char kAltSvc[];
+  static const char kAlternateProtocol[];
   static const char kAttachment[];
   static const char kAuthorization[];
   static const char kCacheControl[];
@@ -152,6 +154,13 @@ struct HttpAttributes {
   static const char kXSendfile[];
   static const char kXAccelRedirect[];
 
+  // Gets a sorted StringPieceVector containing all the end-to-end headers.
+  // Any fields listed in here should be ignored during sanitization when they
+  // are specified in a Connection: header.
+  // See http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.5.1
+  // and https://www.mnot.net/blog/2011/07/11/what_proxies_must_do
+  static const StringPieceVector& SortedEndToEndHeaders();
+
   // Gets a sorted StringPieceVector containing all the hop-by-hop headers,
   // plus Set-Cookie and Set-Cookie2, per
   //
@@ -160,7 +169,7 @@ struct HttpAttributes {
   // returning it via StringPieceVector causes us to lose this guarantee and we
   // end up creating temporary GoogleStrings to convert these back to char*.
   // This performance overhead might be revisited if considered important.
-  static StringPieceVector SortedHopByHopHeaders();
+  static const StringPieceVector& SortedHopByHopHeaders();
 
   // Gets a StringPieceVector containing the caching-related headers that should
   // be removed from responses.
@@ -168,7 +177,7 @@ struct HttpAttributes {
   // returning it via StringPieceVector causes us to lose this guarantee and we
   // end up creating temporary GoogleStrings to convert these back to char*.
   // This performance overhead might be revisited if considered important.
-  static StringPieceVector CachingHeadersToBeRemoved();
+  static const StringPieceVector& CachingHeadersToBeRemoved();
 };
 
 namespace HttpStatus {

--- a/pagespeed/kernel/http/response_headers.cc
+++ b/pagespeed/kernel/http/response_headers.cc
@@ -539,17 +539,73 @@ void ResponseHeaders::SetOriginalContentLength(int64 content_length) {
 }
 
 bool ResponseHeaders::Sanitize() {
-  // Remove cookies, which we will never store in a cache.
-  StringPieceVector names_to_sanitize = HttpAttributes::SortedHopByHopHeaders();
-  return RemoveAllFromSortedArray(&names_to_sanitize[0],
-                                  names_to_sanitize.size());
+  ConstStringStarVector v;
+  bool changed = false;
+
+  // Sanitize any fields marked as hop-by-hop via the Connection: header
+  if (Lookup(HttpAttributes::kConnection, &v)) {
+    for (int i = 0, n = v.size(); i < n; ++i) {
+      StringPiece val = *v[i];
+      if (!IsHopByHopIndication(val)) {
+        continue;
+      }
+      changed = RemoveAll(*v[i]) || changed;
+    }
+  }
+
+  // Remove cookies plus any well-known hop-by-hop headers, which we will never
+  // store in a cache.
+  const StringPieceVector& names_to_sanitize =
+      HttpAttributes::SortedHopByHopHeaders();
+  changed = RemoveAllFromSortedArray(
+      &names_to_sanitize[0], names_to_sanitize.size()) || changed;
+  return changed;
 }
 
 void ResponseHeaders::GetSanitizedProto(HttpResponseHeaders* proto) const {
   Headers<HttpResponseHeaders>::CopyToProto(proto);
   protobuf::RepeatedPtrField<NameValue>* headers = proto->mutable_header();
-  StringPieceVector names_to_sanitize = HttpAttributes::SortedHopByHopHeaders();
+  StringPieceVector more_names;
+
+  // Mark all headers marked as hop-by-hop in "Connection: " for sanitization.
+  for (int i = 0, n = headers->size(); i < n; ++i) {
+    if (StringCaseEqual(headers->Get(i).name(), HttpAttributes::kConnection)) {
+      StringCompareInsensitive compare;
+      StringPieceVector split;
+      SplitStringPieceToVector(headers->Get(i).value(), ",", &split, true);
+      if (split.empty()) {
+        split.push_back(headers->Get(i).value());
+      }
+
+      // Check each value in Connection: val1, val2, ...
+      for (int j = 0, m = split.size(); j < m; ++j) {
+        StringPiece val = split[j];
+        TrimWhitespace(&val);
+        // Skip values that are connection-tokens, empty, or are defined
+        // as being end-to-end.
+        if (!IsHopByHopIndication(val)) {
+          continue;
+        }
+
+        // Find the position at which we should insert to keep the list sorted.
+        std::vector<StringPiece>::iterator up = std::lower_bound(
+            more_names.begin(), more_names.end(), val, compare);
+
+        // Insert when the entry is not already contained.
+        if (up == more_names.end() || !StringCaseEqual(*up, val)) {
+          more_names.insert(up, val);
+        }
+      }
+    }
+  }
+
+  const StringPieceVector& names_to_sanitize =
+      HttpAttributes::SortedHopByHopHeaders();
   RemoveFromHeaders(&names_to_sanitize[0], names_to_sanitize.size(), headers);
+  // The common case will be that more_names is empty.
+  if (more_names.size() > 0) {
+    RemoveFromHeaders(&more_names[0], more_names.size(), headers);
+  }
 }
 
 namespace {
@@ -1272,6 +1328,19 @@ bool ResponseHeaders::ApplySMaxAge(int s_maxage_sec,
     return false;
   }
   *updated_cache_control = StrCat(existing_cache_control, ", ", s_maxage_str);
+  return true;
+}
+
+bool ResponseHeaders::IsHopByHopIndication(StringPiece val) {
+  StringCompareInsensitive compare;
+  const StringPieceVector& end_to_end = HttpAttributes::SortedEndToEndHeaders();
+
+  if (val.empty() || StringCaseEqual(val, "keep-alive") ||
+      StringCaseEqual(val, "close") || StringCaseStartsWith(val, "timeout=") ||
+      StringCaseStartsWith(val, "max=") ||
+      std::binary_search(end_to_end.begin(), end_to_end.end(), val, compare)) {
+    return false;
+  }
   return true;
 }
 

--- a/pagespeed/kernel/http/response_headers.h
+++ b/pagespeed/kernel/http/response_headers.h
@@ -196,7 +196,8 @@ class ResponseHeaders : public Headers<HttpResponseHeaders> {
   // x-orginal-content-length header.
   void SetContentLength(int64 content_length);
 
-  // Removes cookie headers, and returns true if any changes were made.
+  // Removes hop-by-hop plus cookie headers, and returns true if any changes
+  // were made.
   bool Sanitize();
 
   // Copies the HttpResponseHeaders proto from the response headers to the given
@@ -392,7 +393,9 @@ class ResponseHeaders : public Headers<HttpResponseHeaders> {
   static bool ApplySMaxAge(int s_maxage_sec,
                            StringPiece existing_cache_control,
                            GoogleString* updated_cache_control);
-
+  // Returns true if the given value should be interpreted as a header being 
+  // marked as hop by hop when listed as a value in a Connection: header.
+  static bool IsHopByHopIndication(StringPiece val);
  protected:
   virtual void UpdateHook();
 

--- a/pagespeed/kernel/http/response_headers_test.cc
+++ b/pagespeed/kernel/http/response_headers_test.cc
@@ -716,16 +716,26 @@ TEST_F(ResponseHeadersTest, GetSanitizedProto) {
                       "Vary: User-Agent\r\n"
                       "Set-Cookie2: LA=1275937193\r\n"
                       "Vary: Accept-Encoding\r\n"
+                      "Connection: Foo, bar, Connection, Keep-Alive, "
+                      "Cache-Control,, foo\r\n"
+                      "foo: bar\r\n"
+                      "bar: foo\r\n"
+                      "ShouldRemain: foo\r\n"
                       "\r\n"));
   HttpResponseHeaders proto;
   response_headers_.GetSanitizedProto(&proto);
-  ASSERT_EQ(proto.header_size(), 4);
+  ASSERT_EQ(proto.header_size(), 5);
   EXPECT_EQ(proto.header(0).name(), HttpAttributes::kDate);
+  // Cache-Control is an end-to-end header, and should not be sanitized even
+  // though it is referenced in the Connection: header.
   EXPECT_EQ(proto.header(1).name(), HttpAttributes::kCacheControl);
   EXPECT_EQ(proto.header(1).value(), "max-age=100");
   EXPECT_EQ(proto.header(2).name(), HttpAttributes::kVary);
   EXPECT_EQ(proto.header(2).value(), "User-Agent");
   EXPECT_EQ(proto.header(3).name(), HttpAttributes::kVary);
+  EXPECT_EQ(proto.header(3).value(), "Accept-Encoding");
+  EXPECT_EQ(proto.header(4).name(), "ShouldRemain");
+  EXPECT_EQ(proto.header(4).value(), "foo");
   EXPECT_EQ(proto.status_code(), 200);
 }
 
@@ -2225,6 +2235,32 @@ TEST_F(ResponseHeadersTest, CacheControlPublic) {
   EXPECT_STREQ("no-cache", AddPublicToCacheControl({"no-cache"}));
   EXPECT_STREQ("No-Store", AddPublicToCacheControl({"No-Store"}));
   EXPECT_STREQ("No-Cache", AddPublicToCacheControl({"No-Cache"}));
+}
+
+TEST_F(ResponseHeadersTest, TestHopByHopSanitization) {
+  // RFC hop-by-hop list: http://tools.ietf.org/html/rfc7230#section-6.1
+  ResponseHeaders headers;
+
+  headers.Add(HttpAttributes::kConnection,
+              "Keep-Alive, Foo,, , bar, Cache-Control");
+  headers.Add(HttpAttributes::kKeepAlive, "foo");
+  headers.Add(HttpAttributes::kProxyAuthenticate, "foo");
+  headers.Add(HttpAttributes::kProxyAuthorization, "foo");
+  headers.Add(HttpAttributes::kTE, "foo");
+  headers.Add(HttpAttributes::kTrailers, "foo");
+  headers.Add(HttpAttributes::kTransferEncoding, "foo");
+  headers.Add(HttpAttributes::kUpgrade, "foo");
+  headers.Add(HttpAttributes::kAlternateProtocol, "foo");
+  headers.Add(HttpAttributes::kCacheControl, "foo");
+  // foo: foo is be referenced in "Connection: Foo", and therefore is marked
+  // as hop-by-hop and as such candidate for sanitization.
+  headers.Add("foo", "foo");
+
+  EXPECT_TRUE(headers.Sanitize());
+
+  // After sanitization, only end-to-end header Cache-Control should remain.
+  EXPECT_EQ("HTTP/1.0 0 (null)\r\nCache-Control: foo\r\n\r\n",
+            headers.ToString());
 }
 
 }  // namespace net_instaweb


### PR DESCRIPTION
Details: 
- Adds `Connection:` to the list of headers that contain fields separated by ","
- Marks `Alt-Svc` and `Alternate-Protocol` as hop-by-hop, so we will treat them as such.
- Adds sanitization of headers marked as hop-by-hop in `Connection:` headers as per rfc.
- Moves initialization of 'AtExitManager' out of the css filter to the more central `ProcessContext` as this change adds another dependancy on it -- and we must initialize it exactly once.
- Changes the header definitions to be lazy initialized to avoid extra allocations when manipulating headers, while avoiding static initialization. 

Fixes #1090
