### PR TITLE
Strip subresource hints / issue 973

### DIFF
--- a/install/debug.conf.template
+++ b/install/debug.conf.template
@@ -238,6 +238,29 @@ ModPagespeedLoadFromFile "http://@@APACHE_DOMAIN@@/mod_pagespeed_test/ipro/insta
   Header append 'Cache-Control' 'no-transform'
 </Directory>
 
+<Directory "@@APACHE_DOC_ROOT@@/mod_pagespeed_test/strip_subresource_hints/default" >
+  ModPagespeedRewriteLevel CoreFilters
+  ModPagespeedDisableFilters add_instrumentation
+  ModPagespeedDisallow *dontrewriteme*
+</Directory>
+
+<Directory "@@APACHE_DOC_ROOT@@/mod_pagespeed_test/strip_subresource_hints/preserve_on/" >
+  ModPagespeedPreserveSubresourceHints on
+  ModPagespeedRewriteLevel CoreFilters
+  ModPagespeedDisableFilters add_instrumentation
+</Directory>
+
+<Directory "@@APACHE_DOC_ROOT@@/mod_pagespeed_test/strip_subresource_hints/preserve_off/" >
+  ModPagespeedPreserveSubresourceHints off
+  ModPagespeedRewriteLevel CoreFilters
+  ModPagespeedDisableFilters add_instrumentation
+</Directory>
+
+<Directory "@@APACHE_DOC_ROOT@@/mod_pagespeed_test/strip_subresource_hints/default_passthrough/" >
+  ModPagespeedRewriteLevel PassThrough
+  ModPagespeedDisableFilters add_instrumentation
+</Directory>
+
 # This Directory does not even exist, but by setting some options in that
 # scope we test to make sure the options we claim are really settable in
 # .htaccess.  Note that <Directory> and .htaccess are enforced the same way.
@@ -1861,6 +1884,7 @@ Listen 127.0.0.2:@@APACHE_TERTIARY_PORT@@
 #ALL_DIRECTIVES ModPagespeedNumExpensiveRewriteThreads 2
 #ALL_DIRECTIVES ModPagespeedNumRewriteThreads 4
 #ALL_DIRECTIVES ModPagespeedOptionCookiesDurationMs 12345
+#ALL_DIRECTIVES ModPagespeedPreserveSubresourceHints on
 #ALL_DIRECTIVES ModPagespeedPreserveUrlRelativity on
 #ALL_DIRECTIVES ModPagespeedProgressiveJpegMinBytes 1000
 #ALL_DIRECTIVES ModPagespeedRateLimitBackgroundFetches true

--- a/install/mod_pagespeed_test/strip_subresource_hints/default/disallowtest.html
+++ b/install/mod_pagespeed_test/strip_subresource_hints/default/disallowtest.html
@@ -1,0 +1,5 @@
+<html>
+  <head><link rel="subresource" src="dontrewriteme_resource.jpg"/></head>
+<body>
+</body>
+</html>

--- a/install/mod_pagespeed_test/strip_subresource_hints/default/index.html
+++ b/install/mod_pagespeed_test/strip_subresource_hints/default/index.html
@@ -1,0 +1,5 @@
+<html>
+  <head><link rel="subresource" src="test"/></head>
+<body>
+</body>
+</html>

--- a/install/mod_pagespeed_test/strip_subresource_hints/default/multiple_subresource_hints.html
+++ b/install/mod_pagespeed_test/strip_subresource_hints/default/multiple_subresource_hints.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <link rel="subresource" src="test1"/>
+    <link rel="subresource" src="test2"/>
+  </head>
+<body>
+</body>
+</html>

--- a/install/mod_pagespeed_test/strip_subresource_hints/default_passthrough/index.html
+++ b/install/mod_pagespeed_test/strip_subresource_hints/default_passthrough/index.html
@@ -1,0 +1,5 @@
+<html>
+  <head><link rel="subresource" src="test"/></head>
+<body>
+</body>
+</html>

--- a/install/mod_pagespeed_test/strip_subresource_hints/preserve_off/index.html
+++ b/install/mod_pagespeed_test/strip_subresource_hints/preserve_off/index.html
@@ -1,0 +1,5 @@
+<html>
+  <head><link rel="subresource" src="test"/></head>
+<body>
+</body>
+</html>

--- a/install/mod_pagespeed_test/strip_subresource_hints/preserve_on/index.html
+++ b/install/mod_pagespeed_test/strip_subresource_hints/preserve_on/index.html
@@ -1,0 +1,5 @@
+<html>
+  <head><link rel="subresource" src="test"/></head>
+<body>
+</body>
+</html>

--- a/install/setup_test_machine.sh
+++ b/install/setup_test_machine.sh
@@ -66,6 +66,7 @@ fi
 # This sequence is described in /usr/share/doc/apache2.2-common/README.Debian.gz
 sudo a2ensite default-ssl
 sudo a2enmod ssl
