### PR TITLE
convert-meta-tags: don't allow newlines when converting meta tags.

### DIFF
--- a/net/instaweb/rewriter/meta_tag_filter_test.cc
+++ b/net/instaweb/rewriter/meta_tag_filter_test.cc
@@ -67,6 +67,19 @@ TEST_F(MetaTagFilterTest, TestTags) {
       << *values[0];
 }
 
+const char kMetaTagDocInvalidAttribute[] =
+    "<html><head>"
+    "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=U\r\nTF-8\">"
+    "</head><body></body></html>";
+
+TEST_F(MetaTagFilterTest, TestRejectInvalidAttribute) {
+  headers()->RemoveAll(HttpAttributes::kContentType);
+  ValidateNoChanges("convert_tags_invalid_attribute", kMetaTagDocInvalidAttribute);
+  ConstStringStarVector values;
+  EXPECT_FALSE(headers()->Lookup(HttpAttributes::kContentType, &values));
+  ASSERT_EQ(0, values.size());
+}
+
 const char kMetaTagDoubleDoc[] =
     "<html><head>"
     "<meta http-equiv=\"Content-Type\" content=\"text/html;  charset=UTF-8\">"

--- a/pagespeed/kernel/http/response_headers.cc
+++ b/pagespeed/kernel/http/response_headers.cc
@@ -321,6 +321,12 @@ bool ResponseHeaders::CombineContentTypes(const StringPiece& orig,
 }
 
 bool ResponseHeaders::MergeContentType(const StringPiece& content_type) {
+  for (size_t i = 0; i < content_type.size(); i++) {
+    if (!IsNonControlAscii(content_type[i])) {
+      return false;
+    }
+  }
+
   bool ret = false;
   ConstStringStarVector old_values;
   Lookup(HttpAttributes::kContentType, &old_values);

--- a/pagespeed/kernel/http/response_headers.h
+++ b/pagespeed/kernel/http/response_headers.h
@@ -75,6 +75,8 @@ class ResponseHeaders : public Headers<HttpResponseHeaders> {
 
   // Merge the new content_type with what is already in the headers.
   // Returns true if the existing content-type header was changed.
+  // If the new content_type contains non-printable characters, the
+  // change will be rejected silently (and false will be returned).
   bool MergeContentType(const StringPiece& content_type);
 
   // Merge headers. Replaces all headers specified both here and in


### PR DESCRIPTION
This change makes ResponseHeaders::MergeContentType reject values
containing unprintable characters.

Fixes https://github.com/pagespeed/mod_pagespeed/issues/1083
