### PR TITLE
ngxpagespeed.com configuration: fix /install

### DIFF
--- a/install/ngxpagespeed-com.conf
+++ b/install/ngxpagespeed-com.conf
@@ -86,7 +86,7 @@ http {
         }
 
         location /install {
-            rewrite ^/.* https://raw.githubusercontent.com/pagespeed/ngx_pagespeed/trunk-tracking/scripts/build_ngx_pagespeed.sh;
+            rewrite ^/.* https://raw.githubusercontent.com/pagespeed/ngx_pagespeed/master/scripts/build_ngx_pagespeed.sh;
         }
 
         pagespeed on;


### PR DESCRIPTION
ngxpagespeed.com/install serves a redirect to build_ngx_pagespeed.sh on github.  Now that we develop on master and trunk-tracking is gone, fix it to point at master.

Already fixed (manually) on the live site.