### PR TITLE
Add redis as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -111,3 +111,6 @@
 [submodule "third_party/mod_fcgid"]
 	path = third_party/mod_fcgid
 	url = https://github.com/pagespeed/mod_fcgid.git
+[submodule "third_party/redis"]
+	path = third_party/redis
+	url = https://github.com/antirez/redis.git


### PR DESCRIPTION
Our redis tests require a version of redis more recent than the 2.8.4 that people developing on Ubuntu 14 LTS will have by default.  This is because we want to test cluster support, which was added in 3.0.  Instead of requiring people to set up redis themselves, include it as a submodule so build_development_apache.sh can use it.