### PR TITLE
Make Travis run unit tests for external cache servers as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,7 @@ install:
   - sudo dpkg -i out/Release/mod-pagespeed*.deb
 script:
   - cd ~/build_directory/src
-  - ./out/Release/mod_pagespeed_test
-  - ./out/Release/pagespeed_automatic_test
+  - ./install/run_program_with_ext_caches.sh ./out/Release/mod_pagespeed_test \; ./out/Release/pagespeed_automatic_test
   - find . -name "*.sh" | xargs chmod +x
   - cd install
   - sudo -E ./ubuntu.sh apache_debug_restart


### PR DESCRIPTION
I've checked logs and unit tests for RedisCache and AprMemCache are run as expected.
