### PR TITLE
Move InstawebHandler initialization after validity checks.

### DIFF
--- a/pagespeed/apache/mod_instaweb.cc
+++ b/pagespeed/apache/mod_instaweb.cc
@@ -378,9 +378,6 @@ InstawebContext* build_context_for_request(request_rec* request) {
     return NULL;
   }
 
-  InstawebHandler instaweb_handler(request);
-  const RewriteOptions* options = instaweb_handler.options();
-
   if (request->unparsed_uri == NULL) {
     // TODO(jmarantz): consider adding Debug message if unparsed_uri is NULL,
     // possibly of request->the_request which was non-null in the case where
@@ -444,6 +441,9 @@ InstawebContext* build_context_for_request(request_rec* request) {
                   "Request not rewritten because: X-Mod-Pagespeed header set.");
     return NULL;
   }
+
+  InstawebHandler instaweb_handler(request);
+  const RewriteOptions* options = instaweb_handler.options();
 
   const GoogleUrl& stripped_gurl = instaweb_handler.stripped_gurl();
   if (!stripped_gurl.IsWebValid()) {

--- a/pagespeed/system/system_test.sh
+++ b/pagespeed/system/system_test.sh
@@ -2287,3 +2287,8 @@ start_test AddResourceHeaders works for pagespeed resources.
 URL="$TEST_ROOT/compressed/hello_js.custom_ext.pagespeed.ce.HdziXmtLIV.txt"
 HTML_HEADERS=$($WGET_DUMP $URL)
 check_from "$HTML_HEADERS" grep -q "^X-Foo: Bar"
+
+start_test long url handling
+# This is an extremely long url, enough that it should give a 4xx server error.
+OUT=$($CURL -sS -D- "$TEST_ROOT/$(head -c 10000 < /dev/zero | tr '\0' 'a')")
+check_from "$OUT" grep -q "414 Request-URI Too Large"


### PR DESCRIPTION
Creating an instaweb handler will run MakeRequestUrl, which assumes that
request->unparsed_uri is non-null.  So move the creation to after where
we check that it's non-null.  To be safe, move it all the way down to
where it's first needed, in case some other validity checks end up being
relevant.

Fixes https://github.com/pagespeed/mod_pagespeed/issues/1248
