### PR TITLE
strip-subresource-hints: respect preserve with rel=preload, use href not src

### DIFF
--- a/install/mod_pagespeed_test/strip_subresource_hints/default/disallowtest.html
+++ b/install/mod_pagespeed_test/strip_subresource_hints/default/disallowtest.html
@@ -1,5 +1,5 @@
 <html>
-  <head><link rel="subresource" src="dontrewriteme_resource.jpg"/></head>
+  <head><link rel="subresource" href="dontrewriteme_resource.jpg"/></head>
 <body>
 </body>
 </html>

--- a/install/mod_pagespeed_test/strip_subresource_hints/default/index.html
+++ b/install/mod_pagespeed_test/strip_subresource_hints/default/index.html
@@ -1,5 +1,5 @@
 <html>
-  <head><link rel="subresource" src="test"/></head>
+  <head><link rel="subresource" href="test"/></head>
 <body>
 </body>
 </html>

--- a/install/mod_pagespeed_test/strip_subresource_hints/default/multiple_subresource_hints.html
+++ b/install/mod_pagespeed_test/strip_subresource_hints/default/multiple_subresource_hints.html
@@ -1,7 +1,7 @@
 <html>
   <head>
-    <link rel="subresource" src="test1"/>
-    <link rel="subresource" src="test2"/>
+    <link rel="subresource" href="test1"/>
+    <link rel="subresource" href="test2"/>
   </head>
 <body>
 </body>

--- a/install/mod_pagespeed_test/strip_subresource_hints/default_passthrough/index.html
+++ b/install/mod_pagespeed_test/strip_subresource_hints/default_passthrough/index.html
@@ -1,5 +1,5 @@
 <html>
-  <head><link rel="subresource" src="test"/></head>
+  <head><link rel="subresource" href="test"/></head>
 <body>
 </body>
 </html>

--- a/install/mod_pagespeed_test/strip_subresource_hints/preserve_off/index.html
+++ b/install/mod_pagespeed_test/strip_subresource_hints/preserve_off/index.html
@@ -1,5 +1,5 @@
 <html>
-  <head><link rel="subresource" src="test"/></head>
+  <head><link rel="subresource" href="test"/></head>
 <body>
 </body>
 </html>

--- a/install/mod_pagespeed_test/strip_subresource_hints/preserve_on/index.html
+++ b/install/mod_pagespeed_test/strip_subresource_hints/preserve_on/index.html
@@ -1,5 +1,5 @@
 <html>
-  <head><link rel="subresource" src="test"/></head>
+  <head><link rel="subresource" href="test"/></head>
 <body>
 </body>
 </html>

--- a/net/instaweb/rewriter/public/strip_subresource_hints_filter.h
+++ b/net/instaweb/rewriter/public/strip_subresource_hints_filter.h
@@ -43,7 +43,10 @@ class StripSubresourceHintsFilter : public EmptyHtmlFilter {
  private:
   RewriteDriver* driver_;
   HtmlElement* delete_element_;
-  bool remove_;
+  bool remove_script_;
+  bool remove_style_;
+  bool remove_image_;
+  bool remove_any_;
 
   DISALLOW_COPY_AND_ASSIGN(StripSubresourceHintsFilter);
 };

