### PR TITLE
licensing: correct license comments

### DIFF
--- a/devel/apache_cleanup.sh
+++ b/devel/apache_cleanup.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+#
+# Copyright 2010 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # See bug 3103898 and
 # http://carlosrivero.com/fix-apache

--- a/devel/apache_configure_https_port.sh
+++ b/devel/apache_configure_https_port.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 #
+# Copyright 2011 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Script to enable SSL on the given port for Apache, usually in ~/apache2.
 #
 # usage: apache_configure_https_port.sh apache-root-directory https-port

--- a/devel/apache_configure_php5_from_etc_php5.sh
+++ b/devel/apache_configure_php5_from_etc_php5.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 #
+# Copyright 2012 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Script to enable PHP5 in Apache assuming it has already been installed into
 # the standard Ubuntu directory (/etc/apache, /usr/apache) rather than the
 # ~/apache2 directory we use [in other words, modules have been apt install'd

--- a/devel/apache_create_server_certificate.sh
+++ b/devel/apache_create_server_certificate.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 #
+# Copyright 2012 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Script to create a server certificate (and key) file for Apache,
 # usually in ~/apache2.
 #

--- a/devel/apache_install.sh
+++ b/devel/apache_install.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 #
+# Copyright 2010 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Script to install a debuggable mod_pagespeed.so into the Apache
 # distribution, usually in ~/apache2.
 

--- a/devel/apache_rotate_logs.sh
+++ b/devel/apache_rotate_logs.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+#
+# Copyright 2011 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Rotate the logs in the apache logs directory specified on the command line,
 # and gzip them, then erase old logs if disk usage is over 85%.  Note that
 # apache must be stopped when we do this.  Note also that we take pains not to

--- a/devel/check_tests_are_run.sh
+++ b/devel/check_tests_are_run.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 #
+# Copyright 2011 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Scans source directories for _test.cc files and makes sure they are mentioned
 # in the appropriate gyp files.
 #

--- a/devel/checkin_test_helpers.sh
+++ b/devel/checkin_test_helpers.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 #
-# Copyright 2011 Google Inc. All Rights Reserved.
+# Copyright 2011 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: sligocki@google.com (Shawn Ligocki)
 #
 # Helper functions for holding locks so that checkin tests from two clients

--- a/devel/doxify.sh
+++ b/devel/doxify.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 #
+# Copyright 2003 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Runs a file in $1 through a giant sed script, transforming normal
 # C++ comments to Doxygen comments.  The resultant file is placed in
 # $2/$1, so $2 must be a subdirectory.

--- a/devel/doxify_tree.sh
+++ b/devel/doxify_tree.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 #
+# Copyright 2010 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Processes the open-source header files using Doxygen.  Each header
 # must be preprocessed using doxify.sh to convert normal C++ comments
 # into Doxygen Usage.

--- a/devel/fetch_all.py
+++ b/devel/fetch_all.py
@@ -1,7 +1,18 @@
 #!/usr/bin/python
 #
-# Copyright 2010 Google Inc. All Rights Reserved.
-
+# Copyright 2010 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Fetches a set of URLs via a proxy, keeping statistics.
 
 This script attempts to fetch all URLs in the list given on

--- a/devel/gcov-all.sh
+++ b/devel/gcov-all.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 #
+# Copyright 2011 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # A helper for running gcov on all of the project sources.
 # Usage:
 #   gcov-all.sh (--prepare | --summarize) path

--- a/devel/mps_generate_load.sh
+++ b/devel/mps_generate_load.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 #
+# Copyright 2012 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # This script is intended to be run from devel/mps_load_test.sh, although it can
 # be run directly as well.
 #

--- a/devel/mps_load_test.sh
+++ b/devel/mps_load_test.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 #
+# Copyright 2012 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Note: this script is not yet usable outside Google, because it depends on a
 # corpus database that we can't open source.  It should be possible to create a
 # db with a combination of mod_pagespeed's slurping and a headless browser, but

--- a/devel/scrape_error_log_for_crashes.sh
+++ b/devel/scrape_error_log_for_crashes.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+#
+# Copyright 2012 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 if [ $# -lt 2 ]; then
   echo Usage: $0 error_log_filename stop_filename

--- a/devel/slurp_test.sh
+++ b/devel/slurp_test.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 set -e
 set -u

--- a/devel/trace_stress_test.sh
+++ b/devel/trace_stress_test.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+#
+# Copyright 2012 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # This scripts reads a list of URLs from the provided file, and
 # fetches them in parallel from a local slurping proxy in a randomized
 # order. Loading times and statuses for them are then output to

--- a/devel/trace_stress_test_percentiles.sh
+++ b/devel/trace_stress_test_percentiles.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+#
+# Copyright 2012 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # This script takes the output of trace_stress_test.sh and reports cheap and
 # cheerful median, 75th, 90th, 95th, 99th, and worst latencies.
 if [ "X$1" == "X" ]; then

--- a/devel/turn_on_timewait_recyling.sh
+++ b/devel/turn_on_timewait_recyling.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 #
+# Copyright 2012 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Makes linux enable fast reuse of sockets in TIME-WAIT state.  We need this for
 # load testing so that we don't run out of connection table slots and fail to
 # get a socket.  This isn't generally a good idea to set on public-facing

--- a/install/apache_experiment_ga_test.sh
+++ b/install/apache_experiment_ga_test.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 #
-# Copyright 2012 Google Inc. All Rights Reserved.
+# Copyright 2012 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Author: jefftk@google.com (Jeff Kaufman)
 #
 # Runs all Apache-specific experiment framework tests that depend on AnalyticsID

--- a/install/apache_experiment_no_ga_test.sh
+++ b/install/apache_experiment_no_ga_test.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 #
-# Copyright 2012 Google Inc. All Rights Reserved.
+# Copyright 2012 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: jefftk@google.com (Jeff Kaufman)
 #
 # Runs all Apache-specific experiment framework tests that depend on AnalyticsID

--- a/install/apache_experiment_test.sh
+++ b/install/apache_experiment_test.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 #
-# Copyright 2012 Google Inc. All Rights Reserved.
+# Copyright 2012 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: jefftk@google.com (Jeff Kaufman)
 #
 # Runs all Apache-specific experiment framework tests that don't depend on

--- a/install/apache_https_fetch_test.sh
+++ b/install/apache_https_fetch_test.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+#
+# Copyright 2013 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # Tests that mod_pagespeed can fetch HTTPS resources.  Note that mod_pagespeed
 # does not work like this by default: a flag must be specified in

--- a/install/build_development_apache.sh
+++ b/install/build_development_apache.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Install mod_pagespeed testing version of Apache for use in checkin test.
 # This also installs the dependencies for mod_h2 if you're building 2.4
 #

--- a/install/build_mps.sh
+++ b/install/build_mps.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
-# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: cheesy@google.com (Steve Hill)
 #
 # Script to build mod_pagespeed.

--- a/install/build_on_vm.sh
+++ b/install/build_on_vm.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
-# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: cheesy@google.com (Steve Hill)
 #
 # Build a mod_pagespeed release on a gcloud VM.

--- a/install/build_psol.sh
+++ b/install/build_psol.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
-# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: cheesy@google.com (Steve Hill)
 #
 # Builds psol tarball from a mod_pagespeed checkout.

--- a/install/build_release.sh
+++ b/install/build_release.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 source "$(dirname "$BASH_SOURCE")/build_env.sh" || exit 1
 

--- a/install/centos/build_env.sh
+++ b/install/centos/build_env.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
-# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: cheesy@google.com (Steve Hill)
 #
 # Sets common environment variables requires for building PageSpeed stuff.

--- a/install/centos/install_mps_package.sh
+++ b/install/centos/install_mps_package.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
-# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: cheesy@google.com (Steve Hill)
 #
 # Remove old mod_pagespeed debs and install a new one.

--- a/install/centos/install_required_packages.sh
+++ b/install/centos/install_required_packages.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
-# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: cheesy@google.com (Steve Hill)
 #
 # Install packages required for building mod_pagespeed.

--- a/install/centos/run_in_chroot.sh
+++ b/install/centos/run_in_chroot.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
-# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: cheesy@google.com (Steve Hill)
 #
 # This script emulates the behavior of schroot, which:

--- a/install/centos/setup_chroot.sh
+++ b/install/centos/setup_chroot.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
-# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: cheesy@google.com (Steve Hill)
 #
 # Setup a 32-bit chroot for CentOS.

--- a/install/clean_slate_for_tests.sh
+++ b/install/clean_slate_for_tests.sh
@@ -1,5 +1,19 @@
 #!/bin/sh
 #
+# Copyright 2012 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Deletes the specified cache directories and the apache log.  Note that this
 # is not necessary or sufficient for purging the cache in a running system,
 # because it does not affect the in-memory cache, or any external caches like

--- a/install/find_redis_cluster.sh
+++ b/install/find_redis_cluster.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 #
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Checks that redis-server and redis-cli exist and supports Redis Cluster.
 # If $REDIS_SERVER/$REDIS_CLI are not set, defaults them to
 # redis-server/redis-cli.

--- a/install/install_apxs.sh
+++ b/install/install_apxs.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 #
+# Copyright 2011 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Install Page Speed, using the Apache apxs tool to determine the
 # installation locations.
 #

