### PR TITLE
doc: open source the user-facing documentation

### DIFF
--- a/doc/.htaccess
+++ b/doc/.htaccess
@@ -1,0 +1,14 @@
+# Turn on server side include processing for the header inclusion.
+AddOutputFilter INCLUDES .html
+Options +Includes
+Options +FollowSymLinks
+
+# Make /foo.html available at /foo
+RewriteEngine on
+RewriteCond %{REQUEST_FILENAME}.html -f
+RewriteRule !.*\.html$ %{REQUEST_FILENAME}.html [L]
+
+# Turn on mod_pagespeed to optimize our docs.
+ModPagespeed on
+ModPagespeedRewriteLevel CoreFilters
+ModPagespeedInPlaceResourceOptimization on

--- a/doc/.htaccess
+++ b/doc/.htaccess
@@ -12,4 +12,5 @@ RewriteRule !.*\.html$ %{REQUEST_FILENAME}.html [L]
 ModPagespeed on
 ModPagespeedRewriteLevel CoreFilters
 ModPagespeedEnableFilters collapse_whitespace
+ModPagespeedEnableFilters remove_comments
 ModPagespeedInPlaceResourceOptimization on

--- a/doc/.htaccess
+++ b/doc/.htaccess
@@ -11,4 +11,5 @@ RewriteRule !.*\.html$ %{REQUEST_FILENAME}.html [L]
 # Turn on mod_pagespeed to optimize our docs.
 ModPagespeed on
 ModPagespeedRewriteLevel CoreFilters
+ModPagespeedEnableFilters collapse_whitespace
 ModPagespeedInPlaceResourceOptimization on

