### PR TITLE
Make Travis run unit tests with apache_test make target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,9 @@ install:
   - sudo dpkg -i out/Release/mod-pagespeed*.deb
 script:
   - cd ~/build_directory/src
-  - ./out/Release/mod_pagespeed_test
-  - ./out/Release/pagespeed_automatic_test
   - find . -name "*.sh" | xargs chmod +x
   - cd install
+  - sudo -E ./ubuntu.sh apache_test
   - sudo -E ./ubuntu.sh apache_debug_restart
   - sudo -E ./ubuntu.sh apache_vm_system_tests
 sudo: required


### PR DESCRIPTION
I'm waiting till <a href="https://travis-ci.org/pagespeed/mod_pagespeed/builds/152483485">build</a> succeeds and then will manually check logs to ensure that memcached and redis tests were not skipped.
