### PR TITLE
Separate option for specifying a critical images beacon url.

### DIFF
--- a/install/Makefile.tests
+++ b/install/Makefile.tests
@@ -167,6 +167,7 @@ apache_debug_smoke_test : apache_install_conf apache_debug_restart
 	@echo '***' System-test without InheritVhostConfig, stats on.
 	sed -e "s/InheritVHostConfig on/InheritVHostConfig off/" \
 		< $(APACHE_DEBUG_PAGESPEED_CONF).save \
+		| sed -e "s/#NEED_VHOST_BEACON//" \
 		> $(APACHE_DEBUG_PAGESPEED_CONF)
 	grep ModPagespeedStatistics $(APACHE_DEBUG_PAGESPEED_CONF)
 	grep ModPagespeedInheritVHostConfig $(APACHE_DEBUG_PAGESPEED_CONF)

--- a/install/apache_experiment_test.sh
+++ b/install/apache_experiment_test.sh
@@ -60,13 +60,13 @@ check_not_from "$OUT" fgrep 'PageSpeedExperiment='
 
 start_test The beacon should include the experiment id.
 OUT=$($WGET_DUMP --header='Cookie: PageSpeedExperiment=2' $EXTEND_CACHE)
-check_from "$OUT" grep "pagespeed.addInstrumentationInit('/mod_pagespeed_beacon', 'load', '&exptid=2', 'http://localhost[:0-9]*/mod_pagespeed_example/extend_cache.html');"
+check_from "$OUT" grep "pagespeed.addInstrumentationInit('/.*beacon.*', 'load', '&exptid=2', 'http://localhost[:0-9]*/mod_pagespeed_example/extend_cache.html');"
 OUT=$($WGET_DUMP --header='Cookie: PageSpeedExperiment=7' $EXTEND_CACHE)
-check_from "$OUT" grep "pagespeed.addInstrumentationInit('/mod_pagespeed_beacon', 'load', '&exptid=7', 'http://localhost[:0-9]*/mod_pagespeed_example/extend_cache.html');"
+check_from "$OUT" grep "pagespeed.addInstrumentationInit('/.*beacon.*', 'load', '&exptid=7', 'http://localhost[:0-9]*/mod_pagespeed_example/extend_cache.html');"
 
 start_test The no-experiment group beacon should not include an experiment id.
 OUT=$($WGET_DUMP --header='Cookie: PageSpeedExperiment=0' $EXTEND_CACHE)
-check_not_from "$OUT" grep 'mod_pagespeed_beacon.*exptid'
+check_not_from "$OUT" grep '.*beacon.*exptid'
 
 # We expect id=7 to be index=a and id=2 to be index=b because that's the
 # order they're defined in the config file.

--- a/install/debug.conf.template
+++ b/install/debug.conf.template
@@ -51,6 +51,10 @@ ModPagespeedInlineResourcesWithoutExplicitAuthorization off
 # built with ssl, but otherwise will cause no trouble.
 ModPagespeedFetchHttps enable
 
+
+ModPagespeedBeaconUrl /ps-timing-beacon
+ModPagespeedCriticalImagesBeaconUrl /ps-images-beacon
+
 ModPagespeedLibrary 43 1o978_K0_LNE5_ystNklf http://www.modpagespeed.com/rewrite_javascript.js
 ModPagespeedRetainComment " google_ad_section*"
 
@@ -545,6 +549,8 @@ NameVirtualHost localhost:@@APACHE_SECONDARY_PORT@@
 
   # Helps testing whether the configuration of reporting 'unload' time works.
   ModPagespeedReportUnloadTime on
+#NEED_VHOST_BEACON ModPagespeedBeaconUrl /ps-timing-beacon
+#NEED_VHOST_BEACON ModPagespeedCriticalImagesBeaconUrl /ps-images-beacon
 
   # Make a non-empty subdirectory config to make sure that
   # cache.flush updates get transmitted to nested configurations.
@@ -1121,7 +1127,13 @@ ModPagespeedUsePerVHostStatistics on
 
   # add_instrumentation tests beacon handling with no handler specified, while
   # here we test it with a handler (that should do nothing).
-  <Location /mod_pagespeed_beacon>
+#NEED_VHOST_BEACON ModPagespeedBeaconUrl /ps-timing-beacon
+#NEED_VHOST_BEACON ModPagespeedCriticalImagesBeaconUrl /ps-images-beacon
+
+  <Location /ps-timing-beacon>
+    SetHandler mod_pagespeed_beacon
+  </Location>
+  <Location /ps-images-beacon>
     SetHandler mod_pagespeed_beacon
   </Location>
 </VirtualHost>
