### PR TITLE
Use fetch_until for AddResourceHeaders check

### DIFF
--- a/pagespeed/system/system_test.sh
+++ b/pagespeed/system/system_test.sh
@@ -2285,8 +2285,7 @@ fi
 
 start_test AddResourceHeaders works for pagespeed resources.
 URL="$TEST_ROOT/compressed/hello_js.custom_ext.pagespeed.ce.HdziXmtLIV.txt"
-HTML_HEADERS=$($WGET_DUMP $URL)
-check_from "$HTML_HEADERS" grep -q "^X-Foo: Bar"
+fetch_until "$URL" 'grep -c "^X-Foo: Bar"' 1 --save-headers
 
 start_test long url handling
 # This is an extremely long url, enough that it should give a 4xx server error.


### PR DESCRIPTION
The fetch in that test depends on Serf, which can timeout during valgrind tests.