--- a/doc/_footer.html
+++ b/doc/_footer.html
@@ -39,8 +39,8 @@ function buildToc() {
   tocContents.textContent = "Contents";
   toc.appendChild(tocContents);
 
-  ulNodes = [];  // stack of active <ul> nodes
-  // replace level with ulNodes.length + 1
+  var level = 1;
+  var currentUl = null;
   for (var i = 0; i < headers.length; i++) {
     var header = headers[i];
     var headerLevel = header[0];
@@ -48,25 +48,30 @@ function buildToc() {
     var headerId = header[2];
 
     var newLevel = parseInt(headerLevel.substring(1));
-    while (newLevel >= ulNodes.length) {
-      ulNodes.push(document.createElement("ul"));
+    while (newLevel > level) {
+      // We loop here to handle the case where we have h2 ... h4.  This
+      // isn't a good way to write html, but someone may still do it.
+
+      var newUl = document.createElement("ul");
+      if (currentUl == null) {
+        toc.appendChild(newUl);
+      } else {
+        currentUl.appendChild(newUl);
+      }
+      currentUl = newUl;
+      level++;
     }
-    while (newLevel <=  ulNodes.length) {
-      var finishedUl = ulNodes.pop();
-      ulNodes[ulNodes.length - 1].appendChild(finishedUl);
+    while (newLevel < level) {
+      currentUl = currentUl.parentNode;
+      level--;
     }
     var li = document.createElement("li");
     var a = document.createElement("a");
     a.href = "#" + headerId;
     a.textContent = headerValue;
     li.appendChild(a);
-    ulNodes[ulNodes.length - 1].appendChild(li);
+    currentUl.appendChild(li);
   }
-  while (ulNodes.length > 1) {
-    var finishedUl = ulNodes.pop();
-    ulNodes[ulNodes.length - 1].appendChild(finishedUl);
-  }
-  toc.appendChild(ulNodes[0]);
 }
 
 function wrapTables() {

--- a/doc/_footer.html
+++ b/doc/_footer.html
@@ -3,28 +3,28 @@
 </div>
 
 <script>
-function build_toc_helper(node, headers) {
+function buildTocHelper(node, headers) {
   if (node.nodeType == 1) {
     // Element node.
-    var node_name = node.nodeName.toLowerCase();
-    if (node_name == "h2" || node_name == "h3" || node_name == "h4" ||
-        node_name == "h5" || node_name == "h6") {
+    var nodeName = node.nodeName.toLowerCase();
+    if (nodeName == "h2" || nodeName == "h3" || nodeName == "h4" ||
+        nodeName == "h5" || nodeName == "h6") {
       if (node.id) {
-        headers.push([node_name, node.innerHTML, node.id]);
+        headers.push([nodeName, node.innerHTML, node.id]);
         node.innerHTML +=
           '&nbsp;<a class=header-link href="#' + node.id + '">&#x1f517;</a>';
       }
     } else {
       for (var i = 0; i < node.childNodes.length; i++) {
-        build_toc_helper(node.childNodes[i], headers);
+        buildTocHelper(node.childNodes[i], headers);
       }
     }
   }
 }
 
-function build_toc() {
+function buildToc() {
   var headers = [];
-  build_toc_helper(document.body, headers);
+  buildTocHelper(document.body, headers);
   if (headers.length == 0) {
     return;
   }
@@ -33,20 +33,20 @@ function build_toc() {
   var level = 1;
   for (var i = 0; i < headers.length; i++) {
     var header = headers[i];
-    var header_level = header[0];
-    var header_value = header[1];
-    var header_id = header[2];
+    var headerLevel = header[0];
+    var headerValue = header[1];
+    var headerId = header[2];
 
-    var new_level = parseInt(header_level.substring(1));
-    while (new_level > level) {
+    var newLevel = parseInt(headerLevel.substring(1));
+    while (newLevel > level) {
       toc += "<ul>"
       level++;
     }
-    while (new_level < level) {
+    while (newLevel < level) {
       toc += "</ul>";
       level--;
     }
-    toc += '<li><a href="#' + header_id + '">' + header_value + '</a>'
+    toc += '<li><a href="#' + headerId + '">' + headerValue + '</a>'
   }
   while (level > 1) {
     toc += "</ul>";
@@ -55,7 +55,7 @@ function build_toc() {
   document.getElementById("toc").innerHTML += toc;
 }
 
-function wrap_tables() {
+function wrapTables() {
   var tables = document.getElementsByTagName("table");
   for (var i = 0; i < tables.length; i++) {
     var table = tables[i];
@@ -67,6 +67,6 @@ function wrap_tables() {
   }
 }
 
-build_toc();
-wrap_tables();
+buildToc();
+wrapTables();
 </script>

--- a/doc/_footer.html
+++ b/doc/_footer.html
@@ -15,7 +15,7 @@ function buildTocHelper(node, headers) {
 	var a = document.createElement("a");
 	a.class = "header-link";
 	a.href = "#" + node.id;
-	a.appendChild(document.createTextNode("\uD83D\uDD17"));  // link symbol
+	a.textContent = "\uD83D\uDD17";  // link symbol
 	node.appendChild(a);
       }
     } else {
@@ -36,7 +36,7 @@ function buildToc() {
   var toc = document.getElementById("toc");
   var tocContents = document.createElement("div");
   tocContents.id = "toc-contents";
-  tocContents.appendChild(document.createTextNode("Contents"));
+  tocContents.textContent = "Contents";
   toc.appendChild(tocContents);
 
   ulNodes = [];  // stack of active <ul> nodes
@@ -58,7 +58,7 @@ function buildToc() {
     var li = document.createElement("li");
     var a = document.createElement("a");
     a.href = "#" + headerId;
-    a.appendChild(document.createTextNode(headerValue));
+    a.textContent = headerValue;
     li.appendChild(a);
     ulNodes[ulNodes.length - 1].appendChild(li);
   }

--- a/doc/_footer.html
+++ b/doc/_footer.html
@@ -11,8 +11,12 @@ function buildTocHelper(node, headers) {
         nodeName == "h5" || nodeName == "h6") {
       if (node.id) {
         headers.push([nodeName, node.innerHTML, node.id]);
-        node.innerHTML +=
-          '&nbsp;<a class=header-link href="#' + node.id + '">&#x1f517;</a>';
+	node.appendChild(document.createTextNode("\u00A0"));  // nbsp
+	var a = document.createElement("a");
+	a.class = "header-link";
+	a.href = "#" + node.id;
+	a.appendChild(document.createTextNode("\uD83D\uDD17"));  // link symbol
+	node.appendChild(a);
       }
     } else {
       for (var i = 0; i < node.childNodes.length; i++) {
@@ -29,8 +33,14 @@ function buildToc() {
     return;
   }
 
-  var toc = "<div id=toc-contents>Contents</div>";
-  var level = 1;
+  var toc = document.getElementById("toc");
+  var tocContents = document.createElement("div");
+  tocContents.id = "toc-contents";
+  tocContents.appendChild(document.createTextNode("Contents"));
+  toc.appendChild(tocContents);
+
+  ulNodes = [];  // stack of active <ul> nodes
+  // replace level with ulNodes.length + 1
   for (var i = 0; i < headers.length; i++) {
     var header = headers[i];
     var headerLevel = header[0];
@@ -38,21 +48,25 @@ function buildToc() {
     var headerId = header[2];
 
     var newLevel = parseInt(headerLevel.substring(1));
-    while (newLevel > level) {
-      toc += "<ul>"
-      level++;
+    while (newLevel >= ulNodes.length) {
+      ulNodes.push(document.createElement("ul"));
     }
-    while (newLevel < level) {
-      toc += "</ul>";
-      level--;
+    while (newLevel <=  ulNodes.length) {
+      var finishedUl = ulNodes.pop();
+      ulNodes[ulNodes.length - 1].appendChild(finishedUl);
     }
-    toc += '<li><a href="#' + headerId + '">' + headerValue + '</a>'
+    var li = document.createElement("li");
+    var a = document.createElement("a");
+    a.href = "#" + headerId;
+    a.appendChild(document.createTextNode(headerValue));
+    li.appendChild(a);
+    ulNodes[ulNodes.length - 1].appendChild(li);
   }
-  while (level > 1) {
-    toc += "</ul>";
-    level--;
+  while (ulNodes.length > 1) {
+    var finishedUl = ulNodes.pop();
+    ulNodes[ulNodes.length - 1].appendChild(finishedUl);
   }
-  document.getElementById("toc").innerHTML += toc;
+  toc.appendChild(ulNodes[0]);
 }
 
 function wrapTables() {

--- a/doc/_footer.html
+++ b/doc/_footer.html
@@ -1,0 +1,72 @@
+<div id=footer>
+  <!--#include virtual="_navline.html" -->
+</div>
+
+<script>
+function build_toc_helper(node, headers) {
+  if (node.nodeType == 1) {
+    // Element node.
+    var node_name = node.nodeName.toLowerCase();
+    if (node_name == "h2" || node_name == "h3" || node_name == "h4" ||
+        node_name == "h5" || node_name == "h6") {
+      if (node.id) {
+        headers.push([node_name, node.innerHTML, node.id]);
+        node.innerHTML +=
+          '&nbsp;<a class=header-link href="#' + node.id + '">&#x1f517;</a>';
+      }
+    } else {
+      for (var i = 0; i < node.childNodes.length; i++) {
+        build_toc_helper(node.childNodes[i], headers);
+      }
+    }
+  }
+}
+
+function build_toc() {
+  var headers = [];
+  build_toc_helper(document.body, headers);
+  if (headers.length == 0) {
+    return;
+  }
+
+  var toc = "<div id=toc-contents>Contents</div>";
+  var level = 1;
+  for (var i = 0; i < headers.length; i++) {
+    var header = headers[i];
+    var header_level = header[0];
+    var header_value = header[1];
+    var header_id = header[2];
+
+    var new_level = parseInt(header_level.substring(1));
+    while (new_level > level) {
+      toc += "<ul>"
+      level++;
+    }
+    while (new_level < level) {
+      toc += "</ul>";
+      level--;
+    }
+    toc += '<li><a href="#' + header_id + '">' + header_value + '</a>'
+  }
+  while (level > 1) {
+    toc += "</ul>";
+    level--;
+  }
+  document.getElementById("toc").innerHTML += toc;
+}
+
+function wrap_tables() {
+  var tables = document.getElementsByTagName("table");
+  for (var i = 0; i < tables.length; i++) {
+    var table = tables[i];
+    var parent = table.parentNode;
+    var div = document.createElement('div');
+    div.className = "table-wrapper";
+    parent.insertBefore(div, table);
+    div.appendChild(table);
+  }
+}
+
+build_toc();
+wrap_tables();
+</script>

--- a/doc/_header.html
+++ b/doc/_header.html
@@ -1,0 +1,15 @@
+<div id=header>
+  <div id=logoline>
+    <div id=logo>
+      <img src="https://www.gstatic.com/images/branding/product/1x/pagespeed_32dp.png"
+           srcset="https://www.gstatic.com/images/branding/product/2x/pagespeed_32dp.png"
+           width=32 height=32 alt="pagespeed logo">
+    </div>
+    <div id=logotext>PageSpeed</div>
+  </div>
+  <div id=navline>
+    <a href="/doc/">&larr; documentation index</a>
+  </div>
+</div>
+
+<div id=toc></div>

--- a/doc/_navline.html
+++ b/doc/_navline.html
@@ -1,0 +1,3 @@
+<div id=navline>
+  <a href="/doc/">&larr; documentation index</a>
+</div>

--- a/doc/doc.css
+++ b/doc/doc.css
@@ -1,0 +1,193 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 0;
+  line-height: 1.5;
+  word-wrap: break-word;
+}
+
+a {
+  color: #0288d1;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+#header, #navline {
+  color: white;
+}
+
+#header a, #navline a {
+  color: white;
+}
+
+#logoline {
+  background-color: #0061ff;
+  padding: 1em;
+}
+
+#logo {
+  display: inline-block;
+  position: relative;
+  top: 4px;
+}
+
+#logotext {
+  font-size: 32px;
+  display: inline-block;
+}
+
+#navline a{
+  background-color: #3d87ff;
+  display: block;
+  padding: 0.5em 1em 0.5em 1em;
+}
+
+#content {
+  margin: 0.5em;
+  max-width: 35em;
+}
+
+code, pre {
+  background: #f7f7f7;
+  color: #37474f;
+}
+
+.note, .note code {
+  background: #e1f5fe;
+  color: #0288d1;
+}
+
+.note a {
+  color: #0288d1;
+  text-decoration: underline;
+}
+
+.caution, .caution code {
+  background: #fff3e0;
+  color: #dd2c00;
+}
+
+.caution a {
+  color: #dd2c00;
+  text-decoration: underline;
+}
+
+.warning, .warning code {
+  background: #fbe9e7;
+  color: #d50000;
+}
+
+.warning a {
+  color: #d50000;
+  text-decoration: underline;
+}
+
+.note, .caution, .warning {
+  padding: 1em;
+}
+
+pre {
+  padding: 1em;
+  overflow: auto;
+  line-height: 1.1;
+}
+
+table {
+  margin-top: 1em;
+  margin-bottom: 1em;
+  border-collapse: collapse;
+}
+
+th {
+  color: #fff;
+  vertical-align: middle;
+  background-color: #555;
+}
+
+td {
+  border-top: 1px solid #e0e0e0;
+  background-color: #f7f7f7;
+}
+
+th, td {
+  padding: 1em;
+}
+
+li {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+img {
+  max-width: 100%;
+}
+
+.table-wrapper {
+  max-width: 100%;
+  overflow: auto;
+}
+
+#downloads .download {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+#toc {
+  border-left: 4px solid #0061ff;
+  font-size: 0.9em;
+  max-width: 25em;
+  margin-top: 1em;
+  margin-left: 1em;
+}
+
+#toc-contents {
+  color: #757575;
+  font-weight: bold;
+  padding-left: 1em;
+}
+
+#toc ul {
+  list-style: none;
+  list-style-position: inside;
+  padding-left: 1em;
+}
+
+@media screen and (min-width: 55em) {
+  #toc {
+    float: right;
+    max-width: 18em;
+    padding-right: 1em;
+  }
+}
+
+.header-link {
+  visibility: hidden;
+  font-size: 80%;
+}
+
+h2:hover .header-link,
+h3:hover .header-link,
+h4:hover .header-link,
+h5:hover .header-link,
+h6:hover .header-link {
+  visibility: initial;
+  text-decoration: none;
+}
+
+.column {
+  margin: 0.5em;
+}
+
+.columns {
+  max-width: 75em;
+}
+
+@media screen and (min-width: 50em) {
+  .column {
+    display: inline-block;
+    vertical-align: top;
+  }
+}

--- a/doc/index.html
+++ b/doc/index.html
@@ -1,0 +1,102 @@
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Installing From Packages</title>
+    <link rel="stylesheet" href="doc.css">
+  </head>
+  <body>
+
+<div id=header>
+  <div id=logoline>
+    <div id=logo>
+      <img src="https://www.gstatic.com/images/branding/product/1x/pagespeed_32dp.png"
+           srcset="https://www.gstatic.com/images/branding/product/2x/pagespeed_32dp.png"
+           width=32 height=32 alt="pagespeed logo">
+    </div>
+    <div id=logotext>PageSpeed</div>
+  </div>
+</div>
+
+<h1>PageSpeed Documentation</h1>
+
+<div class=columns>
+<div id=guides class=column>
+<h2>Guides</h2>
+<p><a href="download">Installing From Packages</a>
+<p><a href="build_mod_pagespeed_from_source">Installing From Source: Apache</a>
+<p><a href="build_ngx_pagespeed_from_source">Installing From Source: Nginx</a>
+<p><a href="configuration">Module Configuration</a>
+<p><a href="admin">Admin Pages</a>
+<p><a href="config_filters">Configuring Filters</a>
+<p><a href="optimize-for-bandwidth">Optimizing for Bandwidth</a>
+<p><a href="domains">Mapping Domains</a>
+<p><a href="restricting_urls">URL Control</a>
+<p><a href="https_support">HTTPS Support</a>
+<p><a href="system">System Integration</a>
+<p><a href="downstream-caching">Configuring Downstream Caches</a>
+<p><a href="experiment">Manual Experiments</a>
+<p><a href="module-run-experiment">Automated Experiments</a>
+<p><a href="console">Console</a>
+<p><a href="mod_security">Security Considerations</a>
+</div>
+
+<div id=reference class=column>
+<h2>Reference</h2>
+<p><a href="filter-head-add">Add Head</a>
+<p><a href="filter-instrumentation-add">Add Instrumentation</a>
+<p><a href="filter-make-show-ads-async">Async Google AdSense</a>
+<p><a href="filter-make-google-analytics-async">Async Google Analytics</a>
+<p><a href="filter-canonicalize-js">Canonicalize JavaScript Libraries</a>
+<p><a href="filter-whitespace-collapse">Collapse Whitespace</a>
+<p><a href="filter-css-combine">Combine CSS</a>
+<p><a href="filter-js-combine">Combine JavaScript</a>
+<p><a href="filter-head-combine">Combine Heads</a>
+<p><a href="filter-convert-meta-tags">Convert Meta Tags</a>
+<p><a href="filter-dedup-inlined-images">Deduplicate Inlined Images</a>
+<p><a href="filter-js-defer">Defer JavaScript</a>
+<p><a href="filter-attribute-elide">Elide Attributes</a>
+<p><a href="filter-cache-extend">Extend Cache</a>
+<p><a href="filter-cache-extend-pdfs">Extend Cache PDFs</a>
+<p><a href="reference-image-optimize"
+      >Filters and Options for Optimizing Images</a>
+<p><a href="filter-flatten-css-imports">Flatten CSS @imports</a>
+<p><a href="filter-hint-preload-subresources">Hint Resource Preloading</a>
+<p><a href="filter-source-maps-include">Include JavaScript Source Maps</a>
+<p><a href="filter-css-inline-import">Inline @import to Link</a>
+<p><a href="filter-css-inline">Inline CSS</a>
+<p><a href="filter-css-inline-google-fonts">Inline Google Fonts API CSS</a>
+<p><a href="filter-js-inline">Inline JavaScript</a>
+<p><a href="filter-inline-preview-images">Inline Preview Images</a>
+<p><a href="filter-insert-ga">Insert Google Analytics</a>
+<p><a href="filter-lazyload-images">Lazily Load Images</a>
+<p><a href="filter-local-storage-cache">Local Storage Cache</a>
+<p><a href="filter-image-responsive">Make Images Responsive</a>
+<p><a href="filter-js-minify">Minify JavaScript</a>
+<p><a href="filter-css-above-scripts">Move CSS Above Scripts</a>
+<p><a href="filter-css-to-head">Move CSS to Head</a>
+<p><a href="filter-image-optimize">Optimize Images</a>
+<p><a href="filter-css-outline">Outline CSS</a>
+<p><a href="filter-js-outline">Outline JavaScript</a>
+<p><a href="filter-pedantic">Pedantic</a>
+<p><a href="filter-insert-dns-prefetch">Pre-Resolve DNS</a>
+<p><a href="filter-prioritize-critical-css">Prioritize Critical CSS</a>
+<p><a href="filter-comment-remove">Remove Comments</a>
+<p><a href="filter-quote-remove">Remove Quotes</a>
+<p><a href="filter-css-rewrite">Rewrite CSS</a>
+<p><a href="filter-domain-rewrite">Rewrite Domain</a>
+<p><a href="filter-rewrite-style-attributes">Rewrite Style Attributes</a>
+<p><a href="module-run-experiment">Run Experiments</a>
+<p><a href="filter-image-sprite">Sprite Images</a>
+<p><a href="filter-trim-urls">Trim URLs</a>
+</div>
+
+<div id=support class=column>
+<h2>Suport</h2>
+<p><a href="faq">FAQ</a>
+<p><a href="release_notes">Release Notes</a>
+<p><a href="mailing-lists">Mailing Lists</a>
+</div>
+</div>
+
+  </body>
+</html>


### PR DESCRIPTION
This is an open source version of the user-facing docs on [developers.google.com/speed/pagespeed/module/](https://developers.google.com/speed/pagespeed/module/).  I currently have it staged at [modpagespeed.com/doc](https://modpagespeed.com/doc), which is probably where this should go when live.

It uses server-side includes for headers and footers, which isn't as nice as being fully static, but should be more maintainable.

This change doesn't include a landing page for mod_pagespeed.  I think that should probably go on modpagespeed.com / ngxpagespeed.com and not in the docs directly.  Having it in the docs is a weird artifact of how we were hosted on developers.google.com.  But this is not in this CL.

Mobile PSI score is 100 with mod_pagespeed and 89 without, so we're also doing a bit of demonstrating pagespeed.

For reviewability, this is split into three sequential changes:
* https://github.com/pagespeed/mod_pagespeed/pull/1464 : straight copy-over of existing docs
* https://github.com/pagespeed/mod_pagespeed/pull/1465 : formatting changes that apply in bulk to all html files
* https://github.com/pagespeed/mod_pagespeed/pull/1459 (this change) : css and js to make the docs be usable and nice to look at 