### PR TITLE
Add option to make ProxyFetch forward incoming flushes

### DIFF
--- a/install/debug.conf.template
+++ b/install/debug.conf.template
@@ -1929,6 +1929,16 @@ Listen 127.0.0.2:@@APACHE_TERTIARY_PORT@@
   ModPagespeedRewriteDeadlinePerFlushMs 5000
 </VirtualHost>
 
+<VirtualHost localhost:@@APACHE_SECONDARY_PORT@@>
+  ServerName flush.example.com
+  DocumentRoot "@@APACHE_DOC_ROOT@@"
+  ModPagespeedFileCachePath "@@MOD_PAGESPEED_CACHE@@_test"
+  ModPagespeed on
+  ModPagespeedRewriteLevel PassThrough
+  ModPagespeedRewriteDeadlinePerFlushMs 1
+  ModPagespeedDisableFilters add_instrumentation
+</VirtualHost>
+
 #ALL_DIRECTIVES # Invoke all ModPagespeed* directives to make sure they work:
 #ALL_DIRECTIVES ModPagespeedAllow foo
 #ALL_DIRECTIVES ModPagespeedAddResourceHeader foo bar

--- a/install/mod_pagespeed_test/slow_flushing_html_response.php
+++ b/install/mod_pagespeed_test/slow_flushing_html_response.php
@@ -1,0 +1,15 @@
+<?php
+header('Content-Type: text/html');
+
+echo "<html><head></head><body>\n";
+$size = 5;
+
+for($i = 1; $i <= $size; $i++) {
+  echo "<p>foo</p><div>bar:" . $i  . "</div>\n";
+  ob_flush();
+  flush();
+  sleep(1);
+}
+
+echo "</body></html>\n";
+?>

