### PR TITLE
setup the doc root before running vm_system_tests.

### DIFF
--- a/install/Makefile.tests
+++ b/install/Makefile.tests
@@ -40,7 +40,7 @@ export APACHE_LOG
 export APACHE_DOC_ROOT
 export MOD_PAGESPEED_CACHE
 
-apache_vm_system_tests :
+apache_vm_system_tests : setup_doc_root
 	$(MAKE) FAST_RESTART=1 apache_debug_smoke_test
 	$(MAKE) FAST_RESTART=1 apache_debug_downstream_caching_test
 	$(MAKE) FAST_RESTART=1 apache_debug_per_vhost_stats_test


### PR DESCRIPTION
This will hopefully fix the travis builds.
