### PR TITLE
Backportable targeted fix for serf spin

### DIFF
--- a/pagespeed/system/serf_url_async_fetcher.cc
+++ b/pagespeed/system/serf_url_async_fetcher.cc
@@ -591,6 +591,9 @@ apr_status_t SerfFetch::ReadBody(serf_bucket_t* response) {
   apr_size_t bytes_to_flush = 0;
   while (MoreDataAvailable(status) && (async_fetch_ != NULL)) {
     status = serf_bucket_read(response, SERF_READ_ALL_AVAIL, &data, &len);
+    if (APR_STATUS_IS_EAGAIN(status)) {
+      break;
+    }
     bytes_received_ += len;
     bytes_to_flush += len;
     if (IsStatusOk(status) && (len != 0) &&


### PR DESCRIPTION
Targeted fix for serf spin observed on ngx_pagespeed. This only fixes the spin loop but not the error handling.
https://github.com/pagespeed/ngx_pagespeed/issues/674
