### PR TITLE
travis: add -luuid so we can build with devel on travis

### DIFF
--- a/third_party/apr/apr.gyp
+++ b/third_party/apr/apr.gyp
@@ -81,6 +81,7 @@
                   'link_settings': {
                     'libraries': [
                       '-ldl',
+                      '-luuid',
                   ]},
                 }],
               ],


### PR DESCRIPTION
This should fix the ngx_pagespeed build on travis, because the ngx_pagespeed build is using devel.

(This is actually something I had originally done as part of preparing 91662d08a, but because part of that change involved removing our exporting tools I hand-exported the change and missed this file.)