### PR TITLE
New option: AddResourceHeader

### DIFF
--- a/install/debug.conf.template
+++ b/install/debug.conf.template
@@ -32,6 +32,11 @@ ModPagespeedBlockingRewriteKey psatest
 # enable image beaconing explicitly.
 ModPagespeedCriticalImagesBeaconEnabled false
 
+<Location ~ "\.pagespeed\.([a-z]\.)?[a-z]{2}\.[^.]{10}\.[^.]+">
+  # For testing that AddResourceHeader gets passed through
+  ModPagespeedAddResourceHeader "X-Foo" "Bar"
+</Location>
+
 # By default, resources will not be used for inlining without explicit
 # authorization. Supported values are off or a comma-separated list of strings
 # from {Script,Stylesheet}.
@@ -1793,6 +1798,7 @@ Listen 127.0.0.2:@@APACHE_TERTIARY_PORT@@
 </VirtualHost>
 
 #ALL_DIRECTIVES # Invoke all ModPagespeed* directives to make sure they work:
+#ALL_DIRECTIVES ModPagespeedAddResourceHeader foo bar
 #ALL_DIRECTIVES ModPagespeedAllow foo
 #ALL_DIRECTIVES ModPagespeedAnalyticsID 1234
 #ALL_DIRECTIVES ModPagespeedAvoidRenamingIntrospectiveJavascript true
@@ -1813,6 +1819,7 @@ Listen 127.0.0.2:@@APACHE_TERTIARY_PORT@@
 #ALL_DIRECTIVES ModPagespeedCssInlineMaxBytes 2000
 #ALL_DIRECTIVES ModPagespeedCssOutlineMinBytes 2000
 #ALL_DIRECTIVES ModPagespeedCssPreserveURLs off
+#ALL_DIRECTIVES ModPagespeedCustomFetchHeader foo bar
 #ALL_DIRECTIVES ModPagespeedDefaultSharedMemoryCacheKB 1000
 #ALL_DIRECTIVES ModPagespeedDisableFilters strip_scripts
 #ALL_DIRECTIVES ModPagespeedDisallow bar