--- a/install/install_from_source.sh
+++ b/install/install_from_source.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
-# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: cheesy@google.com (Steve Hill)
 #
 # Trivial wrapper for shell function that installs a package from source

--- a/install/opensuse-initd-wrapper.sh
+++ b/install/opensuse-initd-wrapper.sh
@@ -1,4 +1,19 @@
 #!/bin/sh
+#
+# Copyright 2012 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Takes care of conflict in shell vars used by us and system scripts
 unset APACHE_MODULES
 /etc/init.d/apache2 $*

--- a/install/opensuse.sh
+++ b/install/opensuse.sh
@@ -1,4 +1,19 @@
 #!/bin/sh
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -x
 
 SUFFIX=

--- a/install/os_redirector.sh
+++ b/install/os_redirector.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
-# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: cheesy@google.com (Steve Hill)
 #
 # Locate and run the OS-specific version of a PageSpeed setup script.

--- a/install/prepare_ngx_pagespeed_examples.sh
+++ b/install/prepare_ngx_pagespeed_examples.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # This script prepares ngx_pagespeed_example.tar.gz for ngxpagespeed.com
 # Usage:

--- a/install/run_program_with_ext_caches.sh
+++ b/install/run_program_with_ext_caches.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 #
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Starts all external cache servers and sets environment appropriately, then
 # runs single command in $@. There should be no substitutions in $@, as they may
 # happen in between starts of different servers.

--- a/install/run_program_with_memcached.sh
+++ b/install/run_program_with_memcached.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 #
+# Copyright 2014 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Checks that that memcached is already installed, and then runs it on
 # random port with temporary working directory. Port is saved in $MEMCACHED_PORT
 # env variable. Commands in $@ (e.g. a test binary) are then run and server is

--- a/install/run_program_with_redis.sh
+++ b/install/run_program_with_redis.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 #
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Checks that that redis is already installed, and then runs it on
 # random port with temporary working directory. Port is saved in $REDIS_PORT env
 # variable. Commands in $@ (e.g. a test binary) are then run and server is then

--- a/install/run_program_with_redis_cluster.sh
+++ b/install/run_program_with_redis_cluster.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 #
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Sets up Redis Cluster and runs corresponding unit tests.
 # TODO(yeputons) it does not know what to do in open-source yet
 

--- a/install/run_with_log.sh
+++ b/install/run_with_log.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
-# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: cheesy@google.com (Steve Hill)
 #
 # Trivial wrapper for shell function that writes output to a log.

--- a/install/shell_utils.sh
+++ b/install/shell_utils.sh
@@ -1,4 +1,19 @@
-# Copyright 2011 Google Inc. All Rights Reserved.
+#!/bin/bash
+#
+# Copyright 2011 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: sligocki@google.com (Shawn Ligocki)
 #
 # Common shell utils.

