### PR TITLE
run-on-vm: add support for running checkin tests on a vm

### DIFF
--- a/devel/checkin_on_vm.sh
+++ b/devel/checkin_on_vm.sh
@@ -79,10 +79,10 @@ function machine_ready() {
   sudo apt-get -y upgrade
   sudo apt-get -y install git
   if ! [ -d mod_pagespeed ]; then
-    git clone -b "$branch" https://github.com/pagespeed/mod_pagespeed.git
+    git clone -b "$branch" https://github.com/pagespeed/mod_pagespeed.git \
+              --recurse-submodules
   fi
   cd mod_pagespeed
-  git submodule update --init --recursive
   if ! [ -d ~/apache2 ]; then
     install/build_development_apache.sh 2.2 prefork
   fi

--- a/devel/checkin_on_vm.sh
+++ b/devel/checkin_on_vm.sh
@@ -75,6 +75,8 @@ function machine_ready() {
   gcloud compute ssh "$machine_name" -- bash << EOF
   set -e
   set -x
+  set -u
+
   sudo apt-get -y update
   sudo apt-get -y upgrade
   sudo apt-get -y install git

--- a/devel/checkin_on_vm.sh
+++ b/devel/checkin_on_vm.sh
@@ -67,6 +67,7 @@ if [ -z "$machine_name" ]; then
   machine_name="${USER}-checkin-${sanitized_branch}"
 fi
 
+# Empty final argument is to placate -u
 remaining_arguments=( "$@" "" )
 
 # Hook for run_on_vm.sh to call.

--- a/devel/checkin_on_vm.sh
+++ b/devel/checkin_on_vm.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: jefftk@google.com (Jeff Kaufman)
+#
+# Runs mod_pagespeed checkin tests on a gcloud VM.
+#
+# You may want to set CLOUDSDK_COMPUTE_REGION and/or CLOUDSDK_CORE_PROJECT,
+# or set your gcloud defaults befor running this:
+# https://cloud.google.com/sdk/gcloud/reference/config/set
+
+set -u
+
+this_dir=$(dirname $0)
+
+branch=
+delete_existing_machine=true
+image_family=ubuntu-1404-lts
+keep_machine=false
+machine_name=
+use_existing_machine=false
+
+options="$(getopt --long branch:,machine_name:,use_existing_machine \
+    -o '' -- "$@")"
+if [ $? -ne 0 ]; then
+  echo "Usage: $(basename "$0") [options]" >&2
+  echo "  --branch=<branch>               mod_pagespeed branch to test" >&2
+  echo "  --machine_name=<machine_name>   VM name to create (optional)" >&2
+  echo "  --use_existing_machine          Re-run script on existing VM" >&2
+  exit 1
+fi
+
+set -e
+eval set -- "$options"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --branch) branch="$2"; shift 2 ;;
+    --machine_name) machine_name="$2"; shift 2 ;;
+    --use_existing_machine) use_existing_machine=true;
+                            delete_existing_machine=false; shift ;;
+    --) shift; break ;;
+    *) echo "getopt error" >&2; exit 1 ;;
+  esac
+done
+
+if [ -z "$branch" ]; then
+  echo "Must set --branch" >&2
+  exit 1
+fi
+
+if [ -z "$machine_name" ]; then
+  sanitized_branch="$(tr _ - <<< "$branch" | tr -d .)"
+  machine_name="${USER}-checkin-${sanitized_branch}"
+fi
+
+remaining_arguments=( "$@" "" )
+
+# Hook for run_on_vm.sh to call.
+function machine_ready() {
+  gcloud compute ssh "$machine_name" -- bash << EOF
+  set -e
+  set -x
+  sudo apt-get -y update
+  sudo apt-get -y upgrade
+  sudo apt-get -y install git
+  if ! [ -d mod_pagespeed ]; then
+    git clone -b "$branch" https://github.com/pagespeed/mod_pagespeed.git
+  fi
+  cd mod_pagespeed
+  git submodule update --init --recursive
+  if ! [ -d ~/apache2 ]; then
+    install/build_development_apache.sh 2.2 prefork
+  fi
+  devel/checkin ${remaining_arguments[@]}
+EOF
+}
+
+source "$this_dir/../install/run_on_vm.sh"

--- a/devel/checkin_on_vm.sh
+++ b/devel/checkin_on_vm.sh
@@ -86,7 +86,7 @@ function machine_ready() {
   if ! [ -d ~/apache2 ]; then
     install/build_development_apache.sh 2.2 prefork
   fi
-  devel/checkin ${remaining_arguments[@]}
+  devel/checkin "${remaining_arguments[@]}"
 EOF
 }
 

--- a/install/build_on_vm.sh
+++ b/install/build_on_vm.sh
@@ -24,6 +24,8 @@
 
 set -u
 
+this_dir=$(dirname $0)
+
 branch=master
 delete_existing_machine=false
 image_family=ubuntu-1204-lts
@@ -69,16 +71,9 @@ if $use_existing_machine && $delete_existing_machine; then
   exit 1
 fi
 
-if ! type gcloud >/dev/null 2>&1; then
-  echo "gcloud is not in your PATH. See: https://cloud.google.com/sdk/" >&2
-  exit 1
-fi
-
-use_rpms=false
-
 case "$image_family" in
-  centos-*) image_project=centos-cloud ; use_rpms=true ;;
-  ubuntu-*) image_project=ubuntu-os-cloud ;;
+  centos-*) use_rpms=true ;;
+  ubuntu-*) use_rpms=false ;;
   *) echo "This script doesn't recognize image family '$image_family'" >&2;
      exit 1 ;;
 esac
