### PR TITLE
devel: fix flakes in build_development_apache

### DIFF
--- a/install/build_development_apache.sh
+++ b/install/build_development_apache.sh
@@ -77,7 +77,7 @@ cd "$third_party/apr/src"
 ./buildconf --prefix=$TARGET
 ./configure --prefix=$TARGET
 make
-make install
+make install -j1
 
 cd "$third_party/aprutil/src"
 ./buildconf --with-apr="$third_party/apr/src" --prefix=$TARGET


### PR DESCRIPTION
build_development_apache.sh flakes about 21% of the time, due to the apr
makefile not handling parallelism properly when running the install target.
Explicitly set -j1 when installing apr.

Fixes pagespeed/ngx_pagespeed#1338