--- a/install/start_background_server.sh
+++ b/install/start_background_server.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 #
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Helping script which runs arbitrary server process (e.g. memcached or
 # redis-server) in a temporary directory on random available port.
 #

--- a/install/start_php.sh
+++ b/install/start_php.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # Starts a php-cgi server on the specified port.  If there's already one running
 # on that port that it looks like it started, kills that one first.

--- a/install/stop_apache.sh
+++ b/install/stop_apache.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2011 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #!/bin/sh
 #
 # Yet Another Attempt (YAA) at robustly stopping Apache.  Fun facts:

--- a/install/stress_test.sh
+++ b/install/stress_test.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
-# Copyright 2010 Google Inc. All Rights Reserved.
+#
+# Copyright 2010 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: abliss@google.com (Adam Bliss)
 #
 # Usage: ./stress_test.sh HOSTPORT

--- a/install/test_package.sh
+++ b/install/test_package.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
-# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: cheesy@google.com (Steve Hill)
 #
 # Install a mod_pagespeed package and run tests on it.

--- a/install/ubuntu/build_env.sh
+++ b/install/ubuntu/build_env.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
-# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: cheesy@google.com (Steve Hill)
 #
 # Sets common environment variables requires for building PageSpeed stuff.

--- a/install/ubuntu/install_mps_package.sh
+++ b/install/ubuntu/install_mps_package.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
-# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: cheesy@google.com (Steve Hill)
 #
 # Remove old mod_pagespeed debs and install a new one.

--- a/install/ubuntu/install_required_packages.sh
+++ b/install/ubuntu/install_required_packages.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
-# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: cheesy@google.com (Steve Hill)
 #
 # Install packages required for building mod_pagespeed.

--- a/install/ubuntu/run_in_chroot.sh
+++ b/install/ubuntu/run_in_chroot.sh
@@ -1,5 +1,19 @@
 #!/bin/sh
-# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: cheesy@google.com (Steve Hill)
 #
 # Run a single command in a chroot via schroot.

--- a/install/ubuntu/setup_chroot.sh
+++ b/install/ubuntu/setup_chroot.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
-# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: cheesy@google.com (Steve Hill)
 #
 # Setup a 32-bit chroot for Ubuntu.

--- a/install/verify_nginx_release.sh
+++ b/install/verify_nginx_release.sh
@@ -1,5 +1,19 @@
 #!/bin/sh
 #
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Checks that an nginx release builds and passes tests.  This ensures that the
 # PSOL tarball is good, and that it's compatible with the nginx code we intend
 # to release.

--- a/net/instaweb/http/http_response_parser_test.cc
+++ b/net/instaweb/http/http_response_parser_test.cc
@@ -1,4 +1,17 @@
-// Copyright 2010 and onwards Google Inc.
+// Copyright 2010 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 // Author: jmarantz@google.com (Joshua Marantz)
 
 #include "net/instaweb/http/public/http_response_parser.h"

--- a/net/instaweb/rewriter/css_move_to_head_filter_test.cc
+++ b/net/instaweb/rewriter/css_move_to_head_filter_test.cc
@@ -1,4 +1,17 @@
-// Copyright 2010 Google Inc. All Rights Reserved.
+// Copyright 2010 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 // Author: sligocki@google.com (Shawn Ligocki)
 
 #include "net/instaweb/rewriter/public/css_move_to_head_filter.h"

--- a/net/instaweb/rewriter/css_url_counter.cc
+++ b/net/instaweb/rewriter/css_url_counter.cc
@@ -1,4 +1,17 @@
-// Copyright 2012 Google Inc. All Rights Reserved.
+// Copyright 2012 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 // Author: sligocki@google.com (Shawn Ligocki)
 
 #include "net/instaweb/rewriter/public/css_url_counter.h"

--- a/net/instaweb/rewriter/css_url_extractor.cc
+++ b/net/instaweb/rewriter/css_url_extractor.cc
@@ -1,4 +1,17 @@
-// Copyright 2013 Google Inc. All Rights Reserved.
+// Copyright 2013 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 // Author: mpalem@google.com (Maya Palem)
 
 #include "net/instaweb/rewriter/public/css_url_extractor.h"

--- a/net/instaweb/rewriter/html_minifier_main.cc
+++ b/net/instaweb/rewriter/html_minifier_main.cc
@@ -1,4 +1,17 @@
-// Copyright 2010 Google Inc. All Rights Reserved.
+// Copyright 2010 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 // Author: bmcquade@google.com (Bryan McQuade)
 //
 // Simple HTML minifier, based on pagespeed's minify_html.cc

--- a/net/instaweb/rewriter/mock_resource_callback.cc
+++ b/net/instaweb/rewriter/mock_resource_callback.cc
@@ -1,4 +1,17 @@
-// Copyright 2011 Google Inc. All Rights Reserved.
+// Copyright 2011 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 // Author: sligocki@google.com (Shawn Ligocki)
 
 #include "net/instaweb/rewriter/public/mock_resource_callback.h"

--- a/pagespeed/apache/gzip_test.sh
+++ b/pagespeed/apache/gzip_test.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
-# Copyright 2010 Google Inc. All Rights Reserved.
+#
+# Copyright 2010 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: morlovich@google.com (Maks Orlovich)
 #
 # Runs the measurement proxy tests.  This is isolated in a separate file

--- a/pagespeed/apache/mock_apache.cc
+++ b/pagespeed/apache/mock_apache.cc
@@ -1,3 +1,18 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: jefftk@google.com (Jeff Kaufman)
 #include "pagespeed/apache/mock_apache.h"
 
 #include <cstdlib>

--- a/pagespeed/apache/process_scope_test.sh
+++ b/pagespeed/apache/process_scope_test.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
-# Copyright 2010 Google Inc. All Rights Reserved.
+#
+# Copyright 2010 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: morlovich@google.com (Maks Orlovich)
 #
 # Runs apache process-scope tests.  Note that the config required for this test

--- a/pagespeed/apache/system_test.sh
+++ b/pagespeed/apache/system_test.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
-# Copyright 2010 Google Inc. All Rights Reserved.
+#
+# Copyright 2010 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: abliss@google.com (Adam Bliss)
 #
 # Runs all Apache-specific and general system tests.

--- a/pagespeed/apache/system_tests/beacons_load.sh
+++ b/pagespeed/apache/system_tests/beacons_load.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2012 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # This is dependent upon having a beacon handler.
 test_filter add_instrumentation beacons load.
 OUT=$($CURL -sSi $PRIMARY_SERVER/$BEACON_HANDLER?ets=load:13)

--- a/pagespeed/apache/system_tests/blocking_rewrite.sh
+++ b/pagespeed/apache/system_tests/blocking_rewrite.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2013 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 if [ "${FIRST_RUN:-}" = "true" ]; then
   # Likewise, blocking rewrite tests are only run once.
   start_test Blocking rewrite enabled.

--- a/pagespeed/apache/system_tests/cache_flushing.sh
+++ b/pagespeed/apache/system_tests/cache_flushing.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Cache flushing works by touching cache.flush in cache directory.
 
 # If we write fixed values into the css file here, there is a risk that

--- a/pagespeed/apache/system_tests/compressed_cache.sh
+++ b/pagespeed/apache/system_tests/compressed_cache.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 function scrape_secondary_stat {
   http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP \
     "$SECONDARY_ROOT/mod_pagespeed_statistics/" | \

--- a/pagespeed/apache/system_tests/connection_refused.sh
+++ b/pagespeed/apache/system_tests/connection_refused.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # connection_refused.html references modpagespeed.com:1023/someimage.png.
 # mod_pagespeed will attempt to connect to that host and port to fetch the
 # input resource using serf.  We expect the connection to be refused.  Relies

--- a/pagespeed/apache/system_tests/content_encoding_leak.sh
+++ b/pagespeed/apache/system_tests/content_encoding_leak.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Regression test for a bug we used to have; a leak on nonsense
 # Content-Encoding. This will not trigger immediately, but at process exit.
 

--- a/pagespeed/apache/system_tests/custom_fetch_headers.sh
+++ b/pagespeed/apache/system_tests/custom_fetch_headers.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Send custom fetch headers on resource re-fetches.
 PLAIN_HEADER="header=value"
 X_OTHER_HEADER="x-other=False"

--- a/pagespeed/apache/system_tests/encoded_absolute_urls.sh
+++ b/pagespeed/apache/system_tests/encoded_absolute_urls.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Encoded absolute urls are not respected
 HOST_NAME="http://absolute-urls.example.com"
 

--- a/pagespeed/apache/system_tests/fetch_gzipped.sh
+++ b/pagespeed/apache/system_tests/fetch_gzipped.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Fetch gzipped, make sure that we have cache compressed at gzip 9.
 URL="$PRIMARY_SERVER/mod_pagespeed_test/invalid.css"
 fetch_until -gzip $URL "wc -c" 27

--- a/pagespeed/apache/system_tests/forbid_all_disabled.sh
+++ b/pagespeed/apache/system_tests/forbid_all_disabled.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Test ForbidAllDisabledFilters, which is set in config for
 # /mod_pagespeed_test/forbid_all_disabled/disabled/ where we've disabled
 # remove_quotes, remove_comments, and collapse_whitespace (which are enabled

--- a/pagespeed/apache/system_tests/handler_quoting.sh
+++ b/pagespeed/apache/system_tests/handler_quoting.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # None of these tests apply to nginx because it doesn't echo back urls or log
 # them in these cases.
 

--- a/pagespeed/apache/system_tests/htaccess_override.sh
+++ b/pagespeed/apache/system_tests/htaccess_override.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Make sure Disallow/Allow overrides work in htaccess hierarchies
 DISALLOWED=$($WGET_DUMP "$TEST_ROOT"/htaccess/purple.css)
 check_from "$DISALLOWED" fgrep -q MediumPurple

--- a/pagespeed/apache/system_tests/if_parsing.sh
+++ b/pagespeed/apache/system_tests/if_parsing.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test If parsing
 # $STATISTICS_URL ends in ?ModPagespeed=off, so we need & for now.
 # If we remove the query from $STATISTICS_URL, s/&/?/.

--- a/pagespeed/apache/system_tests/index_html_handling.sh
+++ b/pagespeed/apache/system_tests/index_html_handling.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # This tests whether fetching "/" gets you "/index.html".  With async
 # rewriting, it is not deterministic whether inline css gets
 # rewritten.  That's not what this is trying to test, so we use

--- a/pagespeed/apache/system_tests/inline_google_font_css.sh
+++ b/pagespeed/apache/system_tests/inline_google_font_css.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 if ! "$SKIP_EXTERNAL_RESOURCE_TESTS"; then
   start_test inline_google_font_css before move_to_head and move_above_scripts
   URL="$TEST_ROOT/move_font_css_to_head.html"

--- a/pagespeed/apache/system_tests/loopback.sh
+++ b/pagespeed/apache/system_tests/loopback.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Test that loopback route fetcher works with vhosts not listening on
 # 127.0.0.1  Only run this during CACHE_FLUSH_TEST as that is when
 # APACHE_TERTIARY_PORT is set.

--- a/pagespeed/apache/system_tests/map_proxy_domain_for_cdn.sh
+++ b/pagespeed/apache/system_tests/map_proxy_domain_for_cdn.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test MapProxyDomain for CDN setup
 # Test transitive ProxyMapDomain.  In this mode we have three hosts: cdn,
 # proxy, and origin.  Proxy runs MPS and fetches resources from origin,

--- a/pagespeed/apache/system_tests/max_html_parse_bytes.sh
+++ b/pagespeed/apache/system_tests/max_html_parse_bytes.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test When ModPagespeedMaxHtmlParseBytes is not set, we do not insert \
            a redirect.
 OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP \

--- a/pagespeed/apache/system_tests/mod_pagespeed_message.sh
+++ b/pagespeed/apache/system_tests/mod_pagespeed_message.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Note: There is a similar test in system_test.sh
 # Test /mod_pagespeed_message exists.
 start_test Check if /mod_pagespeed_message page exists.

--- a/pagespeed/apache/system_tests/mod_rewrite.sh
+++ b/pagespeed/apache/system_tests/mod_rewrite.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test mod_rewrite
 check $WGET_DUMP $TEST_ROOT/redirect/php/ -O $OUTDIR/redirect_php.html
 check \

--- a/pagespeed/apache/system_tests/pagespeed_admin.sh
+++ b/pagespeed/apache/system_tests/pagespeed_admin.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Check all the pagespeed_admin pages, both in its default location and an
 # alternate.
 start_test pagespeed_admin and alternate_admin_path

--- a/pagespeed/apache/system_tests/pass_through_headers.sh
+++ b/pagespeed/apache/system_tests/pass_through_headers.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Pass through headers when Cache-Control is set early on HTML.
 http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP \
     http://issue809.example.com/mod_pagespeed_example/index.html \

--- a/pagespeed/apache/system_tests/proxying.sh
+++ b/pagespeed/apache/system_tests/proxying.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Issue 609 -- proxying non-.pagespeed content, and caching it locally
 URL="$PRIMARY_SERVER/modpagespeed_http/not_really_a_font.woff"
 echo $WGET_DUMP $URL ....

--- a/pagespeed/apache/system_tests/purging_disabled.sh
+++ b/pagespeed/apache/system_tests/purging_disabled.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Base config has purging disabled.  Check error message syntax.
 OUT=$($WGET_DUMP "$HOSTNAME/pagespeed_admin/cache?purge=*")
 check_from "$OUT" fgrep -q "ModPagespeedEnableCachePurge on"

--- a/pagespeed/apache/system_tests/response_headers.sh
+++ b/pagespeed/apache/system_tests/response_headers.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Request Headers affect MPS options
 
 # Get the special file response_headers.html and test the result.

--- a/pagespeed/apache/system_tests/statistics.sh
+++ b/pagespeed/apache/system_tests/statistics.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Determine whether statistics are enabled or not.  If not, don't test them,
 # but do an additional regression test that tries harder to get a cache miss.
 if [ $statistics_enabled = "1" ]; then

--- a/pagespeed/apache/system_tests/statistics_logging.sh
+++ b/pagespeed/apache/system_tests/statistics_logging.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Statistics logging works.
 check ls $MOD_PAGESPEED_STATS_LOG
 check [ $(grep "timestamp: " $MOD_PAGESPEED_STATS_LOG | wc -l) -ge 1 ]

--- a/pagespeed/apache/system_tests/unload_handler.sh
+++ b/pagespeed/apache/system_tests/unload_handler.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
   start_test add_instrumentation has added unload handler with \
     ModPagespeedReportUnloadTime enabled in APACHE_SECONDARY_PORT.
 URL="$SECONDARY_TEST_ROOT/add_instrumentation.html\

--- a/pagespeed/apache/system_tests/unplugged.sh
+++ b/pagespeed/apache/system_tests/unplugged.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test PageSpeed Unplugged and Off
 SPROXY="http://localhost:$APACHE_SECONDARY_PORT"
 VHOST_MPS_OFF="http://mpsoff.example.com"

--- a/pagespeed/apache/system_tests/vhost_inheritance.sh
+++ b/pagespeed/apache/system_tests/vhost_inheritance.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test vhost inheritance works
 echo $WGET_DUMP $SECONDARY_CONFIG_URL
 SECONDARY_CONFIG=$($WGET_DUMP $SECONDARY_CONFIG_URL)

--- a/pagespeed/apache/system_tests/x_forwarded_proto.sh
+++ b/pagespeed/apache/system_tests/x_forwarded_proto.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Respect X-Forwarded-Proto when told to
 FETCHED=$OUTDIR/x_forwarded_proto
 URL=$TEST_ROOT/?PageSpeedFilters=add_base_tag

--- a/pagespeed/automatic/system_test.sh
+++ b/pagespeed/automatic/system_test.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
-# Copyright 2010 Google Inc. All Rights Reserved.
+#
+# Copyright 2010 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: abliss@google.com (Adam Bliss)
 #
 # Generic system test, which should work on any implementation of Page Speed

--- a/pagespeed/automatic/system_test_helpers.sh
+++ b/pagespeed/automatic/system_test_helpers.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 #
-# Copyright 2012 Google Inc. All Rights Reserved.
+# Copyright 2012 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Author: jefftk@google.com (Jeff Kaufman)
 #
 # Set up variables and functions for use by various system tests.

--- a/pagespeed/automatic/system_tests/add_instrumentation.sh
+++ b/pagespeed/automatic/system_tests/add_instrumentation.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 test_filter add_instrumentation adds 2 script tags
 check run_wget_with_args $URL
 # Counts occurances of '<script' in $FETCHED

--- a/pagespeed/automatic/system_tests/broken_images.sh
+++ b/pagespeed/automatic/system_tests/broken_images.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 BAD_IMG_URL=$REWRITTEN_ROOT/images/xBadName.jpg.pagespeed.ic.Zi7KMNYwzD.jpg
 start_test rewrite_images fails broken image
 echo run_wget_with_args $BAD_IMG_URL

--- a/pagespeed/automatic/system_tests/canonicalize_javascript_libraries.sh
+++ b/pagespeed/automatic/system_tests/canonicalize_javascript_libraries.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Checks that we can correctly identify a known library url.
 test_filter canonicalize_javascript_libraries finds library urls
 fetch_until $URL 'fgrep -c http://www.modpagespeed.com/rewrite_javascript.js' 1

--- a/pagespeed/automatic/system_tests/char_tweaks.sh
+++ b/pagespeed/automatic/system_tests/char_tweaks.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 test_filter collapse_whitespace removes whitespace, but not from pre tags.
 check run_wget_with_args $URL
 check [ $(egrep -c '^ +<' $FETCHED) -eq 1 ]

--- a/pagespeed/automatic/system_tests/combiners.sh
+++ b/pagespeed/automatic/system_tests/combiners.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 test_filter combine_css combines 4 CSS files into 1.
 fetch_until $URL 'fgrep -c text/css' 1
 check run_wget_with_args $URL

--- a/pagespeed/automatic/system_tests/content_length.sh
+++ b/pagespeed/automatic/system_tests/content_length.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test PageSpeed resources should have a content length.
 HTML_URL="$EXAMPLE_ROOT/rewrite_css_images.html?PageSpeedFilters=rewrite_css"
 fetch_until -save "$HTML_URL" "fgrep -c rewrite_css_images.css.pagespeed.cf" 1

--- a/pagespeed/automatic/system_tests/convert_meta_tags.sh
+++ b/pagespeed/automatic/system_tests/convert_meta_tags.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # This filter convert the meta tags in the html into headers.
 test_filter convert_meta_tags
 run_wget_with_args $URL

--- a/pagespeed/automatic/system_tests/cookie_options.sh
+++ b/pagespeed/automatic/system_tests/cookie_options.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Test that we can set options using cookies.
 start_test Cookie options on: by default comments not removed, whitespace is
 URL="$(generate_url options-by-cookies-enabled.example.com \

--- a/pagespeed/automatic/system_tests/css_images.sh
+++ b/pagespeed/automatic/system_tests/css_images.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test rewrite_css,extend_cache extends cache of images in CSS.
 FILE=rewrite_css_images.html?PageSpeedFilters=rewrite_css,extend_cache
 URL=$EXAMPLE_ROOT/$FILE

--- a/pagespeed/automatic/system_tests/css_sprite_images.sh
+++ b/pagespeed/automatic/system_tests/css_sprite_images.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test inline_css,rewrite_css,sprite_images sprites images in CSS.
 FILE=sprite_images.html?PageSpeedFilters=inline_css,rewrite_css,sprite_images
 URL=$EXAMPLE_ROOT/$FILE

--- a/pagespeed/automatic/system_tests/dedup_inlined_images.sh
+++ b/pagespeed/automatic/system_tests/dedup_inlined_images.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Test dedup_inlined_images
 test_filter dedup_inlined_images,inline_images
 fetch_until -save $URL 'fgrep -ocw inlineImg(' 4

--- a/pagespeed/automatic/system_tests/defer_javascript.sh
+++ b/pagespeed/automatic/system_tests/defer_javascript.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test ?PageSpeed=noscript inserts canonical href link
 OUT=$($WGET_DUMP $EXAMPLE_ROOT/defer_javascript.html?PageSpeed=noscript)
 check_from "$OUT" fgrep -q \

--- a/pagespeed/automatic/system_tests/elide_attributes.sh
+++ b/pagespeed/automatic/system_tests/elide_attributes.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 test_filter elide_attributes removes boolean and default attributes.
 check run_wget_with_args $URL
 check_not fgrep "disabled=" $FETCHED   # boolean, should not find

--- a/pagespeed/automatic/system_tests/extend_cache.sh
+++ b/pagespeed/automatic/system_tests/extend_cache.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 test_filter extend_cache_images rewrites an image tag.
 URL=$EXAMPLE_ROOT/extend_cache.html?PageSpeedFilters=extend_cache_images
 fetch_until $URL 'egrep -c src.*/Puzzle[.]jpg[.]pagespeed[.]ce[.].*[.]jpg' 1

--- a/pagespeed/automatic/system_tests/fallback_rewrite_css_urls.sh
+++ b/pagespeed/automatic/system_tests/fallback_rewrite_css_urls.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test fallback_rewrite_css_urls works.
 FILE=fallback_rewrite_css_urls.html?\
 PageSpeedFilters=fallback_rewrite_css_urls,rewrite_css,extend_cache

--- a/pagespeed/automatic/system_tests/flatten_css_imports.sh
+++ b/pagespeed/automatic/system_tests/flatten_css_imports.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Fetch with the default limit so our test file is inlined.
 test_filter flatten_css_imports,rewrite_css default limit
 # Force the request to be rewritten with all applicable filters.

--- a/pagespeed/automatic/system_tests/follow_flushes.sh
+++ b/pagespeed/automatic/system_tests/follow_flushes.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 if [ -z "${DISABLE_PHP_TESTS:-}" ]; then
   start_test Follow flushes does what it should do.
   echo "Check that FollowFlushes on outputs timely chunks"

--- a/pagespeed/automatic/system_tests/gce_public_cache.sh
+++ b/pagespeed/automatic/system_tests/gce_public_cache.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 YELLOW="$EXAMPLE_ROOT/styles/yellow.css"
 PUBYELLOW="$TEST_ROOT/public/yellow.css"
 

--- a/pagespeed/automatic/system_tests/hint_preload_subresources.sh
+++ b/pagespeed/automatic/system_tests/hint_preload_subresources.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 test_filter hint_preload_subresources works, and finds indirects
 
 # Expect 5 resources to be hinted

--- a/pagespeed/automatic/system_tests/https.sh
+++ b/pagespeed/automatic/system_tests/https.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Simple test that https is working.
 if [ -n "$HTTPS_HOST" ]; then
   URL="$HTTPS_EXAMPLE_ROOT/combine_css.html"

--- a/pagespeed/automatic/system_tests/image_quality_and_response.sh
+++ b/pagespeed/automatic/system_tests/image_quality_and_response.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 set -u
 set -e
 

--- a/pagespeed/automatic/system_tests/image_quality_generic.sh
+++ b/pagespeed/automatic/system_tests/image_quality_generic.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test quality of jpeg output images with generic quality flag
 URL="$TEST_ROOT/image_rewriting/rewrite_images.html"
 WGET_ARGS="--header PageSpeedFilters:rewrite_images "

--- a/pagespeed/automatic/system_tests/image_quality_jpeg.sh
+++ b/pagespeed/automatic/system_tests/image_quality_jpeg.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test quality of jpeg output images
 URL="$TEST_ROOT/jpeg_rewriting/rewrite_images.html"
 WGET_ARGS="--header PageSpeedFilters:rewrite_images "

--- a/pagespeed/automatic/system_tests/image_quality_webp.sh
+++ b/pagespeed/automatic/system_tests/image_quality_webp.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test quality of webp output images
 rm -rf $OUTDIR
 mkdir $OUTDIR

--- a/pagespeed/automatic/system_tests/image_resize.sh
+++ b/pagespeed/automatic/system_tests/image_resize.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test resize images and modify URLs
 rm -rf $OUTDIR
 mkdir $OUTDIR

--- a/pagespeed/automatic/system_tests/images_in_styles.sh
+++ b/pagespeed/automatic/system_tests/images_in_styles.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Rewrite images in styles.
 start_test rewrite_images,rewrite_css,rewrite_style_attributes_with_url optimizes images in style.
 FILE=rewrite_style_attributes.html?PageSpeedFilters=rewrite_images,rewrite_css,rewrite_style_attributes_with_url

--- a/pagespeed/automatic/system_tests/initial_header_check.sh
+++ b/pagespeed/automatic/system_tests/initial_header_check.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Page Speed Automatic is running and writes the expected header.
 echo $WGET_DUMP $EXAMPLE_ROOT/combine_css.html
 

--- a/pagespeed/automatic/system_tests/initial_sanity_checks.sh
+++ b/pagespeed/automatic/system_tests/initial_sanity_checks.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # This tests whether fetching "/" gets you "/index.html".  With async
 # rewriting, it is not deterministic whether inline css gets
 # rewritten.  That's not what this is trying to test, so we use

--- a/pagespeed/automatic/system_tests/inline_preview_images.sh
+++ b/pagespeed/automatic/system_tests/inline_preview_images.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Checks that inline_preview_images injects compiled javascript
 test_filter inline_preview_images optimize mode
 FILE=delay_images.html?PageSpeedFilters=$FILTER_NAME

--- a/pagespeed/automatic/system_tests/inliners.sh
+++ b/pagespeed/automatic/system_tests/inliners.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 test_filter inline_css converts 3 out of 5 link tags to style tags.
 fetch_until $URL 'grep -c <style' 3
 

--- a/pagespeed/automatic/system_tests/insert_dns_prefetch.sh
+++ b/pagespeed/automatic/system_tests/insert_dns_prefetch.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Test DNS prefetching. DNS prefetching is dependent on user agent, but is
 # enabled for Wget UAs, allowing this test to work with our default wget params.
 test_filter insert_dns_prefetch

--- a/pagespeed/automatic/system_tests/invalid_host_header.sh
+++ b/pagespeed/automatic/system_tests/invalid_host_header.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Invalid HOST URL does not crash the server.
 
 if [[ "$HOSTNAME" == *:* ]]; then

--- a/pagespeed/automatic/system_tests/ipro.sh
+++ b/pagespeed/automatic/system_tests/ipro.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test In-place resource optimization
 FETCHED=$OUTDIR/ipro
 # Note: we intentionally want to use an image which will not appear on

--- a/pagespeed/automatic/system_tests/js_blacklist.sh
+++ b/pagespeed/automatic/system_tests/js_blacklist.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Filters do not rewrite blacklisted JavaScript files.
 URL=$TEST_ROOT/blacklist/blacklist.html?PageSpeedFilters=extend_cache,rewrite_javascript,trim_urls
 fetch_until -save $URL 'grep -c .js.pagespeed.' 4

--- a/pagespeed/automatic/system_tests/keep_data_urls.sh
+++ b/pagespeed/automatic/system_tests/keep_data_urls.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Make sure we don't blank url(data:...) in CSS.
 start_test CSS data URLs
 URL=$REWRITTEN_ROOT/styles/A.data.css.pagespeed.cf.Hash.css

--- a/pagespeed/automatic/system_tests/lazyload_images.sh
+++ b/pagespeed/automatic/system_tests/lazyload_images.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # This filter loads below the fold images lazily.
 test_filter lazyload_images
 check run_wget_with_args $URL

--- a/pagespeed/automatic/system_tests/local_storage_cache.sh
+++ b/pagespeed/automatic/system_tests/local_storage_cache.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Checks that local_storage_cache injects optimized javascript from
 # local_storage_cache.js, adds the data-pagespeed-lsc- attributes, inlines the data
 # (if the cache were empty the inlining wouldn't make the timer cutoff but the

--- a/pagespeed/automatic/system_tests/make_show_ads_async.sh
+++ b/pagespeed/automatic/system_tests/make_show_ads_async.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 test_filter make_show_ads_async works
 OUT=$($WGET_DUMP $URL)
 check_from     "$OUT" grep -q 'data-ad'

--- a/pagespeed/automatic/system_tests/move_css.sh
+++ b/pagespeed/automatic/system_tests/move_css.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test move_css_above_scripts works.
 URL=$EXAMPLE_ROOT/move_css_above_scripts.html?PageSpeedFilters=move_css_above_scripts
 FETCHED=$OUTDIR/output-file

--- a/pagespeed/automatic/system_tests/no_cache.sh
+++ b/pagespeed/automatic/system_tests/no_cache.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 echo Test that we can rewrite resources that are served with
 echo Cache-Control: no-cache with on-the-fly filters.  Tests that the
 echo no-cache header is preserved.

--- a/pagespeed/automatic/system_tests/optimize_to_webp.sh
+++ b/pagespeed/automatic/system_tests/optimize_to_webp.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Optimize images to webp
 function test_optimize_to_webp() {
   HTML="$TEST_ROOT/optimize_for_bandwidth/$1"

--- a/pagespeed/automatic/system_tests/outliners.sh
+++ b/pagespeed/automatic/system_tests/outliners.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 test_filter outline_css outlines large styles, but not small ones.
 check run_wget_with_args $URL
 check egrep -q '<link.*text/css.*large' $FETCHED  # outlined

--- a/pagespeed/automatic/system_tests/query_params_in_resource_flow.sh
+++ b/pagespeed/automatic/system_tests/query_params_in_resource_flow.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Query params and headers are recognized in resource flow.
 URL=$REWRITTEN_ROOT/styles/W.rewrite_css_images.css.pagespeed.cf.Hash.css
 echo "Image gets rewritten by default."

--- a/pagespeed/automatic/system_tests/redirect_with_ps_params.sh
+++ b/pagespeed/automatic/system_tests/redirect_with_ps_params.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Test that redirecting to the same domain retains MPS query parameters.
 # The test domain is configured for collapse_whitepsace,add_instrumentation
 # so if the QPs are retained we should get the former but not the latter.

--- a/pagespeed/automatic/system_tests/rel_canonical.sh
+++ b/pagespeed/automatic/system_tests/rel_canonical.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test rel-canonical
 
 # .pagespeed. resources should have Link rel=canonical headers, IPRO resources

--- a/pagespeed/automatic/system_tests/resource_content_type_html.sh
+++ b/pagespeed/automatic/system_tests/resource_content_type_html.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Usage: verify_nosniff leaf content_type1 content_type2 ...
 #
 # Checks that the response has a "nosniff" header and one of the supplied

--- a/pagespeed/automatic/system_tests/responsive_images.sh
+++ b/pagespeed/automatic/system_tests/responsive_images.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 test_filter responsive_images,rewrite_images,-inline_images adds srcset for \
   Puzzle.jpg and Cuppa.png
 fetch_until $URL 'grep -c srcset=' 3

--- a/pagespeed/automatic/system_tests/rewrite_compressed_js.sh
+++ b/pagespeed/automatic/system_tests/rewrite_compressed_js.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 echo Testing whether we can rewrite javascript resources that are served
 echo gzipped, even though we generally ask for them clear.  This particular
 echo js file has "alert('Hello')" but is checked into source control in gzipped

--- a/pagespeed/automatic/system_tests/rewrite_css.sh
+++ b/pagespeed/automatic/system_tests/rewrite_css.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 test_filter rewrite_css minifies CSS and saves bytes.
 fetch_until -save $URL 'grep -c comment' 0
 check_file_size $FETCH_FILE -lt 680  # down from 689

--- a/pagespeed/automatic/system_tests/rewrite_css_images.sh
+++ b/pagespeed/automatic/system_tests/rewrite_css_images.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test rewrite_css,rewrite_images rewrites and inlines images in CSS.
 FILE='rewrite_css_images.html?PageSpeedFilters=rewrite_css,rewrite_images'
 FILE+='&ModPagespeedCssImageInlineMaxBytes=2048'

--- a/pagespeed/automatic/system_tests/rewrite_images.sh
+++ b/pagespeed/automatic/system_tests/rewrite_images.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 test_filter rewrite_images inlines, compresses, and resizes.
 fetch_until $URL 'grep -c data:image/png' 1  # Images inlined.
 fetch_until $URL 'grep -c .pagespeed.ic' 2  # Images rewritten.

--- a/pagespeed/automatic/system_tests/rewrite_javascript.sh
+++ b/pagespeed/automatic/system_tests/rewrite_javascript.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 test_filter rewrite_javascript minifies JavaScript and saves bytes.
 # External scripts rewritten.
 fetch_until -save -recursive \

--- a/pagespeed/automatic/system_tests/shortcut_icons.sh
+++ b/pagespeed/automatic/system_tests/shortcut_icons.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test "shortcut icons aren't inlined"
 
 URL="$TEST_ROOT/shortcut_icons.html?PageSpeedFilters=debug,rewrite_images"

--- a/pagespeed/automatic/system_tests/signed_urls.sh
+++ b/pagespeed/automatic/system_tests/signed_urls.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Signed Urls : Correct URL signature is passed
 URL_PATH="/mod_pagespeed_test/unauthorized/inline_css.html"
 OPTS="?PageSpeedFilters=rewrite_images,rewrite_css"

--- a/pagespeed/automatic/system_tests/smaxage.sh
+++ b/pagespeed/automatic/system_tests/smaxage.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test ipro and smaxage setup
 
 # We can't use fetch_until because each time through we want to check that

--- a/pagespeed/automatic/system_tests/sticky_cookie_options.sh
+++ b/pagespeed/automatic/system_tests/sticky_cookie_options.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Test that we can make options sticky using cookies.
 
 start_test Sticky option cookies: initially remove_comments only

--- a/pagespeed/kernel/base/string.h
+++ b/pagespeed/kernel/base/string.h
@@ -1,4 +1,18 @@
-// Copyright 2010 and onwards Google Inc.
+/*
+ * Copyright 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 // Author: jmarantz@google.com (Joshua Marantz)
 
 #ifndef PAGESPEED_KERNEL_BASE_STRING_H_

--- a/pagespeed/kernel/base/string_multi_map_test.cc
+++ b/pagespeed/kernel/base/string_multi_map_test.cc
@@ -1,4 +1,17 @@
-// Copyright 2010-2011 and onwards Google Inc.
+// Copyright 2010-2011 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 // Author: jmarantz@google.com (Joshua Marantz)
 
 // Unit-test StringMultiMap.

--- a/pagespeed/kernel/html/html_keywords_test.cc
+++ b/pagespeed/kernel/html/html_keywords_test.cc
@@ -1,4 +1,17 @@
-// Copyright 2010 and onwards Google Inc.
+// Copyright 2010 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 // Author: jmarantz@google.com (Joshua Marantz)
 
 // Unit-test the HTML escaper.

--- a/pagespeed/kernel/thread/blocking_callback.h
+++ b/pagespeed/kernel/thread/blocking_callback.h
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #ifndef PAGESPEED_KERNEL_THREAD_BLOCKING_CALLBACK_H_
 #define PAGESPEED_KERNEL_THREAD_BLOCKING_CALLBACK_H_
 

--- a/pagespeed/kernel/util/simple_stats_test.cc
+++ b/pagespeed/kernel/util/simple_stats_test.cc
@@ -1,4 +1,17 @@
-// Copyright 2010 and onwards Google Inc.
+// Copyright 2010 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 // Author: jmarantz@google.com (Joshua Marantz)
 
 // Unit-test the simple statistics implementation.

--- a/pagespeed/system/external_server_spec.cc
+++ b/pagespeed/system/external_server_spec.cc
@@ -1,3 +1,18 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: yeputons@google.com (Egor Suvorov)
 #include "pagespeed/system/external_server_spec.h"
 
 #include <utility>

--- a/pagespeed/system/external_server_spec.h
+++ b/pagespeed/system/external_server_spec.h
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Author: yeputons@google.com (Egor Suvorov)
 #ifndef PAGESPEED_SYSTEM_EXTERNAL_SERVER_SPEC_H_
 #define PAGESPEED_SYSTEM_EXTERNAL_SERVER_SPEC_H_
 

--- a/pagespeed/system/external_server_spec_test.cc
+++ b/pagespeed/system/external_server_spec_test.cc
@@ -1,5 +1,19 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: yeputons@google.com (Egor Suvorov)
 #include "pagespeed/system/external_server_spec.h"
-
 
 #include "pagespeed/kernel/base/gtest.h"
 

--- a/pagespeed/system/pathological_server.py
+++ b/pagespeed/system/pathological_server.py
@@ -1,4 +1,18 @@
 #!/usr/bin/python
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Simple python server for testing remote_config in tricky situations.
 
 Usage:

--- a/pagespeed/system/remote_config_test.sh
+++ b/pagespeed/system/remote_config_test.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 #
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Run the remote config tests.
 #
 # We need to know the directory this file is located in.  Unfortunately,

--- a/pagespeed/system/system_test.sh
+++ b/pagespeed/system/system_test.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 #
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Runs system tests for system/ and automatic/.
 #
 # See automatic/system_test_helpers.sh for usage.

--- a/pagespeed/system/system_tests/add_instrumentation.sh
+++ b/pagespeed/system/system_tests/add_instrumentation.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test HTML add_instrumentation CDATA
 $WGET -O $WGET_OUTPUT $TEST_ROOT/add_instrumentation.html\
 ?PageSpeedFilters=add_instrumentation

--- a/pagespeed/system/system_tests/add_resource_headers.sh
+++ b/pagespeed/system/system_tests/add_resource_headers.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test AddResourceHeaders works for pagespeed resources.
 URL="$TEST_ROOT/compressed/hello_js.custom_ext.pagespeed.ce.HdziXmtLIV.txt"
 fetch_until -save "$URL" 'fgrep -c text/javascript' 1 --save-headers

--- a/pagespeed/system/system_tests/ajax_overrides_experiments.sh
+++ b/pagespeed/system/system_tests/ajax_overrides_experiments.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Ajax overrides experiments
 
 # Normally, we expect this <head>less HTML file to have a <head> added

--- a/pagespeed/system/system_tests/aris.sh
+++ b/pagespeed/system/system_tests/aris.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test aris disables js inlining for introspective js and only i-js
 URL="$TEST_ROOT/avoid_renaming_introspective_javascript__on/"
 URL+="?PageSpeedFilters=inline_javascript"

--- a/pagespeed/system/system_tests/authorization_basic.sh
+++ b/pagespeed/system/system_tests/authorization_basic.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test authorized resources do not get cached and optimized.
 URL="$TEST_ROOT/auth/medium_purple.css"
 AUTH="Authorization:Basic dXNlcjE6cGFzc3dvcmQ="

--- a/pagespeed/system/system_tests/bad_query_params_and_headers.sh
+++ b/pagespeed/system/system_tests/bad_query_params_and_headers.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Accept bad query params and headers
 
 # The examples page should have this EXPECTED_EXAMPLES_TEXT on it.

--- a/pagespeed/system/system_tests/broken_fetch_ipro_record.sh
+++ b/pagespeed/system/system_tests/broken_fetch_ipro_record.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Broken fetches with ipro-recording 404 after cache flush.
 
 # Note that failed cached results from an earlier run can disturb this

--- a/pagespeed/system/system_tests/cache_compression_pre_gzipping.sh
+++ b/pagespeed/system/system_tests/cache_compression_pre_gzipping.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 function php_ipro_record() {
   local url="$1"
   local max_cache_bytes="$2"

--- a/pagespeed/system/system_tests/cache_partial_html.sh
+++ b/pagespeed/system/system_tests/cache_partial_html.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test cache_partial_html enabled has no effect
 $WGET -O $WGET_OUTPUT $TEST_ROOT/add_instrumentation.html\
 ?PageSpeedFilters=cache_partial_html

--- a/pagespeed/system/system_tests/cache_purge.sh
+++ b/pagespeed/system/system_tests/cache_purge.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Cache purge test
 cache_purge_test http://purge.example.com
 

--- a/pagespeed/system/system_tests/check_headers.sh
+++ b/pagespeed/system/system_tests/check_headers.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Check for correct default pagespeed header format.
 # This will be X-Page-Speed in nginx and X-ModPagespeed in apache.  Accept both.
 OUT=$($WGET_DUMP $EXAMPLE_ROOT/combine_css.html)

--- a/pagespeed/system/system_tests/client_domain_rewrite.sh
+++ b/pagespeed/system/system_tests/client_domain_rewrite.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # This test checks that the ClientDomainRewrite directive can turn on.
 start_test ClientDomainRewrite on directive
 HOST_NAME="http://client-domain-rewrite.example.com"

--- a/pagespeed/system/system_tests/combine_javascript.sh
+++ b/pagespeed/system/system_tests/combine_javascript.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 test_filter combine_javascript combines 2 JS files into 1.
 start_test combine_javascript with long URL still works
 URL=$TEST_ROOT/combine_js_very_many.html?PageSpeedFilters=combine_javascript

--- a/pagespeed/system/system_tests/controller.sh
+++ b/pagespeed/system/system_tests/controller.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test IPRO requests are routed through the controller API
 
 STATS=$OUTDIR/controller_stats

--- a/pagespeed/system/system_tests/controller_process_handling.sh
+++ b/pagespeed/system/system_tests/controller_process_handling.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 function get_controller_pid() {
   grep "Controller running with PID " $ERROR_LOG | tail -n 1 | awk '{print $NF}'
 }

--- a/pagespeed/system/system_tests/critical_image_beaconing.sh
+++ b/pagespeed/system/system_tests/critical_image_beaconing.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Verify that we can send a critical image beacon and that lazyload_images
 # does not try to lazyload the critical images.
 start_test lazyload_images,rewrite_images with critical images beacon

--- a/pagespeed/system/system_tests/cross_site_fetch.sh
+++ b/pagespeed/system/system_tests/cross_site_fetch.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Test lying host headers for cross-site fetch. This should fetch from localhost
 # and therefore succeed.
 start_test Lying host headers for cross-site fetch

--- a/pagespeed/system/system_tests/css_combining_authorization.sh
+++ b/pagespeed/system/system_tests/css_combining_authorization.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test can combine css with authorized ids only
 URL="$TEST_ROOT/combine_css_with_ids.html?PageSpeedFilters=combine_css"
 # Test big.css and bold.css are combined, but not yellow.css or blue.css.

--- a/pagespeed/system/system_tests/domain_rewrite_hyperlinks.sh
+++ b/pagespeed/system/system_tests/domain_rewrite_hyperlinks.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # This test checks that the DomainRewriteHyperlinks directive
 # can turn off.  See mod_pagespeed_test/rewrite_domains.html: it has
 # one <img> URL, one <form> URL, and one <a> url, all referencing

--- a/pagespeed/system/system_tests/downstream_cache_integration_headers.sh
+++ b/pagespeed/system/system_tests/downstream_cache_integration_headers.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Downstream cache integration caching headers.
 URL="http://downstreamcacheresource.example.com/mod_pagespeed_example/images/"
 URL+="xCuppa.png.pagespeed.ic.0.png"

--- a/pagespeed/system/system_tests/downstream_cache_rebeaconing.sh
+++ b/pagespeed/system/system_tests/downstream_cache_rebeaconing.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Verify that downstream caches and rebeaconing interact correctly for images.
 start_test lazyload_images,rewrite_images with downstream cache rebeaconing
 HOST_NAME="http://downstreamcacherebeacon.example.com"

--- a/pagespeed/system/system_tests/embed_config.sh
+++ b/pagespeed/system/system_tests/embed_config.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Embed image configuration in rewritten image URL.
 # The embedded configuration is placed between the "pagespeed" and "ic", e.g.
 # *xPuzzle.jpg.pagespeed.gp+jp+pj+js+rj+rp+rw+ri+cp+md+iq=73.ic.oFXPiLYMka.jpg

--- a/pagespeed/system/system_tests/experiment_device_types.sh
+++ b/pagespeed/system/system_tests/experiment_device_types.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 readonly EXP_DEVICES_EXAMPLE="http://experiment.devicematch.example.com/mod_pagespeed_example"
 readonly EXP_DEVICES_EXTEND_CACHE="$EXP_DEVICES_EXAMPLE/extend_cache.html"
 

--- a/pagespeed/system/system_tests/flush_handling.sh
+++ b/pagespeed/system/system_tests/flush_handling.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Test our handling of headers when a FLUSH event occurs, using PHP.
 # Tests that require PHP can be disabled by setting DISABLE_PHP_TESTS to
 # non-empty, to cater to admins who don't want PHP installed.

--- a/pagespeed/system/system_tests/flush_subresources.sh
+++ b/pagespeed/system/system_tests/flush_subresources.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test flush_subresources rewriter is not applied
 URL="$TEST_ROOT/flush_subresources.html?\
 PageSpeedFilters=flush_subresources,extend_cache_css,\

--- a/pagespeed/system/system_tests/forbid_filters.sh
+++ b/pagespeed/system/system_tests/forbid_filters.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Test ForbidFilters, which is set in the config for the VHost
 # forbidden.example.com, where we've forbidden remove_quotes, remove_comments,
 # collapse_whitespace, rewrite_css, and resize_images; we've also disabled

--- a/pagespeed/system/system_tests/handler_access_messages.sh
+++ b/pagespeed/system/system_tests/handler_access_messages.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Handler access restrictions
 function expect_handler() {
   local host_prefix="$1"

--- a/pagespeed/system/system_tests/image_rewrite_locking.sh
+++ b/pagespeed/system/system_tests/image_rewrite_locking.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Ideally the system should only rewrite an image once when when it gets
 # a burst of requests.  A bug was fixed where we were not obeying a
 # failed lock and were rewriting it potentially many times.  It still

--- a/pagespeed/system/system_tests/inline_unauth.sh
+++ b/pagespeed/system/system_tests/inline_unauth.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 test_filter inline_javascript inlines a small JS file
 start_test no inlining of unauthorized resources
 URL="$TEST_ROOT/unauthorized/inline_unauthorized_javascript.html?"

--- a/pagespeed/system/system_tests/instant_ipro.sh
+++ b/pagespeed/system/system_tests/instant_ipro.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Tests that we get instant ipro rewrites with LoadFromFile and
 # InPlaceWaitForOptimized get us first-pass rewrites.
 start_test instant ipro with InPlaceWaitForOptimized and LoadFromFile

--- a/pagespeed/system/system_tests/ipro_caching.sh
+++ b/pagespeed/system/system_tests/ipro_caching.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test IPRO flow uses cache as expected.
 # TODO(sligocki): Use separate VHost instead to separate stats.
 STATS=$OUTDIR/blocking_rewrite_stats

--- a/pagespeed/system/system_tests/ipro_fixed_size.sh
+++ b/pagespeed/system/system_tests/ipro_fixed_size.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test IPRO-optimized resources should have fixed size, not chunked.
 URL="$EXAMPLE_ROOT/images/Puzzle.jpg"
 URL+="?PageSpeedJpegRecompressionQuality=75"

--- a/pagespeed/system/system_tests/ipro_for_browser.sh
+++ b/pagespeed/system/system_tests/ipro_for_browser.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Optimize in-place images for browser. Ideal test matrix (not covered yet):
 # User-Agent:  Accept:  Image type   Result
 # -----------  -------  ----------   ----------------------------------

--- a/pagespeed/system/system_tests/ipro_load_from_file.sh
+++ b/pagespeed/system/system_tests/ipro_load_from_file.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test load from file with ipro
 URL="http://lff-ipro.example.com/mod_pagespeed_test/lff_ipro/fake.woff"
 OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET -O - $URL)

--- a/pagespeed/system/system_tests/ipro_max_cachable.sh
+++ b/pagespeed/system/system_tests/ipro_max_cachable.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test max cacheable content length with ipro
 URL="http://max-cacheable-content-length.example.com/mod_pagespeed_example/"
 URL+="images/BikeCrashIcn.png"

--- a/pagespeed/system/system_tests/ipro_noop.sh
+++ b/pagespeed/system/system_tests/ipro_noop.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Ipro transcode to webp, iterating with Noop
 # There's a trick for making demo pages that show the fully optimized ipro
 # images without relying on the user flushing the browser cache, which relies

--- a/pagespeed/system/system_tests/ipro_source_map.sh
+++ b/pagespeed/system/system_tests/ipro_source_map.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test IPRO source map tests
 URL="$TEST_ROOT/experimental_js_minifier/script.js"
 URL+="?PageSpeedFilters=rewrite_javascript,include_js_source_maps"

--- a/pagespeed/system/system_tests/ipro_vary_cookie.sh
+++ b/pagespeed/system/system_tests/ipro_vary_cookie.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Even though we don't have a cookie, we will conservatively avoid
 # optimizing resources with Vary:Cookie set on the response, so we
 # will not get the instant response, of "body{background:#9370db}":

--- a/pagespeed/system/system_tests/json_content_type.sh
+++ b/pagespeed/system/system_tests/json_content_type.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test json keeps its content type
 URL="$TEST_ROOT/example.json"
 OUT=$($WGET_DUMP "$URL?PageSpeed=off")

--- a/pagespeed/system/system_tests/large_html_files.sh
+++ b/pagespeed/system/system_tests/large_html_files.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Test handling of large HTML files. We first test with a cold cache, and verify
 # that we bail out of parsing and insert a script redirecting to
 # ?PageSpeed=off. This should also insert an entry into the property cache so

--- a/pagespeed/system/system_tests/load_from_file.sh
+++ b/pagespeed/system/system_tests/load_from_file.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test LoadFromFile
 URL=$TEST_ROOT/load_from_file/index.html?PageSpeedFilters=inline_css
 fetch_until $URL 'grep -c blue' 1

--- a/pagespeed/system/system_tests/long_url_handling.sh
+++ b/pagespeed/system/system_tests/long_url_handling.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test long url handling
 # This is an extremely long url, enough that it should give a 4xx server error.
 OUT=$($CURL -sS -D- "$TEST_ROOT/$(head -c 10000 < /dev/zero | tr '\0' 'a')")

--- a/pagespeed/system/system_tests/map_proxy_domain.sh
+++ b/pagespeed/system/system_tests/map_proxy_domain.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test MapProxyDomain
 # depends on MapProxyDomain in the config file
 LEAF="proxy_external_resource.html?PageSpeedFilters=-inline_images"

--- a/pagespeed/system/system_tests/mapped_domain_relative_css.sh
+++ b/pagespeed/system/system_tests/mapped_domain_relative_css.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # http://github.com/pagespeed/mod_pagespeed/issues/494 -- test
 # that fetching a css with embedded relative images from a different
 # VirtualHost, accessing the same content, and rewrite-mapped to the

--- a/pagespeed/system/system_tests/max_cachable.sh
+++ b/pagespeed/system/system_tests/max_cachable.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Test max_cacheable_response_content_length.  There are two Javascript files
 # in the html file.  The smaller Javascript file should be rewritten while
 # the larger one shouldn't.

--- a/pagespeed/system/system_tests/max_combined_css_bytes.sh
+++ b/pagespeed/system/system_tests/max_combined_css_bytes.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # TODO(sligocki): Following test only works with query_params. Fix to work
 # with any method and get rid of this manual set.
 filter_spec_method="query_params"

--- a/pagespeed/system/system_tests/message_history_colors.sh
+++ b/pagespeed/system/system_tests/message_history_colors.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Test if the warning messages are colored in message_history page.
 # We color the messages in message_history page to make it clearer to read.
 # Red for Error messages. Brown for Warning messages.

--- a/pagespeed/system/system_tests/modify_caching_headers.sh
+++ b/pagespeed/system/system_tests/modify_caching_headers.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test ModifyCachingHeaders
 URL=$TEST_ROOT/retain_cache_control/index.html
 OUT=$($WGET_DUMP $URL)

--- a/pagespeed/system/system_tests/more_custom_headers.sh
+++ b/pagespeed/system/system_tests/more_custom_headers.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Custom headers remain on HTML, but cache should be disabled.
 URL=$TEST_ROOT/rewrite_compressed_js.html
 echo $WGET_DUMP $URL

--- a/pagespeed/system/system_tests/no_critical_unauthorized_resources.sh
+++ b/pagespeed/system/system_tests/no_critical_unauthorized_resources.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 test_filter prioritize_critical_css
 
 start_test no critical selectors chosen from unauthorized resources

--- a/pagespeed/system/system_tests/no_respect_vary.sh
+++ b/pagespeed/system/system_tests/no_respect_vary.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Tests that an origin header with a Vary header other than Vary:Accept-Encoding
 # loses that header when we are not respecting vary.
 start_test Vary:User-Agent on resources is held by our cache.

--- a/pagespeed/system/system_tests/no_transform.sh
+++ b/pagespeed/system/system_tests/no_transform.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # When Cache-Control: no-transform is in the response make sure that
 # the URL is not rewritten and that the no-transform header remains
 # in the resource.

--- a/pagespeed/system/system_tests/optimize_for_bandwidth.sh
+++ b/pagespeed/system/system_tests/optimize_for_bandwidth.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test OptimizeForBandwidth
 # We use blocking-rewrite tests because we want to make sure we don't
 # get rewritten URLs when we don't want them.

--- a/pagespeed/system/system_tests/outline_javascript_limit.sh
+++ b/pagespeed/system/system_tests/outline_javascript_limit.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 test_filter outline_javascript outlines large scripts, but not small ones.
 check run_wget_with_args $URL
 check egrep -q '<script.*large.*src=' $FETCHED       # outlined

--- a/pagespeed/system/system_tests/preserve_urls.sh
+++ b/pagespeed/system/system_tests/preserve_urls.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Make sure that when in PreserveURLs mode that we don't rewrite URLs. This is
 # non-exhaustive, the unit tests should cover the rest.  Note: We block with
 # psatest here because this is a negative test.  We wouldn't otherwise know

--- a/pagespeed/system/system_tests/prioritize_critical_css.sh
+++ b/pagespeed/system/system_tests/prioritize_critical_css.sh
@@ -1,2 +1,17 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test prioritize critical css
 test_prioritize_critical_css

--- a/pagespeed/system/system_tests/protocol_relative_urls.sh
+++ b/pagespeed/system/system_tests/protocol_relative_urls.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Protocol relative urls
 URL="$PRIMARY_SERVER//www.modpagespeed.com/"
 URL+="styles/A.blue.css.pagespeed.cf.0.css"

--- a/pagespeed/system/system_tests/query_params_dont_enable_core_filters.sh
+++ b/pagespeed/system/system_tests/query_params_dont_enable_core_filters.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test query params dont turn on core filters
 # See https://github.com/pagespeed/ngx_pagespeed/issues/1190
 URL="debug-filters.example.com/mod_pagespeed_example/"

--- a/pagespeed/system/system_tests/request_option_override.sh
+++ b/pagespeed/system/system_tests/request_option_override.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Request Option Override : Correct values are passed
 HOST_NAME="http://request-option-override.example.com"
 OPTS="?ModPagespeed=on"

--- a/pagespeed/system/system_tests/resize_rendered_dimensions.sh
+++ b/pagespeed/system/system_tests/resize_rendered_dimensions.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Verify rendered image dimensions test.
 start_test resize_rendered_image_dimensions with critical images beacon
 HOST_NAME="http://renderedimagebeacon.example.com"

--- a/pagespeed/system/system_tests/resource_404_count.sh
+++ b/pagespeed/system/system_tests/resource_404_count.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test 404s are served and properly recorded.
 echo $STATISTICS_URL
 NUM_404=$(scrape_stat resource_404_count)

--- a/pagespeed/system/system_tests/resource_ext_corruption.sh
+++ b/pagespeed/system/system_tests/resource_ext_corruption.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 test_filter combine_css combines 4 CSS files into 1.
 fetch_until $URL 'grep -c text/css' 1
 check run_wget_with_args $URL

--- a/pagespeed/system/system_tests/respect_custom_options.sh
+++ b/pagespeed/system/system_tests/respect_custom_options.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Respect custom options on resources.
 IMG_NON_CUSTOM="$EXAMPLE_ROOT/images/xPuzzle.jpg.pagespeed.ic.fakehash.jpg"
 IMG_CUSTOM="$TEST_ROOT/custom_options/xPuzzle.jpg.pagespeed.ic.fakehash.jpg"

--- a/pagespeed/system/system_tests/respect_vary.sh
+++ b/pagespeed/system/system_tests/respect_vary.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test respect vary user-agent
 URL="$SECONDARY_HOSTNAME/mod_pagespeed_test/vary/index.html"
 URL+="?PageSpeedFilters=inline_css"

--- a/pagespeed/system/system_tests/retain_comment.sh
+++ b/pagespeed/system/system_tests/retain_comment.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Test RetainComment directive.
 test_filter remove_comments retains appropriate comments.
 check run_wget_with_args $URL

--- a/pagespeed/system/system_tests/rewrite_deadline_ipro.sh
+++ b/pagespeed/system/system_tests/rewrite_deadline_ipro.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test 2-pass ipro with long ModPagespeedInPlaceRewriteDeadline
 cmd="$WGET_DUMP $TEST_ROOT/ipro/wait/long/purple.css"
 echo $cmd; OUT=$($cmd)

--- a/pagespeed/system/system_tests/sane_connection_header.sh
+++ b/pagespeed/system/system_tests/sane_connection_header.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Test to make sure we have a sane Connection Header.  See
 # https://github.com/pagespeed/mod_pagespeed/issues/664
 #

--- a/pagespeed/system/system_tests/server_side_includes.sh
+++ b/pagespeed/system/system_tests/server_side_includes.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test server-side includes
 fetch_until -save $TEST_ROOT/ssi/ssi.shtml?PageSpeedFilters=combine_css \
     'fgrep -c .pagespeed.' 1

--- a/pagespeed/system/system_tests/shard_domain.sh
+++ b/pagespeed/system/system_tests/shard_domain.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test ShardDomain directive in per-directory config
 fetch_until -save $TEST_ROOT/shard/shard.html 'fgrep -c .pagespeed.ce' 4
 check [ $(grep -ce href=\"http://shard1 $FETCH_FILE) = 2 ];

--- a/pagespeed/system/system_tests/shared_cdn_host_header.sh
+++ b/pagespeed/system/system_tests/shared_cdn_host_header.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Test a scenario where a multi-domain installation is using a
 # single CDN for all hosts, and uses a subdirectory in the CDN to
 # distinguish hosts.  Some of the resources may already be mapped to

--- a/pagespeed/system/system_tests/shm_cache.sh
+++ b/pagespeed/system/system_tests/shm_cache.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Test that we work fine with an explicitly configured SHM metadata cache.
 start_test Using SHM metadata cache
 HOST_NAME="http://shmcache.example.com"

--- a/pagespeed/system/system_tests/show_cache.sh
+++ b/pagespeed/system/system_tests/show_cache.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test ShowCache without URL gets a form, inputs, preloaded UA.
 ADMIN_CACHE=$PRIMARY_SERVER/pagespeed_admin/cache
 OUT=$($WGET_DUMP $ADMIN_CACHE)

--- a/pagespeed/system/system_tests/source_maps.sh
+++ b/pagespeed/system/system_tests/source_maps.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test UseExperimentalJsMinifier
 URL="$TEST_ROOT/experimental_js_minifier/index.html"
 URL+="?PageSpeedFilters=rewrite_javascript"

--- a/pagespeed/system/system_tests/static_asset_domain_rewrite.sh
+++ b/pagespeed/system/system_tests/static_asset_domain_rewrite.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test static asset urls are mapped/sharded
 
 HOST_NAME="http://map-static-domain.example.com"

--- a/pagespeed/system/system_tests/statistics_are_local_only.sh
+++ b/pagespeed/system/system_tests/statistics_are_local_only.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # This test only makes sense if you're running tests against localhost.
 if echo "$HOSTNAME" | grep "^localhost:"; then
   if which ifconfig >/dev/null; then

--- a/pagespeed/system/system_tests/strip_subresources.sh
+++ b/pagespeed/system/system_tests/strip_subresources.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 start_test Strip subresources default behaviour
 URL="$TEST_ROOT/strip_subresource_hints/default/index.html"
 echo $WGET_DUMP $URL

--- a/pagespeed/system/system_tests/url_valued_attributes.sh
+++ b/pagespeed/system/system_tests/url_valued_attributes.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Test to make sure dynamically defined url-valued attributes are rewritten by
 # rewrite_domains.  See mod_pagespeed_test/rewrite_domains.html: in addition
 # to having one <img> URL, one <form> URL, and one <a> url it also has one

--- a/pagespeed/system/system_tests/x_header_value.sh
+++ b/pagespeed/system/system_tests/x_header_value.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # This test checks that the XHeaderValue directive works.
 start_test XHeaderValue directive
 

--- a/pagespeed/system/system_tests/x_sendfile.sh
+++ b/pagespeed/system/system_tests/x_sendfile.sh
@@ -1,3 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Test that we do not rewrite resources when the X-Sendfile header is set, or
 # when the X-Accel-Redirect header is set.
 start_test check that rewriting only happens without X-Sendfile

--- a/pagespeed/system/tcp_connection_for_testing.cc
+++ b/pagespeed/system/tcp_connection_for_testing.cc
@@ -1,3 +1,18 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: cheesy@google.com (Steve Hill)
 #include "pagespeed/system/tcp_connection_for_testing.h"
 
 #include <sys/socket.h>

--- a/url/base/string16.h
+++ b/url/base/string16.h
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Author: morlovich@google.com (Maks Orlovich)
 #ifndef URL_COMPAT_STRING16_H
 #define URL_COMPAT_STRING16_H
 // We have both of:


### PR DESCRIPTION
* many files had no license comments at all
* some files had license comments suggesting that they weren't open source
  (like a terse "all rights reserved") when they actually are open source.
* all our files are licensed under apache and should be marked as such