--- a/net/instaweb/rewriter/strip_subresource_hints_filter.cc
+++ b/net/instaweb/rewriter/strip_subresource_hints_filter.cc
@@ -32,32 +32,48 @@ namespace net_instaweb {
 StripSubresourceHintsFilter::StripSubresourceHintsFilter(RewriteDriver* driver)
     : driver_(driver),
       delete_element_(NULL),
-      remove_(false) {
+      remove_script_(false),
+      remove_style_(false),
+      remove_image_(false),
+      remove_any_(false) {
 }
 
 StripSubresourceHintsFilter::~StripSubresourceHintsFilter() { }
 
 void StripSubresourceHintsFilter::StartDocument() {
   const RewriteOptions *options = driver_->options();
-  remove_ = (driver_->can_modify_urls() &&
-             (!(options->css_preserve_urls() &&
-                options->image_preserve_urls() &&
-                options->js_preserve_urls())));
+  remove_script_ = driver_->can_modify_urls() && !options->js_preserve_urls();
+  remove_style_ = driver_->can_modify_urls() && !options->css_preserve_urls();
+  remove_image_ = driver_->can_modify_urls() && !options->image_preserve_urls();
+  remove_any_ = remove_script_ || remove_style_ || remove_image_;
   delete_element_ = NULL;
 }
 
 void StripSubresourceHintsFilter::StartElement(HtmlElement* element) {
-  if (!remove_ || delete_element_) return;
+  if (!remove_any_ || delete_element_) return;
 
   if (element->keyword() == HtmlName::kLink) {
-    const char *value = element->AttributeValue(HtmlName::kRel);
-    if (value && (
-            StringCaseEqual(value, "subresource") ||
-            StringCaseEqual(value, "preload"))) {
+    // Strip:
+    //   <link rel=subresource href=...> regardless
+    //   <link rel=preload as=script href=...> unless preserve scripts
+    //   <link rel=preload as=style href=...>  unless preserve styles
+    //   <link rel=preload as=image href=...>  unless preserve images
+    //
+    // Don't strip other kinds of rel=preload hints, because we don't change
+    // their urls, so existing ones are still valid.
+    const char* rel_value;
+    const char* as_value;
+    if ((rel_value = element->AttributeValue(HtmlName::kRel)) != NULL &&
+        (StringCaseEqual(rel_value, "subresource") ||
+         (StringCaseEqual(rel_value, "preload") &&
+          (as_value = element->AttributeValue(HtmlName::kAs)) != NULL &&
+          ((remove_script_ && StringCaseEqual(as_value, "script")) ||
+           (remove_style_ && StringCaseEqual(as_value, "style")) ||
+           (remove_image_ && StringCaseEqual(as_value, "image")))))) {
       const RewriteOptions *options = driver_->options();
-      const char *resource_url = element->AttributeValue(HtmlName::kSrc);
+      const char *resource_url = element->AttributeValue(HtmlName::kHref);
       if (!resource_url) {
-        // There's either no src attr, or one that we can't decode (utf8 etc).
+        // There's either no href attr, or one that we can't decode (utf8 etc).
         // One way this could happen is if we have a url-encoded utf8 url in an
         // img tag and a utf8 encoded url in the subresource tag.  Delete the
         // subresource link to be on the safe side.

--- a/pagespeed/kernel/html/html_name.gperf
+++ b/pagespeed/kernel/html/html_name.gperf
@@ -33,6 +33,7 @@ struct KeywordMap {const char* name; net_instaweb::HtmlName::Keyword keyword;};
 "alt",                                HtmlName::kAlt
 "area",                               HtmlName::kArea
 "article",                            HtmlName::kArticle
+"as",                                 HtmlName::kAs
 "aside",                              HtmlName::kAside
 "async",                              HtmlName::kAsync
 "audio",                              HtmlName::kAudio

--- a/pagespeed/kernel/html/html_name.h
+++ b/pagespeed/kernel/html/html_name.h
@@ -45,6 +45,7 @@ class HtmlName {
     kAlt,
     kArea,
     kArticle,
+    kAs,
     kAside,
     kAsync,
     kAudio,


### PR DESCRIPTION
- With rel=preload the hint tells us what type of resource it is, and if
  urls have been preserved for that type we should not strip it.
- If the rel=preload type isn't image, script, or style we shouldn't
  strip it, because those are the only urls we change.
- The filter was originally written to use src= when it should have used
  href=, which meant it removed hints it shouldn't have.

This is a minimal change for backporting for branch 33.  For the master branch
I have a draft of a more complex change that does additional cleanups.

Fixes: https://github.com/pagespeed/mod_pagespeed/issues/1392
Fixes: https://github.com/pagespeed/mod_pagespeed/issues/1393