--- a/net/instaweb/rewriter/resource_fetch.cc
+++ b/net/instaweb/rewriter/resource_fetch.cc
@@ -171,6 +171,11 @@ void ResourceFetch::HandleHeadersComplete() {
   DCHECK(!response_headers()->Lookup(HttpAttributes::kSetCookie2, &v));
   response_headers()->RemoveAll(HttpAttributes::kSetCookie);
   response_headers()->RemoveAll(HttpAttributes::kSetCookie2);
+  for (int i = 0; i < driver_->options()->num_resource_headers(); ++i) {
+    const RewriteOptions::NameValue* nv =
+        driver_->options()->resource_header(i);
+    response_headers()->Add(nv->name, nv->value);
+  }
 
   // "Vary: Accept-Encoding" for all resources that are transmitted compressed.
   // Server ought to set these, I suppose.

--- a/net/instaweb/rewriter/resource_fetch_test.cc
+++ b/net/instaweb/rewriter/resource_fetch_test.cc
@@ -43,6 +43,7 @@ namespace {
 
 const char kCssContent[] = "* { display: none; }";
 const char kMinimizedCssContent[] = "*{display:none}";
+const char kValue[] = "Value";
 
 class ResourceFetchTest : public RewriteTestBase {
 };
@@ -66,6 +67,52 @@ TEST_F(ResourceFetchTest, BlockingFetch) {
           CreateRequestContext());
   RewriteOptions* custom_options =
       server_context()->global_options()->Clone();
+
+  GoogleString err;
+  // Tell ResourceFetch to add a few response headers to its results.
+  // Empty field name gets rejected.
+  EXPECT_FALSE(custom_options->ValidateAndAddResourceHeader("", "Bar", &err));
+
+  // Empty field value gets accepted.
+  EXPECT_TRUE(custom_options->ValidateAndAddResourceHeader(
+      "X-Foo-Empty", "", &err));
+
+  // No control characters allowed in field name
+  EXPECT_FALSE(custom_options->ValidateAndAddResourceHeader(
+      "X-Foo\ncontinue", "Bar", &err));
+
+  // No control characters allowed in field value
+  EXPECT_FALSE(custom_options->ValidateAndAddResourceHeader(
+      "X-Foo", "Bar\ncontinue", &err));
+
+  // No separators should be accepted in the field name
+  EXPECT_FALSE(custom_options->ValidateAndAddResourceHeader(
+      "X-Fo;o", "Bar", &err));
+
+  // Hop by hop headers should be refused.
+  EXPECT_FALSE(custom_options->ValidateAndAddResourceHeader(
+      "Connection", "close", &err));
+
+  // Cache-control header should be refused.
+  EXPECT_FALSE(custom_options->ValidateAndAddResourceHeader(
+      "Cache-Control", "private", &err));
+
+  // Request adding a reasonable header, which ResourceFetch should accept:
+  EXPECT_TRUE(custom_options->ValidateAndAddResourceHeader(
+      "X-Resource-Header", kValue, &err));
+
+  // Separators should be accepted in the field value
+  EXPECT_TRUE(custom_options->ValidateAndAddResourceHeader(
+      "X-FooSeparator", "B; ar", &err));
+
+  // Values should be trimmed.
+  EXPECT_TRUE(custom_options->ValidateAndAddResourceHeader(
+      "  X-FooTrim  ", "  Bar   ", &err));
+
+  // Empty field value gets accepted.
+  EXPECT_TRUE(custom_options->ValidateAndAddResourceHeader(
+      "X-Foo-Spaced-Value", "aa bb", &err));
+
   RewriteDriver* custom_driver =
       server_context()->NewCustomRewriteDriver(
           custom_options,
@@ -77,6 +124,26 @@ TEST_F(ResourceFetchTest, BlockingFetch) {
           url, server_context(), custom_driver, callback));
   EXPECT_TRUE(callback->IsDone());
   EXPECT_TRUE(callback->success());
+
+  // Validate our expectations w/regard to our earlier AddResponseHeader calls.
+  EXPECT_FALSE(callback->response_headers()->Has(""));
+  EXPECT_FALSE(callback->response_headers()->Has("X-Foo\ncontinue"));
+  EXPECT_FALSE(callback->response_headers()->Has("X-Foo"));
+
+  EXPECT_TRUE(callback->response_headers()->Has("X-Foo-Empty"));
+  EXPECT_STREQ("", callback->response_headers()->Lookup1("X-Foo-Empty"));
+
+  EXPECT_TRUE(callback->response_headers()->Has("X-Resource-Header"));
+  EXPECT_STREQ(
+      kValue, callback->response_headers()->Lookup1("X-Resource-Header"));
+
+  EXPECT_TRUE(callback->response_headers()->Has("X-FooTrim"));
+  EXPECT_STREQ("Bar", callback->response_headers()->Lookup1("X-FooTrim"));
+
+  EXPECT_TRUE(callback->response_headers()->Has("X-Foo-Spaced-Value"));
+  EXPECT_STREQ("aa bb", callback->response_headers()->Lookup1(
+      "X-Foo-Spaced-Value"));
+
   callback->Release();
 
   EXPECT_EQ(kMinimizedCssContent, buffer);
@@ -92,6 +159,12 @@ TEST_F(ResourceFetchTest, BlockingFetchOfInvalidUrl) {
   RewriteDriver* custom_driver =
       server_context()->NewCustomRewriteDriver(
           custom_options, CreateRequestContext());
+
+  GoogleString err;
+  EXPECT_TRUE(custom_options->ValidateAndAddResourceHeader(
+      "X-Resource-Header", kValue, &err));
+  EXPECT_EQ("", err);
+
   SyncFetcherAdapterCallback* callback =
       new SyncFetcherAdapterCallback(
           server_context()->thread_system(), &writer, CreateRequestContext());
@@ -111,8 +184,15 @@ TEST_F(ResourceFetchTest, BlockingFetchOfInvalidUrl) {
   EXPECT_FALSE(
       ResourceFetch::BlockingFetch(
           url, server_context(), custom_driver, callback));
+
+  // Validate our expectations w/regard to our earlier AddResponseHeader calls
+  // for responses to bad urls.
   EXPECT_TRUE(callback->IsDone());
   EXPECT_FALSE(callback->success());
+  EXPECT_TRUE(callback->response_headers()->Has("X-Resource-Header"));
+  EXPECT_STREQ(
+      kValue, callback->response_headers()->Lookup1("X-Resource-Header"));
+
   callback->Release();
 
   EXPECT_EQ("", buffer);

--- a/net/instaweb/rewriter/rewrite_options.cc
+++ b/net/instaweb/rewriter/rewrite_options.cc
@@ -329,6 +329,7 @@ const char RewriteOptions::kForbidFilters[] = "ForbidFilters";
 const char RewriteOptions::kInlineResourcesWithoutExplicitAuthorization[] =
     "InlineResourcesWithoutExplicitAuthorization";
 const char RewriteOptions::kRetainComment[] = "RetainComment";
+const char RewriteOptions::kAddResourceHeader[] = "AddResourceHeader";
 const char RewriteOptions::kCustomFetchHeader[] = "CustomFetchHeader";
 const char RewriteOptions::kLoadFromFile[] = "LoadFromFile";
 const char RewriteOptions::kLoadFromFileMatch[] = "LoadFromFileMatch";
@@ -994,6 +995,11 @@ std::vector<DeprecatedOptionMap> kDeprecatedOptionNameList(
     kDeprecatedOptionNameData,
     kDeprecatedOptionNameData + arraysize(kDeprecatedOptionNameData)
 );
+
+// Will be initialized to a sorted list of headers not allowed in
+// AddResourceHeader.
+const StringPieceVector* fixed_resource_headers = NULL;
+bool http_header_separators[256] = {false};
 
 }  // namespace
 
@@ -2454,6 +2460,7 @@ void RewriteOptions::AddProperties() {
 }  // NOLINT  (large function)
 
 RewriteOptions::~RewriteOptions() {
+  STLDeleteElements(&resource_headers_);
   STLDeleteElements(&custom_fetch_headers_);
   STLDeleteElements(&experiment_specs_);
   STLDeleteElements(&url_cache_invalidation_entries_);
@@ -2543,6 +2550,7 @@ bool RewriteOptions::Initialize() {
     all_properties_->Merge(properties_);
     InitOptionIdToPropertyArray();
     InitOptionNameToPropertyArray();
+    InitFixedResourceHeaders();
 
     for (int f = 0; f < static_cast<int>(RewriteOptions::kEndOfFilters); ++f) {
       RewriteOptions::Filter filter = static_cast<RewriteOptions::Filter>(f);
@@ -2641,7 +2649,39 @@ void RewriteOptions::InitOptionNameToPropertyArray() {
   }
 }
 
+void RewriteOptions::InitFixedResourceHeaders() {
+  StringPieceVector* tmp = new StringPieceVector();
+  tmp->push_back(HttpAttributes::kAcceptRanges);
+  tmp->push_back(HttpAttributes::kCacheControl);
+  tmp->push_back(HttpAttributes::kContentEncoding);
+  tmp->push_back(HttpAttributes::kContentLength);
+  tmp->push_back(HttpAttributes::kContentType);
+  tmp->push_back(HttpAttributes::kDate);
+  tmp->push_back(HttpAttributes::kEtag);
+  tmp->push_back(HttpAttributes::kExpires);
+  tmp->push_back(HttpAttributes::kLastModified);
+  tmp->push_back(HttpAttributes::kLink);
+  tmp->push_back(HttpAttributes::kServer);
+  tmp->push_back(HttpAttributes::kVary);
+  fixed_resource_headers = tmp;
+
+  // From <https://www.ietf.org/rfc/rfc2616.txt>
+  // token          = 1*<any CHAR except CTLs or separators>
+  //       separators     = "(" | ")" | "<" | ">" | "@"
+  //                      | "," | ";" | ":" | "\" | <">
+  //                      | "/" | "[" | "]" | "?" | "="
+  //                      | "{" | "}" | SP | HT
+  const GoogleString separators("()<>@,;:\\\"/[]?={} \t");
+  for (int i = 0, n = separators.size(); i < n; ++i) {
+    http_header_separators[static_cast<unsigned int>(separators.at(i))] = true;
+  }
+}
+
 bool RewriteOptions::Terminate() {
+  if (fixed_resource_headers != NULL) {
+    delete fixed_resource_headers;
+    fixed_resource_headers = NULL;
+  }
   if (Properties::Terminate(&properties_)) {
     DCHECK(option_id_to_property_array_ != NULL);
     delete [] option_id_to_property_array_;
@@ -3310,7 +3350,11 @@ RewriteOptions::OptionSettingResult RewriteOptions::ParseAndSetOptionFromName2(
   OptionSettingResult result = RewriteOptions::kOptionOk;
 
   // TODO(matterbury): use a hash map for faster lookup/switching.
-  if (StringCaseEqual(name, kCustomFetchHeader)) {
+  if (StringCaseEqual(name, kAddResourceHeader)) {
+    if (!ValidateAndAddResourceHeader(arg1, arg2, msg)) {
+      return RewriteOptions::kOptionValueInvalid;
+    }
+  } else if (StringCaseEqual(name, kCustomFetchHeader)) {
     AddCustomFetchHeader(arg1, arg2);
   } else if (StringCaseEqual(name, kLoadFromFile)) {
     file_load_policy()->Associate(arg1, arg2);
@@ -3769,6 +3813,10 @@ void RewriteOptions::Merge(const RewriteOptions& src) {
   if (src.downstream_cache_purge_location_prefix_.was_set()) {
     set_downstream_cache_purge_location_prefix(
       src.downstream_cache_purge_location_prefix());
+  }
+  for (int i = 0, n = src.resource_headers_.size(); i < n; ++i) {
+    NameValue* nv = src.resource_headers_[i];
+    AddResourceHeader(nv->name, nv->value);
   }
   for (int i = 0, n = src.custom_fetch_headers_.size(); i < n; ++i) {
     NameValue* nv = src.custom_fetch_headers_[i];
@@ -4432,6 +4480,104 @@ bool RewriteOptions::MergeOK() const {
 }
 #endif
 
+bool RewriteOptions::ValidateConfiguredHttpHeader(const GoogleString& name,
+                                                  const GoogleString& value,
+                                                  GoogleString* error_message) {
+  DCHECK(error_message != NULL);
+
+  if (error_message == NULL) {
+    return false;
+  }
+
+  // Reject empty field names. Empty field-values are acceptable.
+  // Impose a max length of 1024 on both field-name and field-value.
+  if (name.size() == 0) {
+    *error_message = "Empty field name not allowed";
+    return false;
+  }
+  if (name.size() > 1024) {
+    *error_message = "Field name too long";
+  }
+  if (value.size() > 1024) {
+    *error_message = "Field value too long";
+    return false;
+  }
+
+  for (int i = 0, n = name.size(); i < n; ++i) {
+    char c = name[i];
+    if (!IsNonControlAscii(c)) {
+      *error_message = StrCat("Invalid character in field name: ",
+                              GoogleString(1, c));
+      return false;
+    }
+    if (http_header_separators[static_cast<unsigned int>(c)]) {
+      *error_message = StrCat("Separator found in field name: ",
+                              GoogleString(1, c));
+      return false;
+    }
+  }
+
+  for (int i = 0, n = value.size(); i < n; ++i) {
+    // Formally the value may have any OCTET except CNTL, but including LWS.
+    // But in practice I think this is fair enough for our use case:
+    if (!IsNonControlAscii(value[i])) {
+      *error_message = StrCat("Invalid character in field value: ",
+                              GoogleString(1, value[i]));
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool RewriteOptions::ValidateAndAddResourceHeader(const StringPiece& name,
+                                                  const StringPiece& value,
+                                                  GoogleString* error_message) {
+  GoogleString gs_name;
+  GoogleString gs_value;
+
+  // Trim our input of whitespace, as we don't want any interpretation of that
+  // (especially header folding), and it probably was not intentionally
+  // configured like that anyway.
+  TrimWhitespace(name, &gs_name);
+  TrimWhitespace(value, &gs_value);
+
+  if (ValidateConfiguredHttpHeader(gs_name, gs_value, error_message)) {
+    // We don't allow overwriting hop-by-hop headers like Connection.
+    StringPieceVector hbh = HttpAttributes::SortedHopByHopHeaders();
+    StringCompareInsensitive compare;
+    if (std::binary_search(&hbh[0], &hbh[0] + hbh.size(), gs_name, compare)) {
+        *error_message = StrCat("Rejecting hop by hop header '", name, " '");
+        return false;
+    }
+
+    // We don't allow overwriting of headers we compute, like Cache-Control.
+    // In addition, there's a few other headers that should not be allowed
+    // so reject those fields as well:
+    const StringPiece* start = &fixed_resource_headers->at(0);
+    if (std::binary_search(
+        start, start + fixed_resource_headers->size(), gs_name, compare)) {
+        *error_message = StrCat("Rejecting header '", name, " '");
+        return false;
+    }
+
+    // Arbitrary limit of adding 20 headers
+    if (resource_headers_.size() > 20) {
+      *error_message = "Too many AddResourceHeader directives (max: 20)";
+      return false;
+    }
+    AddResourceHeader(gs_name, gs_value);
+    return true;
+  }
+  return false;
+}
+
+void RewriteOptions::AddResourceHeader(const StringPiece& name,
+                                       const StringPiece& value) {
+  resource_headers_.push_back(new NameValue(name, value));
+}
+
+  // TODO(oschaaf): should AddCustomFetchHeader have validations as well?
 void RewriteOptions::AddCustomFetchHeader(const StringPiece& name,
                                           const StringPiece& value) {
   custom_fetch_headers_.push_back(new NameValue(name, value));

--- a/pagespeed/apache/mod_instaweb.cc
+++ b/pagespeed/apache/mod_instaweb.cc
@@ -120,6 +120,7 @@ const char kModPagespeedBlockingRewriteRefererUrls[] =
 const char kModPagespeedConsoleDomains[] = "ModPagespeedConsoleDomains";
 const char kModPagespeedCreateSharedMemoryMetadataCache[] =
     "ModPagespeedCreateSharedMemoryMetadataCache";
+const char kModPagespeedAddResourceHeader[] = "ModPagespeedAddResourceHeader";
 const char kModPagespeedCustomFetchHeader[] = "ModPagespeedCustomFetchHeader";
 const char kModPagespeedDisableFilters[] = "ModPagespeedDisableFilters";
 const char kModPagespeedDisableForBots[] = "ModPagespeedDisableForBots";
@@ -1731,6 +1732,8 @@ static const command_rec mod_pagespeed_filter_cmds[] = {
                        "rewrites"),
 
   // All two parameter options that are allowed in <Directory> blocks.
+  APACHE_CONFIG_DIR_OPTION2(kModPagespeedAddResourceHeader,
+        "add_resource_header_name add_resource_header_value"),
   APACHE_CONFIG_DIR_OPTION2(kModPagespeedCustomFetchHeader,
         "custom_header_name custom_header_value"),
   APACHE_CONFIG_DIR_OPTION23(kModPagespeedMapOriginDomain,

--- a/pagespeed/kernel/http/http_names.cc
+++ b/pagespeed/kernel/http/http_names.cc
@@ -26,6 +26,7 @@ namespace net_instaweb {
 
 const char HttpAttributes::kAccept[] = "Accept";
 const char HttpAttributes::kAcceptEncoding[] = "Accept-Encoding";
+const char HttpAttributes::kAcceptRanges[] = "Accept-Ranges";
 const char HttpAttributes::kAccessControlAllowOrigin[] =
     "Access-Control-Allow-Origin";
 const char HttpAttributes::kAccessControlAllowCredentials[] =

--- a/pagespeed/kernel/http/http_names.h
+++ b/pagespeed/kernel/http/http_names.h
@@ -32,6 +32,7 @@ namespace net_instaweb {
 struct HttpAttributes {
   static const char kAccept[];
   static const char kAcceptEncoding[];
+  static const char kAcceptRanges[];
   static const char kAccessControlAllowOrigin[];
   static const char kAccessControlAllowCredentials[];
   static const char kAge[];

--- a/pagespeed/system/system_test.sh
+++ b/pagespeed/system/system_test.sh
@@ -2249,3 +2249,8 @@ if [ "$CACHE_FLUSH_TEST" = "on" ]; then
   # check [ $bytes -gt 100000 ]
   check [ $bytes -lt 100000 ]
 fi
+
+start_test AddResourceHeaders works for pagespeed resources.
+URL="$TEST_ROOT/compressed/hello_js.custom_ext.pagespeed.ce.HdziXmtLIV.txt"
+HTML_HEADERS=$($WGET_DUMP $URL)
+check_from "$HTML_HEADERS" grep -q "^X-Foo: Bar"


### PR DESCRIPTION
Allows setting headers on PageSpeed resources for CORS support.

Fixes https://github.com/pagespeed/ngx_pagespeed/issues/1005
