### PR TITLE
doc: use HTTPS for LazyloadImagesBlankUrl

### DIFF
--- a/html/doc/filter-lazyload-images.html
+++ b/html/doc/filter-lazyload-images.html
@@ -75,9 +75,9 @@ possible to use the same image served by Google's network, or any image that you
 choose, by specifying:</p>
 <dl>
   <dt>Apache:<dd><pre class="prettyprint"
-     >ModPagespeedLazyloadImagesBlankUrl "http://www.gstatic.com/psa/static/1.gif"</pre>
+     >ModPagespeedLazyloadImagesBlankUrl "https://www.gstatic.com/psa/static/1.gif"</pre>
   <dt>Nginx:<dd><pre class="prettyprint"
-     >pagespeed LazyloadImagesBlankUrl "http://www.gstatic.com/psa/static/1.gif";</pre>
+     >pagespeed LazyloadImagesBlankUrl "https://www.gstatic.com/psa/static/1.gif";</pre>
 </dl>
 <p>An advantage of this approach is that this gif may already be in
 the browser cache since any PageSpeed-enabled site can share it.


### PR DESCRIPTION
Fixes https://github.com/pagespeed/ngx_pagespeed/issues/1358