### PR TITLE
Test purging of ipro-rewritten resources.

### DIFF
--- a/install/Makefile.tests
+++ b/install/Makefile.tests
@@ -455,3 +455,19 @@ apache_debug_unplugged_test : apache_install_conf apache_debug_restart
 	mv $(APACHE_DEBUG_PAGESPEED_CONF).save $(APACHE_DEBUG_PAGESPEED_CONF)
 	$(MAKE) apache_debug_stop
 	@echo PASS
+
+# Target used to populate the docroot for a webserver, including the
+# read-only mod_pagespeed_example, mod_pagespeed_test, and do_not_modify,
+# plus the read/write areas for cache purging and flush tests.  The
+# read-only directories are symlinked in for speed, and the read/write
+# directories are deep-copied, but they are small.
+setup_doc_root :
+	mkdir -p $(APACHE_DOC_ROOT)
+	cd $(APACHE_DOC_ROOT); \
+	  rm -f mod_pagespeed_example mod_pagespeed_test do_not_modify; \
+	  rm -rf cache_flush purge; \
+	  ln -s "$(PWD)/mod_pagespeed_example"; \
+	  ln -s "$(PWD)/mod_pagespeed_test"; \
+	  ln -s "$(PWD)/do_not_modify"; \
+	  cp -r "$(PWD)/mod_pagespeed_test/cache_flush" .; \
+	  cp -r "$(PWD)/mod_pagespeed_test/purge" . \

--- a/install/debug.conf.template
+++ b/install/debug.conf.template
@@ -485,7 +485,7 @@ ModPagespeedCompressMetadataCache true
 
 # Make a non-empty subdirectory config to make sure that
 # cache.flush updates get transmitted to nested configurations.
-<Directory "@@APACHE_DOC_ROOT@@/mod_pagespeed_test/cache_flush/" >
+<Directory "@@APACHE_DOC_ROOT@@/cache_flush/" >
   ModPagespeedRewriteLevel PassThrough
   ModPagespeedEnableFilters inline_css
   ModPagespeedDisableFilters add_instrumentation
@@ -534,7 +534,7 @@ NameVirtualHost localhost:@@APACHE_SECONDARY_PORT@@
 
   # Make a non-empty subdirectory config to make sure that
   # cache.flush updates get transmitted to nested configurations.
-  <Directory "@@APACHE_DOC_ROOT@@/mod_pagespeed_test/cache_flush/" >
+  <Directory "@@APACHE_DOC_ROOT@@/cache_flush/" >
     ModPagespeedRewriteLevel PassThrough
     ModPagespeedEnableFilters inline_css
     ModPagespeedDisableFilters add_instrumentation
@@ -1334,7 +1334,7 @@ ModPagespeedCreateSharedMemoryMetadataCache "@@MOD_PAGESPEED_CACHE@@_noned_shmm"
   ModPagespeedEnableCachePurge on
 
   ModPagespeedPurgeMethod PURGE
-  DocumentRoot "@@APACHE_DOC_ROOT@@/mod_pagespeed_test/purge"
+  DocumentRoot "@@APACHE_DOC_ROOT@@/purge"
   ModPagespeedFileCachePath "@@MOD_PAGESPEED_CACHE@@_purge"
   ModPagespeedDisableFilters add_instrumentation
   ModPagespeedRewriteLevel PassThrough
@@ -1345,7 +1345,7 @@ ModPagespeedCreateSharedMemoryMetadataCache "@@MOD_PAGESPEED_CACHE@@_noned_shmm"
 # back on.
 <VirtualHost localhost:@@APACHE_SECONDARY_PORT@@>
   ServerName psoff-dir-on.example.com
-  DocumentRoot "@@APACHE_DOC_ROOT@@/mod_pagespeed_test/purge"
+  DocumentRoot "@@APACHE_DOC_ROOT@@/purge"
   ModPagespeedFileCachePath "@@MOD_PAGESPEED_CACHE@@_mpsoff_dir_on"
   ModPagespeed off
   ModPagespeedEnableCachePurge on
@@ -1353,7 +1353,7 @@ ModPagespeedCreateSharedMemoryMetadataCache "@@MOD_PAGESPEED_CACHE@@_noned_shmm"
   ModPagespeedDisableFilters add_instrumentation
   ModPagespeedRewriteLevel PassThrough
   ModPagespeedEnableFilters rewrite_css
-  <Directory "@@APACHE_DOC_ROOT@@/mod_pagespeed_test/purge">
+  <Directory "@@APACHE_DOC_ROOT@@/purge">
     ModPagespeed on
   </Directory>
 </VirtualHost>
@@ -1362,7 +1362,7 @@ ModPagespeedCreateSharedMemoryMetadataCache "@@MOD_PAGESPEED_CACHE@@_noned_shmm"
 # back on.
 <VirtualHost localhost:@@APACHE_SECONDARY_PORT@@>
   ServerName psoff-htaccess-on.example.com
-  DocumentRoot "@@APACHE_DOC_ROOT@@/mod_pagespeed_test/purge"
+  DocumentRoot "@@APACHE_DOC_ROOT@@/purge"
   ModPagespeedFileCachePath "@@MOD_PAGESPEED_CACHE@@_mpsoff_htaccess_on"
   ModPagespeed off
   ModPagespeedEnableCachePurge on
@@ -1370,7 +1370,7 @@ ModPagespeedCreateSharedMemoryMetadataCache "@@MOD_PAGESPEED_CACHE@@_noned_shmm"
   ModPagespeedDisableFilters add_instrumentation
   ModPagespeedRewriteLevel PassThrough
   ModPagespeedEnableFilters rewrite_css
-  <Directory "@@APACHE_DOC_ROOT@@/mod_pagespeed_test/purge">
+  <Directory "@@APACHE_DOC_ROOT@@/purge">
     AllowOverride All
   </Directory>
 </VirtualHost>


### PR DESCRIPTION
This previously worked in Apache, but only today was fixed in ngx_pagespeed on 5/11/16, in
https://github.com/pagespeed/ngx_pagespeed/pull/1193

To test a fix to this bug, I need to alter files in the htdocs
directory during the test.  This is source-controlled.  We were doing
this before with mod_pagespeed_test/cache_flush but somehow getting
away with it (or just getting lucky with timing).  But this is really
a bad practice.

So in this pull-request I also change the infrastructure to simply copy
the cache_flush/ and purge/ subdirectories to htdocs/.  The rest of the
directories get symlinked.

This must be committed alongside https://github.com/pagespeed/ngx_pagespeed/pull/1197
