### PR TITLE
Remove DCHECK in css summarizer

### DIFF
--- a/net/instaweb/rewriter/css_summarizer_base.cc
+++ b/net/instaweb/rewriter/css_summarizer_base.cc
@@ -303,7 +303,6 @@ void CssSummarizerBase::Clear() {
 void CssSummarizerBase::StartDocumentImpl() {
   // TODO(morlovich): we hold on to the summaries_ memory too long; refine this
   // once the data type is refined.
-  DCHECK(canceled_summaries_.empty());
   Clear();
 }
 


### PR DESCRIPTION
This removes a DCHECK which occasionally fails. There's
a TODO which I think is related to this DCHECK. I propose
we create a new issue to track looking into tuning the memory
lifetime the TODO mentions upon merging this.

Fixes https://github.com/pagespeed/ngx_pagespeed/issues/891