+sudo a2enmod headers
 sudo make-ssl-cert generate-default-snakeoil --force-overwrite
 
 # TODO(jefftk): We don't restart the test servers often enough for this to be

--- a/install/ubuntu.sh
+++ b/install/ubuntu.sh
@@ -2,11 +2,21 @@
 
 echo make $*
 
+APACHE_DOC_ROOT=/var/www
+#Test for new ubuntu setups, doc/root is in /var/www/html
+#we could run into a false positive here, but not probable
+#for build systems
+if [ -e /var/www/html ]
+then
+  APACHE_DOC_ROOT=/var/www/html
+fi
+
 exec make \
     APACHE_CONTROL_PROGRAM=/etc/init.d/apache2 \
     APACHE_LOG=/var/log/apache2/error.log \
     APACHE_MODULES=/usr/lib/apache2/modules \
     APACHE_CONF_FILE=/etc/apache2/apache2.conf \
+    APACHE_DOC_ROOT=$APACHE_DOC_ROOT \
     APACHE_PIDFILE=/var/run/apache2.pid \
     APACHE_PROGRAM=/usr/sbin/apache2 \
     APACHE_ROOT=/etc/apache2 \

--- a/net/instaweb/instaweb.gyp
+++ b/net/instaweb/instaweb.gyp
@@ -1830,6 +1830,7 @@
         'rewriter/split_html_helper_filter.cc',
         'rewriter/strip_non_cacheable_filter.cc',
         'rewriter/strip_scripts_filter.cc',
+        'rewriter/strip_subresource_hints_filter.cc',
         'rewriter/support_noscript_filter.cc',
         'rewriter/suppress_prehead_filter.cc',
         'rewriter/url_input_resource.cc',