--- a/net/instaweb/rewriter/public/rewrite_options.h
+++ b/net/instaweb/rewriter/public/rewrite_options.h
@@ -273,6 +273,7 @@ class RewriteOptions {
   static const char kFlushBufferLimitBytes[];
   static const char kFlushHtml[];
   static const char kFlushMoreResourcesEarlyIfTimePermits[];
+  static const char kFollowFlushes[];
   static const char kGoogleFontCssInlineMaxBytes[];
   static const char kForbidAllDisabledFilters[];
   static const char kHideRefererUsingMeta[];
@@ -2336,6 +2337,9 @@ class RewriteOptions {
     return flush_more_resources_early_if_time_permits_.value();
   }
 
+  void set_follow_flushes(bool x) { set_option(x, &follow_flushes_); }
+  bool follow_flushes() const { return follow_flushes_.value(); }
+
   void set_flush_more_resources_in_ie_and_firefox(bool x) {
     set_option(x, &flush_more_resources_in_ie_and_firefox_);
   }
@@ -3864,6 +3868,9 @@ class RewriteOptions {
   Option<bool> respect_vary_;
   Option<bool> respect_x_forwarded_proto_;
   Option<bool> flush_html_;
+  // If set to true, ProxyFetch will request a flush on its RewriteDriver when
+  // Flush() is called on it.
+  Option<bool> follow_flushes_;
   // Should we serve stale responses if the fetch results in a server side
   // error.
   Option<bool> serve_stale_if_fetch_error_;

--- a/net/instaweb/rewriter/rewrite_options.cc
+++ b/net/instaweb/rewriter/rewrite_options.cc
@@ -136,6 +136,7 @@ const char RewriteOptions::kFlushBufferLimitBytes[] = "FlushBufferLimitBytes";
 const char RewriteOptions::kFlushHtml[] = "FlushHtml";
 const char RewriteOptions::kFlushMoreResourcesEarlyIfTimePermits[] =
     "FlushMoreResourcesEarlyIfTimePermits";
+const char RewriteOptions::kFollowFlushes[] = "FollowFlushes";
 const char RewriteOptions::kForbidAllDisabledFilters[] =
     "ForbidAllDisabledFilters";
 const char RewriteOptions::kGoogleFontCssInlineMaxBytes[] =
@@ -1578,6 +1579,12 @@ void RewriteOptions::AddProperties() {
       "fretp", kFlushMoreResourcesEarlyIfTimePermits,
       kDirectoryScope,
       NULL, true);  // TODO(jmarantz): implement for mod_pagespeed.
+  AddBaseProperty(
+      true, &RewriteOptions::follow_flushes_, "ff", kFollowFlushes,
+      kDirectoryScope,
+      "Attempt to mirror incoming flushes for html streams in the output "
+      "when ProxyFetch is used.",
+      true);
   AddRequestProperty(
       false,
       &RewriteOptions::flush_more_resources_in_ie_and_firefox_,

--- a/net/instaweb/rewriter/rewrite_options_test.cc
+++ b/net/instaweb/rewriter/rewrite_options_test.cc
@@ -980,6 +980,7 @@ TEST_F(RewriteOptionsTest, LookupOptionByNameTest) {
     RewriteOptions::kFlushBufferLimitBytes,
     RewriteOptions::kFlushHtml,
     RewriteOptions::kFlushMoreResourcesEarlyIfTimePermits,
+    RewriteOptions::kFollowFlushes,
     RewriteOptions::kForbidAllDisabledFilters,
     RewriteOptions::kGoogleFontCssInlineMaxBytes,
     RewriteOptions::kHideRefererUsingMeta,

--- a/pagespeed/apache/mod_instaweb.cc
+++ b/pagespeed/apache/mod_instaweb.cc
@@ -131,6 +131,7 @@ const char kModPagespeedForbidFilters[] = "ModPagespeedForbidFilters";
 const char kModPagespeedForceCaching[] = "ModPagespeedForceCaching";
 const char kModPagespeedExperimentVariable[] = "ModPagespeedExperimentVariable";
 const char kModPagespeedExperimentSpec[] = "ModPagespeedExperimentSpec";
+const char kModPagespeedFollowFlushes[] = "ModPagespeedFollowFlushes";
 const char kModPagespeedGeneratedFilePrefix[] =
     "ModPagespeedGeneratedFilePrefix";
 const char kModPagespeedGlobalAdminDomains[] = "ModPagespeedGlobalAdminDomains";

--- a/pagespeed/automatic/proxy_fetch.h
+++ b/pagespeed/automatic/proxy_fetch.h
@@ -357,6 +357,7 @@ class ProxyFetch : public SharedAsyncFetch {
   friend class ProxyFetchPropertyCallbackCollector;
   friend class MockProxyFetch;
   FRIEND_TEST(ProxyFetchTest, TestInhibitParsing);
+  FRIEND_TEST(ProxyFetchTest, TestFollowFlushes);
 
   // Called by ProxyFetchPropertyCallbackCollector when all property-cache
   // fetches are complete.  This function takes ownership of collector.

--- a/pagespeed/automatic/proxy_fetch_test.cc
+++ b/pagespeed/automatic/proxy_fetch_test.cc
@@ -39,6 +39,7 @@
 #include "pagespeed/kernel/http/http_names.h"
 #include "pagespeed/kernel/http/request_headers.h"
 #include "pagespeed/kernel/http/response_headers.h"
+#include "pagespeed/kernel/thread/mock_scheduler.h"
 #include "pagespeed/kernel/thread/thread_synchronizer.h"
 #include "pagespeed/kernel/thread/worker_test_base.h"
 #include "pagespeed/kernel/util/platform.h"
@@ -308,6 +309,89 @@ TEST_F(ProxyFetchTest, TestInhibitParsing) {
   }
 
   mock_proxy_fetch->Done(true);
+}
+
+namespace {
+
+class FlushLoggingStringAsyncFetch : public StringAsyncFetch {
+ public:
+  explicit FlushLoggingStringAsyncFetch(const RequestContextPtr& request_context)
+      : StringAsyncFetch(request_context) {}
+
+  virtual ~FlushLoggingStringAsyncFetch() {}
+
+  bool HandleFlush(MessageHandler* handler) override {
+    HandleWrite("|Flush|", handler);
+    return true;
+  }
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(FlushLoggingStringAsyncFetch);
+};
+
+}  // namespace
+
+TEST_F(ProxyFetchTest, TestFollowFlushes) {
+  NullMessageHandler handler;
+  RewriteOptions* options = server_context()->global_options();
+  options->ClearSignatureForTesting();
+  options->DisableFilter(RewriteOptions::kAddHead);
+  options->set_follow_flushes(true);
+  options->ComputeSignature();
+  FlushLoggingStringAsyncFetch fetch(
+      RequestContext::NewTestRequestContext(
+          server_context()->thread_system()));
+  fetch.response_headers()->Add("Content-Type", "text/html");
+  ProxyFetchFactory factory(server_context_);
+  MockProxyFetch* mock_proxy_fetch = new MockProxyFetch(
+      &fetch, &factory, server_context());
+  mock_proxy_fetch->response_headers()->ComputeCaching();
+
+  // To get a more predictable output with regard to flush markers, we wait
+  // for flushes to be fully processed before continuing. ProxyFetch may
+  // otherwise aggregate, reposition, or ignore induced flushes.
+  mock_proxy_fetch->Write("<html><d>1</d>", &handler);
+  mock_proxy_fetch->Flush(&handler);
+  mock_scheduler()->AwaitQuiescence();
+  mock_proxy_fetch->Write("<d>2</d></html>", &handler);
+  mock_proxy_fetch->Flush(&handler);
+  mock_scheduler()->AwaitQuiescence();
+
+  // Verify we are parsing HTML.
+  EXPECT_TRUE(mock_proxy_fetch->started_parse_);
+
+  mock_proxy_fetch->Done(true);
+  mock_scheduler()->AwaitQuiescence();
+  EXPECT_EQ(0, server_context()->num_active_rewrite_drivers());
+  EXPECT_EQ("<html><d>1</d>|Flush|<d>2</d></html>|Flush||Flush|", fetch.buffer());
+
+  // Test following flushes off behaves as expected.
+  options->ClearSignatureForTesting();
+  options->set_follow_flushes(false);
+  options->ComputeSignature();
+
+  FlushLoggingStringAsyncFetch fetch_off(
+      RequestContext::NewTestRequestContext(
+          server_context()->thread_system()));
+  fetch_off.response_headers()->Add("Content-Type", "text/html");
+
+  mock_proxy_fetch = new MockProxyFetch(
+      &fetch_off, &factory, server_context());
+  mock_proxy_fetch->response_headers()->ComputeCaching();
+
+  mock_proxy_fetch->Write("<html><d>1</d>", &handler);
+  mock_proxy_fetch->Flush(&handler);
+  mock_scheduler()->AwaitQuiescence();
+  mock_proxy_fetch->Write("<d>2</d></html>", &handler);
+  mock_proxy_fetch->Flush(&handler);
+  mock_scheduler()->AwaitQuiescence();
+
+  EXPECT_TRUE(mock_proxy_fetch->started_parse_);
+
+  mock_proxy_fetch->Done(true);
+  mock_scheduler()->AwaitQuiescence();
+  EXPECT_EQ(0, server_context()->num_active_rewrite_drivers());
+  EXPECT_EQ("<html><d>1</d><d>2</d></html>|Flush|", fetch_off.buffer());
 }
 
 TEST_F(ProxyFetchPropertyCallbackCollectorTest, EmptyCollectorTest) {

--- a/pagespeed/automatic/system_test.sh
+++ b/pagespeed/automatic/system_test.sh
@@ -92,6 +92,7 @@ if [ "$SECONDARY_HOSTNAME" != "" ]; then
   run_test invalid_host_header
   run_test optimize_to_webp
   run_test image_quality_and_response
+  run_test follow_flushes
 fi
 
 run_test content_length

--- a/pagespeed/automatic/system_test_helpers.sh
+++ b/pagespeed/automatic/system_test_helpers.sh
@@ -825,3 +825,51 @@ function kill_listener_port {
   PORT="$2"
   kill -9 $(lsof -t -i TCP:${PORT} -s TCP:LISTEN -a -c "/^${CMDLINE}$/") || true
 }
+
+# Performs timed reads on the output from a command passed via $1. The stream
+# will be interpreted as a chunked http encoding. Each chunk will be allowed
+# at most threshold_sec ($2) seconds to be read or the function will fail. When
+# the stream is fully read, the funcion will compare the total number of http
+# chunks read with expect_chunk_count ($3) and fail on mismatch.
+# Usage:
+# check_flushing "curl -N --raw --silent --proxy $SECONDARY_HOSTNAME $URL" 5 1
+# This will check if the curl command resulted in single chunk which was read
+# within one second or less.
+function check_flushing() {
+  local command="$1"
+  local threshold_sec="$2"
+  local expect_chunk_count="$3"
+  local output=""
+  local start=$(date +%s%N)
+  local chunk_count=0
+
+  echo "Command: $command"
+
+  if [ "${USE_VALGRIND:-}" = true ]; then
+    # We can't say much about correctness of timings under valgrind, so relax
+    # the test for that.
+    threshold_sec=$(echo "scale=2; $threshold_sec*10" | bc)
+  fi
+
+  while true; do
+    start=$(date +%s%N)
+    # Read the http chunk size from the stream. This is also the read which
+    # checks timings.
+    check read -t $threshold_sec line
+    echo "Chunk number [$chunk_count] has size: $line"
+    line=$(echo $line | tr -d '\n' | tr -d '\r')
+    # If we read 0 that means we have finished reading the stream.
+    if [ $((16#$line)) -eq "0" ] ; then
+      check [ $expect_chunk_count -le $chunk_count ]
+      return
+    fi
+    let chunk_count=chunk_count+1
+    # read the actual data from the stream, using the amount indicated in
+    # the previous read. This read should be fast.
+    check read -N $((16#$line)) line
+    echo "Chunk data: $line"
+    # Read the trailing \r\n - should be fast.
+    check read -N 2 line
+  done < <($command)
+  check 0
+}

--- a/pagespeed/automatic/system_tests/follow_flushes.sh
+++ b/pagespeed/automatic/system_tests/follow_flushes.sh
@@ -1,0 +1,8 @@
+start_test Follow flushes does what it should do.
+echo "Check that FollowFlushes on outputs timely chunks"
+URL="http://flush.example.com/mod_pagespeed_test/slow_flushing_html_response.php"
+# The php file will write 6 chunks, but the last two often get aggregated
+# into one. Hence 5 or 6 is what we want to see.
+check_flushing "curl -N --raw --silent --proxy $SECONDARY_HOSTNAME $URL" \
+  1.2 5
+


### PR DESCRIPTION
ngx_pagespeed currently buffers when rewriting HTML. This adds an
option to make ProxyFetch follow up on any incoming Flush calls
by requesting a Flush on it's associated RewriteDriver. This option
is on by default, on parity with mod_pagespeed's behaviour.

Includes a gtest for ensuring ProxyFetch complies and system tests
to test for consistent default flushing behaviour accross modules.

Will be accompanied by a PR to ngx_pagespeed's repository.
Edit:
The nps pull is:
https://github.com/pagespeed/ngx_pagespeed/pull/1217