@@ -99,28 +94,13 @@ if [ -z "$machine_name" ]; then
   machine_name+="-${sanitized_branch}-mps-build${bit_suffix}"
 fi
 
-instances=$(gcloud compute instances list -q "$machine_name")
-if [ -n "$instances" ]; then
-  if $delete_existing_machine; then
-    gcloud -q compute instances delete "$machine_name"
-    instances=
-  elif ! $use_existing_machine; then
-    echo "Instance '$machine_name' already exists." >&2
-    exit 1
-  fi
-fi
-
-if [ -z "$instances" ] || ! $use_existing_machine; then
-  gcloud compute instances create "$machine_name" \
-    --image-family="$image_family" --image-project="$image_project"
-fi
-
 mkdir -p ~/release
 
-# Display an error including the machine name if we die in the script below.
-trap '[ $? -ne 0 ] && echo -e "\nBuild failed on $machine_name"' EXIT
+remaining_arguments=( "$@" "" )
 
-gcloud compute ssh "$machine_name" -- bash << EOF
+# Hook for run_on_vm.sh to call.
+function machine_ready() {
+  gcloud compute ssh "$machine_name" -- bash << EOF
   set -e
   set -x
   if $use_rpms; then
@@ -130,11 +110,10 @@ gcloud compute ssh "$machine_name" -- bash << EOF
   fi
   git clone -b "$branch" https://github.com/pagespeed/mod_pagespeed.git
   cd mod_pagespeed
-  install/build_release.sh $@
+  install/build_release.sh ${remaining_arguments[@]}
 EOF
 
-gcloud compute copy-files "${machine_name}:mod_pagespeed/release/*" ~/release/
+  gcloud compute copy-files "${machine_name}:mod_pagespeed/release/*" ~/release/
+}
 
-if ! $keep_machine; then
-  gcloud -q compute instances delete "$machine_name"
-fi
+source "$this_dir/run_on_vm.sh"

--- a/install/build_on_vm.sh
+++ b/install/build_on_vm.sh
@@ -96,6 +96,7 @@ fi
 
 mkdir -p ~/release
 
+# Empty final argument is to placate -u
 remaining_arguments=( "$@" "" )
 
 # Hook for run_on_vm.sh to call.

--- a/install/build_on_vm.sh
+++ b/install/build_on_vm.sh
@@ -111,7 +111,7 @@ function machine_ready() {
   fi
   git clone -b "$branch" https://github.com/pagespeed/mod_pagespeed.git
   cd mod_pagespeed
-  install/build_release.sh ${remaining_arguments[@]}
+  install/build_release.sh "${remaining_arguments[@]}"
 EOF
 
   gcloud compute copy-files "${machine_name}:mod_pagespeed/release/*" ~/release/

--- a/install/run_on_vm.sh
+++ b/install/run_on_vm.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: cheesy@google.com (Steve Hill)
+#
+# Stand up a gcloud VM, run a script, then take down the VM if necessary.
+# Intended to be run by sourcing.
+#
+# Expects the following variables:
+#   delete_existing_machine  If the VM already exists, delete it
+#   image_family             Image family used to create VM
+#                            See: gcloud compute images list
+#   keep_machine             Don't delete the machine on success
+#   machine_name             VM name to create
+#   use_existing_machine     Re-run script on existing VM
+#
+# Calls the following hooks:
+#   machine_ready            Bash function that's run after the machine is up.
+#
+# You should set CLOUDSDK_COMPUTE_REGION and/or CLOUDSDK_CORE_PROJECT, or set
+# your gcloud defaults befor running this:
+# https://cloud.google.com/sdk/gcloud/reference/config/set
+
+# TODO(jefftk): The way this handles argument parsing is not ideal, since any
+# script using run_on_vm.sh is going to have some amount of argument overlap,
+# but fixing this with hooks for specifying additional arguments is (a) awkward
+# and (b) a lot of engineering work for the current two callers.
+
+set -u
+set -e
+
+if ! type gcloud >/dev/null 2>&1; then
+  echo "gcloud is not in your PATH. See: https://cloud.google.com/sdk/" >&2
+  exit 1
+fi
+
+case "$image_family" in
+  centos-*) image_project=centos-cloud ;;
+  ubuntu-*) image_project=ubuntu-os-cloud ;;
+  *) echo "This script doesn't recognize image family '$image_family'" >&2;
+     exit 1 ;;
+esac
+
+instances=$(gcloud compute instances list -q "$machine_name")
+if [ -n "$instances" ]; then
+  if $delete_existing_machine; then
+    echo "Deleting existing $machine_name instance..."
+    gcloud -q compute instances delete "$machine_name"
+    instances=
+  elif ! $use_existing_machine; then
+    echo "Instance '$machine_name' already exists." >&2
+    exit 1
+  fi
+fi
+
+if [ -z "$instances" ] || ! $use_existing_machine; then
+  echo "Creating new $machine_name instance..."
+  gcloud compute instances create "$machine_name" \
+    --image-family="$image_family" --image-project="$image_project"
+fi
+
+# Display an error including the machine name if we die in the script below.
+trap '[ $? -ne 0 ] && echo -e "\nScript failed on $machine_name"' EXIT
+
+echo "Checking whether $machine_name is up; you may see some errors..."
+while ! gcloud compute ssh "$machine_name" -- true; do
+  echo "Waiting for $machine_name to come up..."
+done
+
+machine_ready
+
+if ! $keep_machine; then
+  echo "Deleting $machine_name instance..."
+  gcloud -q compute instances delete "$machine_name"
+fi


### PR DESCRIPTION
Split the 'stand up a vm / delete it when done' portion of build_on_vm.sh
off into a new script, run_on_vm.sh, and add checkin_on_vm.sh that uses it
to run checkin tests.