--- a/net/instaweb/rewriter/public/rewrite_driver.h
+++ b/net/instaweb/rewriter/public/rewrite_driver.h
@@ -1244,7 +1244,7 @@ class RewriteDriver : public HtmlParse {
   bool Decode(StringPiece leaf, ResourceNamer* resource_namer) const;
 
  protected:
-  virtual void DetermineEnabledFiltersImpl();
+  virtual void DetermineFiltersBehaviorImpl();
 
  private:
   friend class DistributedRewriteContextTest;

--- a/net/instaweb/rewriter/public/rewrite_filter.h
+++ b/net/instaweb/rewriter/public/rewrite_filter.h
@@ -49,6 +49,10 @@ class RewriteFilter : public CommonFilter {
   // UsePropertyCacheDomCohort to return true.
   virtual void DetermineEnabled(GoogleString* disabled_reason);
 
+  // RewriteFilters can probably rewrite urls.
+  // A derived filter can change this to return false.
+  virtual bool CanModifyUrls() {return true;}
+
   // All RewriteFilters define how they encode URLs and other
   // associated information needed for a rewrite into a URL.
   // The default implementation handles a single URL with

--- a/net/instaweb/rewriter/public/rewrite_options.h
+++ b/net/instaweb/rewriter/public/rewrite_options.h
@@ -360,6 +360,7 @@ class RewriteOptions {
   static const char kObliviousPagespeedUrls[];
   static const char kOptionCookiesDurationMs[];
   static const char kOverrideCachingTtlMs[];
+  static const char kPreserveSubresourceHints[];
   static const char kPreserveUrlRelativity[];
   static const char kPrivateNotVaryForIE[];
   static const char kProactiveResourceFreshening[];
@@ -1524,6 +1525,13 @@ class RewriteOptions {
   }
   void set_blink_blacklist_end_timestamp_ms(int64 x) {
     set_option(x, &blink_blacklist_end_timestamp_ms_);
+  }
+
+  bool preserve_subresource_hints() const {
+    return preserve_subresource_hints_.value();
+  }
+  void set_preserve_subresource_hints(bool x) {
+    set_option(x, &preserve_subresource_hints_);
   }
 
   bool preserve_url_relativity() const {
@@ -4037,6 +4045,9 @@ class RewriteOptions {
 
   // The timestamp when blink blacklist expires.
   Option<int64> blink_blacklist_end_timestamp_ms_;
+
+  // Keep the original subresource hints
+  Option<bool> preserve_subresource_hints_;
 
   // Keep rewritten URLs as relative as the original resource URL was.
   // TODO(sligocki): Remove this option once we know it's always safe.

--- a/net/instaweb/rewriter/public/strip_subresource_hints_filter.h
+++ b/net/instaweb/rewriter/public/strip_subresource_hints_filter.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Author: kspoelstra@we-amp.com (Kees Spoelstra)
+
+#ifndef NET_INSTAWEB_REWRITER_PUBLIC_STRIP_SUBRESOURCE_HINTS_FILTER_H_
+#define NET_INSTAWEB_REWRITER_PUBLIC_STRIP_SUBRESOURCE_HINTS_FILTER_H_
+
+#include "pagespeed/kernel/base/basictypes.h"
+#include "pagespeed/kernel/html/empty_html_filter.h"
+
+namespace net_instaweb {
+class HtmlElement;
+class RewriteDriver;
+
+// Guarantees there is a head element in HTML. This enables downstream
+// filters to assume that there will be a head.
+class StripSubresourceHintsFilter : public EmptyHtmlFilter {
+ public:
+  explicit StripSubresourceHintsFilter(RewriteDriver* driver);
+  virtual ~StripSubresourceHintsFilter();
+
+  virtual void StartDocument();
+  virtual void StartElement(HtmlElement* element);
+  virtual void EndDocument();
+  virtual void EndElement(HtmlElement* element);
+  virtual void Flush();
+  virtual const char* Name() const { return "StripSubresourceHints"; }
+
+ private:
+  RewriteDriver* driver_;
+  HtmlElement* delete_element_;
+  bool remove_;
+
+  DISALLOW_COPY_AND_ASSIGN(StripSubresourceHintsFilter);
+};
+
+}  // namespace net_instaweb
+
+#endif  // NET_INSTAWEB_REWRITER_PUBLIC_STRIP_SUBRESOURCE_HINTS_FILTER_H_

--- a/net/instaweb/rewriter/rewrite_driver.cc
+++ b/net/instaweb/rewriter/rewrite_driver.cc
@@ -127,6 +127,7 @@
 #include "net/instaweb/rewriter/public/split_html_helper_filter.h"
 #include "net/instaweb/rewriter/public/strip_non_cacheable_filter.h"
 #include "net/instaweb/rewriter/public/strip_scripts_filter.h"
+#include "net/instaweb/rewriter/public/strip_subresource_hints_filter.h"
 #include "net/instaweb/rewriter/public/support_noscript_filter.h"
 #include "net/instaweb/rewriter/public/suppress_prehead_filter.h"
 #include "net/instaweb/rewriter/public/url_input_resource.h"
@@ -656,7 +657,8 @@ void RewriteDriver::FlushAsync(Function* callback) {
   }
   flush_requested_ = false;
 
-  DetermineEnabledFilters();
+  // Determine filter behavior like enabled, can_modify_url_
+  DetermineFiltersBehavior();
 
   for (FilterList::iterator it = early_pre_render_filters_.begin();
       it != early_pre_render_filters_.end(); ++it) {
@@ -1009,6 +1011,10 @@ void RewriteDriver::AddPreRenderFilters() {
   if (rewrite_options->Enabled(RewriteOptions::kComputeStatistics)) {
     dom_stats_filter_ = new DomStatsFilter(this);
     AddOwnedEarlyPreRenderFilter(dom_stats_filter_);
+  }
+
+  if (!rewrite_options->preserve_subresource_hints()) {
+    AddOwnedEarlyPreRenderFilter(new StripSubresourceHintsFilter(this));
   }
 
   if (rewrite_options->Enabled(RewriteOptions::kDecodeRewrittenUrls)) {
@@ -3607,12 +3613,12 @@ bool RewriteDriver::Write(const ResourceVector& inputs,
   return ret;
 }
 
-void RewriteDriver::DetermineEnabledFiltersImpl() {
-  DetermineEnabledFiltersInList(early_pre_render_filters_);
-  DetermineEnabledFiltersInList(pre_render_filters_);
+void RewriteDriver::DetermineFiltersBehaviorImpl() {
+  DetermineFilterListBehavior(early_pre_render_filters_);
+  DetermineFilterListBehavior(pre_render_filters_);
 
-  // Call parent DetermineEnabled to setup post render filters.
-  HtmlParse::DetermineEnabledFiltersImpl();
+  // Call parent DetermineFiltersBehavior to setup post render filters.
+  HtmlParse::DetermineFiltersBehaviorImpl();
 }
 
 void RewriteDriver::ClearRequestProperties() {

--- a/net/instaweb/rewriter/rewrite_options.cc
+++ b/net/instaweb/rewriter/rewrite_options.cc
@@ -262,6 +262,8 @@ const char RewriteOptions::kObliviousPagespeedUrls[] = "ObliviousPagespeedUrls";
 const char RewriteOptions::kOptionCookiesDurationMs[] =
     "OptionCookiesDurationMs";
 const char RewriteOptions::kOverrideCachingTtlMs[] = "OverrideCachingTtlMs";
+const char RewriteOptions::kPreserveSubresourceHints[] =
+    "PreserveSubresourceHints";
 const char RewriteOptions::kPreserveUrlRelativity[] = "PreserveUrlRelativity";
 const char RewriteOptions::kPrivateNotVaryForIE[] = "PrivateNotVaryForIE";
 const char RewriteOptions::kPubliclyCacheMismatchedHashesExperimental[] =
@@ -2207,6 +2209,12 @@ void RewriteOptions::AddProperties() {
 
   AddRequestProperty(
       -1, &RewriteOptions::blink_blacklist_end_timestamp_ms_, "bbet", false);
+
+  AddBaseProperty(
+      false, &RewriteOptions::preserve_subresource_hints_, "psrh",
+      kPreserveSubresourceHints, kDirectoryScope,
+      "Keep original subresource hints in place.",
+      true);
 
   AddBaseProperty(
       true, &RewriteOptions::preserve_url_relativity_, "pur",

--- a/net/instaweb/rewriter/rewrite_options_test.cc
+++ b/net/instaweb/rewriter/rewrite_options_test.cc
@@ -1009,6 +1009,7 @@ TEST_F(RewriteOptionsTest, LookupOptionByNameTest) {
     RewriteOptions::kObliviousPagespeedUrls,
     RewriteOptions::kOptionCookiesDurationMs,
     RewriteOptions::kOverrideCachingTtlMs,
+    RewriteOptions::kPreserveSubresourceHints,
     RewriteOptions::kPreserveUrlRelativity,
     RewriteOptions::kPrivateNotVaryForIE,
     RewriteOptions::kProactiveResourceFreshening,

--- a/net/instaweb/rewriter/strip_subresource_hints_filter.cc
+++ b/net/instaweb/rewriter/strip_subresource_hints_filter.cc
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Author: kspoelstra@we-amp.com (Kees Spoelstra)
+
+#include "net/instaweb/rewriter/public/strip_subresource_hints_filter.h"
+
+#include "base/logging.h"
+#include "pagespeed/kernel/html/html_element.h"
+#include "pagespeed/kernel/html/html_name.h"
+#include "pagespeed/kernel/html/html_parse.h"
+#include "net/instaweb/rewriter/public/rewrite_driver.h"
+#include "net/instaweb/rewriter/public/rewrite_options.h"
+
+namespace net_instaweb {
+
+StripSubresourceHintsFilter::StripSubresourceHintsFilter(RewriteDriver* driver)
+    : driver_(driver),
+      delete_element_(NULL),
+      remove_(false) {
+}
+
+StripSubresourceHintsFilter::~StripSubresourceHintsFilter() { }
+
+void StripSubresourceHintsFilter::StartDocument() {
+  const RewriteOptions *options = driver_->options();
+  if (driver_->can_modify_urls()) {
+    remove_ =
+      (!(options->css_preserve_urls() &&
+        options->image_preserve_urls() &&
+        options->js_preserve_urls()));
+  } else {
+    remove_ = false;
+  }
+  delete_element_ = NULL;
+}
+
+void StripSubresourceHintsFilter::StartElement(HtmlElement* element) {
+  if (!remove_) return;
+  if (!delete_element_) {
+    if (element->keyword() == HtmlName::kLink) {
+      const char *value = element->AttributeValue(HtmlName::kRel);
+      if (value && strcasecmp(value, "subresource") == 0) {
+        const RewriteOptions *options = driver_->options();
+        const char *resource_url = element->AttributeValue(HtmlName::kSrc);
+        if (!resource_url) {  // can't check validity, delete
+          delete_element_ = element;
+          return;
+        }
+        const GoogleUrl &base_url = driver_->decoded_base_url();
+        scoped_ptr<GoogleUrl> resolved_resource_url(
+            new GoogleUrl(base_url, resource_url));
+        if (options->IsAllowed(resolved_resource_url->Spec()) &&
+            options->domain_lawyer()->IsDomainAuthorized(
+              base_url, *resolved_resource_url)) {
+          delete_element_ = element;
+        }
+      }
+    }
+  }
+}
+
+void StripSubresourceHintsFilter::EndElement(HtmlElement* element) {
+  if (delete_element_ == element) {
+    driver_->DeleteNode(delete_element_);
+    delete_element_ = NULL;
+  }
+}
+
+void StripSubresourceHintsFilter::Flush() {
+  delete_element_ = NULL;
+}
+
+void StripSubresourceHintsFilter::EndDocument() {
+}
+
+}  // namespace net_instaweb

--- a/net/instaweb/rewriter/strip_subresource_hints_filter_test.cc
+++ b/net/instaweb/rewriter/strip_subresource_hints_filter_test.cc
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Author: kspoelstra@we-amp.com (Kees Spoelstra)
+
+#include "net/instaweb/rewriter/public/rewrite_test_base.h"
+#include "net/instaweb/rewriter/public/rewrite_driver.h"
+#include "net/instaweb/rewriter/public/rewrite_options.h"
+#include "pagespeed/kernel/base/gtest.h"
+
+namespace {
+
+const char kHtmlDomain[] = "http://test.com/";
+const char kOtherDomain[] = "http://other.test.com/";
+const char kFrom1Domain[] = "http://from1.test.com/";
+const char kFrom2Domain[] = "http://from2.test.com/";
+const char kTo1Domain[] = "http://to1.test.com/";
+const char kTo2Domain[] = "http://to2.test.com/";
+const char kTo2ADomain[] = "http://to2a.test.com/";
+const char kTo2BDomain[] = "http://to2b.test.com/";
+
+}  // namespace
+
+namespace net_instaweb {
+
+class CanModifyUrlsFilter:public EmptyHtmlFilter {
+ public:
+  CanModifyUrlsFilter():
+    EmptyHtmlFilter(),
+    can_modify_urls_(false) {
+  }
+  void set_can_modify_urls(bool value) { can_modify_urls_ = value; }
+  virtual bool CanModifyUrls() { return can_modify_urls_; }
+  virtual const char* Name() const { return "CMURLS"; }
+ protected:
+  bool can_modify_urls_;
+};
+
+class StripSubresourceHintsFilterTestBase : public RewriteTestBase {
+ protected:
+  virtual void SetUp() {
+    RewriteTestBase::SetUp();
+    options()->Disallow("*dontdropme*");
+    DomainLawyer* lawyer = options()->WriteableDomainLawyer();
+    lawyer->AddRewriteDomainMapping(kTo1Domain, kFrom1Domain,
+                                    &message_handler_);
+    lawyer->AddRewriteDomainMapping(kTo2Domain, kFrom2Domain,
+                                    &message_handler_);
+    lawyer->AddShard(kTo2Domain, StrCat(kTo2ADomain, ",", kTo2BDomain),
+                     &message_handler_);
+    can_modify_urls_filter_ = new CanModifyUrlsFilter();
+    rewrite_driver()->AddFilter(can_modify_urls_filter_);
+    CustomSetup();
+    rewrite_driver()->AddFilters();
+  }
+  void ValidateStripSubresourceHint(const char *source, const char *rewritten) {
+    can_modify_urls_filter_->set_can_modify_urls(true);
+    ValidateExpected("validaterewrite_can_modify_urls_true", source, rewritten);
+
+    can_modify_urls_filter_->set_can_modify_urls(false);
+    ValidateExpected("validaterewrite_can_modify_urls_false", source, source);
+  }
+  virtual void CustomSetup() { }
+
+  CanModifyUrlsFilter *can_modify_urls_filter_;
+};
+
+class StripSubresourceHintsFilterTest :
+  public StripSubresourceHintsFilterTestBase {
+};
+
+class StripSubresourceHintsFilterTestPartialPreserve :
+  public StripSubresourceHintsFilterTestBase {
+ protected:
+  virtual void CustomSetup() {
+    options()->set_css_preserve_urls(false);
+    options()->set_js_preserve_urls(false);
+    options()->set_image_preserve_urls(true);
+  }
+};
+
+class StripSubresourceHintsFilterTestFullPreserve : public
+  StripSubresourceHintsFilterTestBase {
+ protected:
+  virtual void CustomSetup() {
+    options()->set_css_preserve_urls(true);
+    options()->set_js_preserve_urls(true);
+    options()->set_image_preserve_urls(true);
+  }
+};
+
+class StripSubresourceHintsFilterTestDisabled :
+  public StripSubresourceHintsFilterTestBase {
+ protected:
+  virtual void CustomSetup() {
+    options()->set_preserve_subresource_hints(true);
+  }
+};
+
+class StripSubresourceHintsFilterTestRewriteLevelPassthrough :
+  public StripSubresourceHintsFilterTestBase {
+ protected:
+  virtual void CustomSetup() {
+    options()->SetRewriteLevel(RewriteOptions::kPassThrough);
+  }
+};
+
+class StripSubresourceHintsFilterTestRewriteLevelCoreFilters :
+  public StripSubresourceHintsFilterTestBase {
+ protected:
+  virtual void CustomSetup() {
+    options()->SetRewriteLevel(RewriteOptions::kCoreFilters);
+  }
+};
+
+TEST_F(StripSubresourceHintsFilterTest, PreserveSubResourceHintsIsFalse) {
+  EXPECT_FALSE(options()->preserve_subresource_hints());
+}
+
+TEST_F(StripSubresourceHintsFilterTest, SingleResourceNoLink) {
+  const char *source =
+    "<head><link rel=\"subresource\"/></head>"
+    "<body><img src=\"1.jpg\"/></body>";
+  const char *rewritten =
+    "<head></head>"
+    "<body><img src=\"1.jpg\"/></body>";
+  ValidateStripSubresourceHint(source, rewritten);
+}
+
+TEST_F(StripSubresourceHintsFilterTest, SingleResourceValidLink) {
+  const char *source =
+    "<head><link rel=\"subresource\" src=\"/test.gif\"/></head>"
+    "<body><img src=\"1.jpg\"/></body>";
+  const char *rewritten =
+    "<head></head>"
+    "<body><img src=\"1.jpg\"/></body>";
+  ValidateStripSubresourceHint(source, rewritten);
+}
+
+TEST_F(StripSubresourceHintsFilterTest, SingleResourceExternalLink) {
+  const char *source =
+    "<head>"
+    "<link rel=\"subresource\" src=\"http://www.example.com/test.gif\"/>"
+    "</head>"
+    "<body><img src=\"1.jpg\"/></body>";
+  ValidateStripSubresourceHint(source, source);
+}
+
+TEST_F(StripSubresourceHintsFilterTest, MultiResourceMixedLinks) {
+  const char *source =
+    "<head>"
+    "<link rel=\"subresource\" src=\"/test.gif\"/>"
+    "<link rel=\"subresource\" src=\"http://www.example.com/test.gif\"/>"
+    "</head>"
+    "<body><img src=\"1.jpg\"/></body>";
+  const char *rewritten =
+    "<head>"
+    "<link rel=\"subresource\" src=\"http://www.example.com/test.gif\"/>"
+    "</head>"
+    "<body><img src=\"1.jpg\"/></body>";
+  ValidateStripSubresourceHint(source, rewritten);
+}
+
+TEST_F(StripSubresourceHintsFilterTest, SingleResourceRewriteDomain) {
+  const char *source =
+    "<head><link rel=\"subresource\" src=\"http://from1.test.com/test.gif\"/>"
+    "</head>"
+    "<body><img src=\"1.jpg\"/></body>";
+  const char *rewritten =
+    "<head></head>"
+    "<body><img src=\"1.jpg\"/></body>";
+  ValidateStripSubresourceHint(source, rewritten);
+}
+
+TEST_F(StripSubresourceHintsFilterTest, SingleResourceDisallow) {
+  const char *source =
+    "<head><link rel=\"subresource\" src=\"/dontdropme/test.gif\"/>"
+    "</head>"
+    "<body><img src=\"1.jpg\"/></body>";
+  const char *rewritten =
+    "<head><link rel=\"subresource\" src=\"/dontdropme/test.gif\"/>"
+    "</head>"
+    "<body><img src=\"1.jpg\"/></body>";
+  ValidateStripSubresourceHint(source, rewritten);
+}
+
+TEST_F(StripSubresourceHintsFilterTestPartialPreserve,
+        MultiResourcePreserveAll) {
+  const char *source =
+    "<head>"
+    "<link rel=\"subresource\" src=\"/dontdropme.gif\"/>"
+    "<link rel=\"subresource\" src=\"/test.gif\"/>"
+    "<link rel=\"subresource\" src=\"http://from1.test.com/test.gif\"/>"
+    "<link rel=\"subresource\" src=\"http://www.example.com/test.gif\"/>"
+    "</head>"
+    "<body><img src=\"1.jpg\"/></body>";
+  const char *rewritten =
+    "<head>"
+    "<link rel=\"subresource\" src=\"/dontdropme.gif\"/>"
+    "<link rel=\"subresource\" src=\"http://www.example.com/test.gif\"/>"
+    "</head>"
+    "<body><img src=\"1.jpg\"/></body>";
+  ValidateStripSubresourceHint(source, rewritten);
+}
+
+
+
+TEST_F(StripSubresourceHintsFilterTestFullPreserve,
+        MultiResourcePreserveAll) {
+  const char *source =
+    "<head>"
+    "<link rel=\"subresource\" src=\"/dontdropme.gif\"/>"
+    "<link rel=\"subresource\" src=\"/test.gif\"/>"
+    "<link rel=\"subresource\" src=\"http://from1.test.com/test.gif\"/>"
+    "<link rel=\"subresource\" src=\"http://www.example.com/test.gif\"/>"
+    "</head>"
+    "<body><img src=\"1.jpg\"/></body>";
+  const char *rewritten =
+    "<head>"
+    "<link rel=\"subresource\" src=\"/dontdropme.gif\"/>"
+    "<link rel=\"subresource\" src=\"/test.gif\"/>"
+    "<link rel=\"subresource\" src=\"http://from1.test.com/test.gif\"/>"
+    "<link rel=\"subresource\" src=\"http://www.example.com/test.gif\"/>"
+    "</head>"
+    "<body><img src=\"1.jpg\"/></body>";
+  ValidateStripSubresourceHint(source, rewritten);
+}
+
+TEST_F(StripSubresourceHintsFilterTestDisabled,
+        PreserveSubResourceHintsIsTrue) {
+  can_modify_urls_filter_->set_can_modify_urls(true);
+  EXPECT_TRUE(options()->preserve_subresource_hints());
+}
+
+TEST_F(StripSubresourceHintsFilterTestDisabled,
+        MultiResourcePreserveAll) {
+  can_modify_urls_filter_->set_can_modify_urls(true);
+  const char *source =
+    "<head>"
+    "<link rel=\"subresource\" src=\"/dontdropme.gif\"/>"
+    "<link rel=\"subresource\" src=\"/test.gif\"/>"
+    "<link rel=\"subresource\" src=\"http://from1.test.com/test.gif\"/>"
+    "<link rel=\"subresource\" src=\"http://www.example.com/test.gif\"/>"
+    "</head>"
+    "<body><img src=\"1.jpg\"/></body>";
+  ValidateStripSubresourceHint(source, source);
+}
+
+TEST_F(StripSubresourceHintsFilterTestRewriteLevelPassthrough,
+        MultiResource) {
+  const char *source =
+    "<head>"
+    "<link rel=\"subresource\" src=\"/dontdropme.gif\"/>"
+    "<link rel=\"subresource\" src=\"/test.gif\"/>"
+    "<link rel=\"subresource\" src=\"http://from1.test.com/test.gif\"/>"
+    "<link rel=\"subresource\" src=\"http://www.example.com/test.gif\"/>"
+    "</head>"
+    "<body></body>";
+  const char *rewritten =
+    "<head>"
+    "<link rel=\"subresource\" src=\"/dontdropme.gif\"/>"
+    "<link rel=\"subresource\" src=\"/test.gif\"/>"
+    "<link rel=\"subresource\" src=\"http://from1.test.com/test.gif\"/>"
+    "<link rel=\"subresource\" src=\"http://www.example.com/test.gif\"/>"
+    "</head>"
+    "<body></body>";
+  ValidateExpected("multi_resource", source, rewritten);
+}
+
+TEST_F(StripSubresourceHintsFilterTestRewriteLevelCoreFilters,
+        MultiResource) {
+  const char *source =
+    "<head>"
+    "<link rel=\"subresource\" src=\"/dontdropme.gif\"/>"
+    "<link rel=\"subresource\" src=\"/test.gif\"/>"
+    "<link rel=\"subresource\" src=\"http://from1.test.com/test.gif\"/>"
+    "<link rel=\"subresource\" src=\"http://www.example.com/test.gif\"/>"
+    "</head>"
+    "<body></body>";
+  const char *rewritten =
+    "<head>"
+    "<link rel=\"subresource\" src=\"/dontdropme.gif\"/>"
+    "<link rel=\"subresource\" src=\"http://www.example.com/test.gif\"/>"
+    "</head>"
+    "<body></body>";
+  ValidateExpected("multi_resource", source, rewritten);
+}
+
+}  // namespace net_instaweb

--- a/net/instaweb/test.gyp
+++ b/net/instaweb/test.gyp
@@ -223,6 +223,7 @@
         'rewriter/static_asset_manager_test.cc',
         'rewriter/strip_non_cacheable_filter_test.cc',
         'rewriter/strip_scripts_filter_test.cc',
+        'rewriter/strip_subresource_hints_filter_test.cc',
         'rewriter/support_noscript_filter_test.cc',
         'rewriter/suppress_prehead_filter_test.cc',
         'rewriter/two_level_cache_test.cc',

--- a/pagespeed/apache/mod_instaweb.cc
+++ b/pagespeed/apache/mod_instaweb.cc
@@ -164,6 +164,8 @@ const char kModPagespeedNumExpensiveRewriteThreads[] =
     "ModPagespeedNumExpensiveRewriteThreads";
 const char kModPagespeedNumRewriteThreads[] = "ModPagespeedNumRewriteThreads";
 const char kModPagespeedNumShards[] = "ModPagespeedNumShards";
+const char kModPagespeedPreserveSubresourceHints[] =
+    "ModPagespeedPreserveSubresourceHints";
 const char kModPagespeedProxySuffix[] = "ModPagespeedProxySuffix";
 const char kModPagespeedRetainComment[] = "ModPagespeedRetainComment";
 const char kModPagespeedRunExperiment[] = "ModPagespeedRunExperiment";
@@ -1664,6 +1666,8 @@ static const command_rec mod_pagespeed_filter_cmds[] = {
         "Adds an error message into the log for every URL fetch in "
         "flight when the HTTP stack encounters a system error, e.g. "
         "Connection Refused"),
+  APACHE_CONFIG_DIR_OPTION(kModPagespeedPreserveSubresourceHints,
+        "Keep all original subresource hints."),
   APACHE_CONFIG_DIR_OPTION(kModPagespeedProxySuffix,
         "Sets up a proxy suffix to be used when slurping."),
   APACHE_CONFIG_DIR_OPTION(kModPagespeedRetainComment,

--- a/pagespeed/automatic/system_test.sh
+++ b/pagespeed/automatic/system_test.sh
@@ -45,6 +45,7 @@ run_test js_blacklist
 run_test move_css
 run_test inliners
 run_test outliners
+run_test subresource_hints
 run_test char_tweaks
 run_test rewrite_css
 run_test rewrite_images

--- a/pagespeed/automatic/system_tests/subresource_hints.sh
+++ b/pagespeed/automatic/system_tests/subresource_hints.sh
@@ -1,0 +1,35 @@
+start_test Strip subresources default behaviour
+URL="$TEST_ROOT/strip_subresource_hints/default/index.html"
+echo $WGET_DUMP $URL
+OUT=$($WGET_DUMP $URL)
+check_not_from "$OUT" grep -q -F "rel=\"subresource"
+
+start_test Strip multiple subresources default behaviour
+URL="$TEST_ROOT/strip_subresource_hints/default/multiple_subresource_hints.html"
+echo $WGET_DUMP $URL
+OUT=$($WGET_DUMP $URL)
+check_not_from "$OUT" grep -q -F "rel=\"subresource"
+
+start_test Strip subresources default behaviour disallow
+URL="$TEST_ROOT/strip_subresource_hints/default/disallowtest.html"
+echo $WGET_DUMP $URL
+OUT=$($WGET_DUMP $URL)
+check_from "$OUT" grep -q -F "rel=\"subresource"
+
+start_test Strip subresources preserve on
+URL="$TEST_ROOT/strip_subresource_hints/preserve_on/index.html"
+echo $WGET_DUMP $URL
+OUT=$($WGET_DUMP $URL)
+check_from "$OUT" grep -q -F "rel=\"subresource"
+
+start_test Strip subresources preserve off
+URL="$TEST_ROOT/strip_subresource_hints/preserve_off/index.html"
+echo $WGET_DUMP $URL
+OUT=$($WGET_DUMP $URL)
+check_not_from "$OUT" grep -q -F "rel=\"subresource"
+
+start_test Strip subresources rewrite level passthrough
+URL="$TEST_ROOT/strip_subresource_hints/default_passthrough/index.html"
+echo $WGET_DUMP $URL
+OUT=$($WGET_DUMP $URL)
+check_from "$OUT" grep -q -F "rel=\"subresource"

--- a/pagespeed/kernel/html/empty_html_filter.h
+++ b/pagespeed/kernel/html/empty_html_filter.h
@@ -60,6 +60,10 @@ class EmptyHtmlFilter : public HtmlFilter {
   virtual void Directive(HtmlDirectiveNode* directive);
   virtual void Flush();
   virtual void DetermineEnabled(GoogleString* disabled_reason);
+  // This filter and derived classes will not rewrite Urls
+  // if a derived filter wants to rewrite urls, override this
+  // function.
+  virtual bool CanModifyUrls() {return false;}
 
   // Note -- this does not provide an implementation for Name().  This
   // must be supplied by derived classes.

--- a/pagespeed/kernel/html/html_filter.h
+++ b/pagespeed/kernel/html/html_filter.h
@@ -103,6 +103,10 @@ class HtmlFilter {
   // Returns whether a filter is enabled.
   bool is_enabled() const { return is_enabled_; }
 
+  // Invoked by the rewrite driver to query whether this filter will
+  // rewrite any urls.
+  virtual bool CanModifyUrls() = 0;
+
   // The name of this filter -- used for logging and debugging.
   virtual const char* Name() const = 0;
 

--- a/pagespeed/kernel/html/html_parse_test.cc
+++ b/pagespeed/kernel/html/html_parse_test.cc
@@ -1244,6 +1244,8 @@ class HandlerCalledFilter : public HtmlFilter {
     set_is_enabled(enabled_value_);
   }
 
+  virtual bool CanModifyUrls() { return false; }
+
   void SetEnabled(bool enabled_value) {
     enabled_value_  = enabled_value;
   }

--- a/pagespeed/kernel/html/html_writer_filter.h
+++ b/pagespeed/kernel/html/html_writer_filter.h
@@ -55,6 +55,8 @@ class HtmlWriterFilter : public HtmlFilter {
   virtual void Directive(HtmlDirectiveNode* directive);
   virtual void Flush();
   virtual void DetermineEnabled(GoogleString* disabled_reason);
+  // this filter will not change urls
+  virtual bool CanModifyUrls() {return false;}
 
   void set_max_column(int max_column) { max_column_ = max_column; }
   void set_case_fold(bool case_fold) { case_fold_ = case_fold; }


### PR DESCRIPTION
Default behaviour is to strip subresource links which are in scope for pagespeed
These are the resources that are not disallowed or are valid domains in the domain laywer
Added new option to explicitly prevent the default behaviour:
ModPreserveSubresourceHints on/off

What about side effects/behavior with RewriteLevel PassThrough?

There are some non-related issues with the system tests on our Ubuntu system which we might have to look into later.
A ngx_pagespeed pull request for the system tests (location mapping) will come later