@@ -1208,10 +1220,14 @@ ModPagespeedUsePerVHostStatistics on
   ModPagespeedRewriteLevel PassThrough
   ModPagespeedEnableFilters resize_rendered_image_dimensions
   ModPagespeedCriticalImagesBeaconEnabled true
-
+#NEED_VHOST_BEACON ModPagespeedBeaconUrl /ps-timing-beacon
+#NEED_VHOST_BEACON ModPagespeedCriticalImagesBeaconUrl /ps-images-beacon
   # add_instrumentation tests beacon handling with no handler specified, while
   # here we test it with a handler (that should do nothing).
-  <Location /mod_pagespeed_beacon>
+  <Location /ps-timing-beacon>
+    SetHandler mod_pagespeed_beacon
+  </Location>
+  <Location /ps-images-beacon>
     SetHandler mod_pagespeed_beacon
   </Location>
 </VirtualHost>

--- a/net/instaweb/rewriter/critical_css_beacon_filter.cc
+++ b/net/instaweb/rewriter/critical_css_beacon_filter.cc
@@ -125,8 +125,8 @@ void CriticalCssBeaconFilter::AppendSelectorsInitJs(
 void CriticalCssBeaconFilter::AppendBeaconInitJs(
     const BeaconMetadata& metadata, GoogleString* script) {
   GoogleString beacon_url = driver()->IsHttps() ?
-      driver()->options()->beacon_url().https :
-      driver()->options()->beacon_url().http;
+      driver()->options()->critical_images_beacon_url().https :
+      driver()->options()->critical_images_beacon_url().http;
   GoogleString page_url;
   EscapeToJsStringLiteral(driver()->google_url().Spec(), false /* add_quotes */,
                           &page_url);

--- a/net/instaweb/rewriter/critical_css_beacon_filter_test.cc
+++ b/net/instaweb/rewriter/critical_css_beacon_filter_test.cc
@@ -139,7 +139,7 @@ class CriticalCssBeaconFilterTestBase : public RewriteTestBase {
         "pagespeed.selectors=[", selectors, "];");
     StrAppend(&html,
               "pagespeed.criticalCssBeaconInit('",
-              options()->beacon_url().http, "','", kTestDomain,
+              options()->critical_images_beacon_url().http, "','", kTestDomain,
               "','0','", ExpectedNonce(), "',pagespeed.selectors);"
               "</script></body>");
     return html;

--- a/net/instaweb/rewriter/public/rewrite_options.h
+++ b/net/instaweb/rewriter/public/rewrite_options.h
@@ -238,6 +238,7 @@ class RewriteOptions {
   static const char kContentExperimentID[];
   static const char kContentExperimentVariantID[];
   static const char kCriticalImagesBeaconEnabled[];
+  static const char kCriticalImagesBeaconUrl[];
   static const char kCssFlattenMaxBytes[];
   static const char kCssImageInlineMaxBytes[];
   static const char kCssInlineMaxBytes[];
@@ -2233,6 +2234,14 @@ class RewriteOptions {
     beacon_url_.SetFromString(beacon_url, &ignored_error_detail);
   }
 
+  const BeaconUrl& critical_images_beacon_url() const {
+    return critical_images_beacon_url_.value(); 
+  }
+  void set_critical_images_beacon_url(const GoogleString& beacon_url) {
+    GoogleString ignored_error_detail;
+    critical_images_beacon_url_.SetFromString(beacon_url, &ignored_error_detail);
+  }
+
   // Return false in a subclass if you want to disallow all URL trimming in CSS.
   virtual bool trim_urls_in_css() const { return true; }
 
@@ -3284,6 +3293,7 @@ class RewriteOptions {
 
   // Protected option values so that derived class can modify.
   Option<BeaconUrl> beacon_url_;
+  Option<BeaconUrl> critical_images_beacon_url_;
 
   // The value we put for the X-Mod-Pagespeed header. Default is our version.
   Option<GoogleString> x_header_value_;

--- a/net/instaweb/rewriter/rewrite_options.cc
+++ b/net/instaweb/rewriter/rewrite_options.cc
@@ -82,6 +82,8 @@ const char RewriteOptions::kContentExperimentVariantID[] =
     "ContentExperimentVariantID";
 const char RewriteOptions::kCriticalImagesBeaconEnabled[] =
     "CriticalImagesBeaconEnabled";
+const char RewriteOptions::kCriticalImagesBeaconUrl[] =
+  "CriticalImagesBeaconUrl";
 const char RewriteOptions::kCssFlattenMaxBytes[] = "CssFlattenMaxBytes";
 const char RewriteOptions::kCssImageInlineMaxBytes[] = "CssImageInlineMaxBytes";
 const char RewriteOptions::kCssInlineMaxBytes[] = "CssInlineMaxBytes";
@@ -1663,6 +1665,13 @@ void RewriteOptions::AddProperties() {
       kBeaconUrl,
       kDirectoryScope,
       "URL for beacon callback injected by add_instrumentation.", false);
+  // TODO(oschaaf): This allows directory-level setting, which seems no good
+  // when I look at NPS at least, which uses global_options_ to compare.
+  AddBaseProperty(
+      kDefaultBeaconUrls, &RewriteOptions::critical_images_beacon_url_, "cbu",
+      kCriticalImagesBeaconUrl,
+      kDirectoryScope,
+      "URL for beacon callback injected by the critical image finder.", false);
 
   // lazyload_images_after_onload_ is especially important for mobile,
   // where the recommendation is that you prefetch all the

--- a/net/instaweb/rewriter/rewrite_options_test.cc
+++ b/net/instaweb/rewriter/rewrite_options_test.cc
@@ -945,6 +945,7 @@ TEST_F(RewriteOptionsTest, LookupOptionByNameTest) {
     RewriteOptions::kContentExperimentID,
     RewriteOptions::kContentExperimentVariantID,
     RewriteOptions::kCriticalImagesBeaconEnabled,
+    RewriteOptions::kCriticalImagesBeaconUrl,
     RewriteOptions::kCssFlattenMaxBytes,
     RewriteOptions::kCssImageInlineMaxBytes,
     RewriteOptions::kCssInlineMaxBytes,

--- a/pagespeed/apache/instaweb_handler.cc
+++ b/pagespeed/apache/instaweb_handler.cc
@@ -865,6 +865,7 @@ bool InstawebHandler::IsBeaconUrl(const RewriteOptions::BeaconUrl& beacons,
   if (!gurl.IsWebValid()) {
     return false;
   }
+
   // Ignore query params in the beacon URLs. Normally the beacon URL won't have
   // a query param, but it could have been added using ModPagespeedBeaconUrl.
   return (gurl.PathSansQuery() == beacons.http_in ||
@@ -1026,7 +1027,9 @@ apr_status_t InstawebHandler::instaweb_handler(request_rec* request) {
       if (!gurl.IsWebValid()) {
         ap_log_rerror(APLOG_MARK, APLOG_DEBUG, APR_SUCCESS, request,
                       "Ignoring invalid URL: %s", gurl.spec_c_str());
-      } else if (IsBeaconUrl(global_config->beacon_url(), gurl)) {
+      } else if (IsBeaconUrl(global_config->beacon_url(), gurl) ||
+                 IsBeaconUrl(global_config->critical_images_beacon_url(),
+                             gurl)) {
         ret = instaweb_beacon_handler(request, server_context);
       // For the beacon accept any method; for all others only allow GETs.
       } else if (request->method_number != M_GET) {
@@ -1143,6 +1146,9 @@ apr_status_t InstawebHandler::save_url_in_note(
         gurl.PathSansLeaf() ==
           server_context->apache_factory()->static_asset_prefix() ||
         IsBeaconUrl(server_context->global_options()->beacon_url(), gurl) ||
+        IsBeaconUrl(
+            server_context->global_options()->critical_images_beacon_url(),
+            gurl) ||
         server_context->IsPagespeedResource(gurl)) {
       bypass_mod_rewrite = true;
     }

--- a/pagespeed/apache/system_test.sh
+++ b/pagespeed/apache/system_test.sh
@@ -26,7 +26,8 @@ if [ -z $APACHE_DOC_ROOT ]; then
 fi
 
 PSA_JS_LIBRARY_URL_PREFIX="mod_pagespeed_static"
-BEACON_HANDLER="mod_pagespeed_beacon"
+BEACON_HANDLER="ps-timing-beacon"
+CRITICAL_IMAGES_BEACON_HANDLER="ps-images-beacon"
 STATISTICS_HANDLER="mod_pagespeed_statistics"
 GLOBAL_STATISTICS_HANDLER="mod_pagespeed_global_statistics"
 MESSAGES_HANDLER="mod_pagespeed_message"
@@ -34,6 +35,7 @@ HEADERS_FINALIZED=false
 
 CACHE_FLUSH_TEST=${CACHE_FLUSH_TEST:-off}
 NO_VHOST_MERGE=${NO_VHOST_MERGE:-off}
+
 SUDO=${SUDO:-}
 # TODO(jkarlin): Should we just use a vhost instead?  If so, remember to update
 # all scripts that use TEST_PROXY_ORIGIN.

--- a/pagespeed/system/system_test.sh
+++ b/pagespeed/system/system_test.sh
@@ -1344,10 +1344,11 @@ if [ "$SECONDARY_HOSTNAME" != "" ]; then
 
   # Send a beacon response using POST indicating that OptPuzzle.jpg is
   # critical and has rendered dimensions.
-  BEACON_URL="$HOST_NAME/$BEACON_HANDLER"
+  BEACON_URL="$HOST_NAME/$CRITICAL_IMAGES_BEACON_HANDLER"
   BEACON_URL+="?url=http%3A%2F%2Frenderedimagebeacon.example.com%2Fmod_pagespeed_test%2F"
   BEACON_URL+="image_rewriting%2Fimage_resize_using_rendered_dimensions.html"
   BEACON_DATA="oh=$OPTIONS_HASH&n=$NONCE&ci=1344500982&rd=%7B%221344500982%22%3A%7B%22rw%22%3A150%2C%22rh%22%3A100%2C%22ow%22%3A256%2C%22oh%22%3A192%7D%7D"
+  echo "$BEACON_URL"
   OUT=$(env http_proxy=$SECONDARY_HOSTNAME \
     $CURL -sSi -d "$BEACON_DATA" "$BEACON_URL")
   check_from "$OUT" egrep -q "HTTP/1[.]. 204"
@@ -1428,7 +1429,7 @@ if [ "$SECONDARY_HOSTNAME" != "" ]; then
     awk -F\' '/^pagespeed\.CriticalImages\.Run/ {print $(NF-1)}' $FETCH_FILE)
   # Send a beacon response using POST indicating that Puzzle.jpg is a critical
   # image.
-  BEACON_URL="$HOST_NAME/$BEACON_HANDLER"
+  BEACON_URL="$HOST_NAME/$CRITICAL_IMAGES_BEACON_HANDLER"
   BEACON_URL+="?url=http%3A%2F%2Fimagebeacon.example.com%2Fmod_pagespeed_test%2F"
   BEACON_URL+="image_rewriting%2Frewrite_images.html"
   BEACON_DATA="oh=$OPTIONS_HASH&n=$NONCE&ci=2932493096"
@@ -1454,7 +1455,7 @@ if [ "$SECONDARY_HOSTNAME" != "" ]; then
     awk -F\' '/^pagespeed\.CriticalImages\.Run/ {print $(NF-3)}' $FETCH_FILE)
   NONCE=$(
     awk -F\' '/^pagespeed\.CriticalImages\.Run/ {print $(NF-1)}' $FETCH_FILE)
-  BEACON_URL="$HOST_NAME/$BEACON_HANDLER"
+  BEACON_URL="$HOST_NAME/$CRITICAL_IMAGES_BEACON_HANDLER"
   BEACON_URL+="?url=http%3A%2F%2Fimagebeacon.example.com%2Fmod_pagespeed_test%2F"
   BEACON_URL+="image_rewriting%2Frewrite_images.html%3Fid%3D4"
   BEACON_DATA="oh=$OPTIONS_HASH&n=$NONCE&ci=2932493096"


### PR DESCRIPTION
There are multiple reasons why someone would like to change the beacon url, and one of them is to have timings originating from the add_instrumentation filter processed on another machine.

Unfortunately, pointing `ModPagespeedBeaconUrl` to another server will also send the beacons that contain data about critical images critical images to the other server, which probably is no good.

This change proposes a separate option for beaconing data about critical images, `ModPagespeedCriticalImagesBeaconUrl`

Note that this should go in together with a separate change in ngx_pagespeed to not break its system tests.
- edit, add the nps PR-:
  https://github.com/pagespeed/ngx_pagespeed/pull/1245
