### PR TITLE
standby: add standby mode

### DIFF
--- a/html/doc/configuration.html
+++ b/html/doc/configuration.html
@@ -97,8 +97,15 @@ ModPagespeed off
 <pre class="prettyprint">
 ModPagespeed unplugged
 </pre>
+
 <p>
-The <code>on</code> and <code>off</code> values can be used in
+
+In versions UNRELEASED and later "off" is deprecated and "standby" has been
+added as a replacement.
+
+<p>
+The <code>on</code>, <code>off</code>, and (in UNRELEASED and
+later) <code>standby</code> values can be used in
 <a href="#htaccess"><code>.htaccess</code> files,
 <code>&lt;Directory&gt;</code></a> scopes, <code>query parameters</code>, and
 <code>headers</code>.  The <code>unplugged</code> value can only be used in the
@@ -166,6 +173,15 @@ pagespeed off;
 </pre>
 This is equivalent to the "unplugged" setting for mod_pagespeed, and entirely
 disables ngx_pagespeed.
+<p>
+
+As of UNRELEASED, "off" is deprecated, and replaced with the synonym
+"unplugged".  Additionally the "standby" setting has been added, which is
+equivalent to the "off" or "standby" setting for mod_pagespeed.
+
+<p class=warning><b>Warning:</b> do not set ngx_pagespeed to "unplugged" mode in
+1.12.34.1 and earlier.  That will trigger a crash on every request.  With those
+versions, use "off" instead.
 
 <h2 id="respectvary">Respecting Vary Headers</h2>
 <p>

--- a/html/doc/configuration.html
+++ b/html/doc/configuration.html
@@ -59,6 +59,86 @@ See the <a href="admin#config">Admin Page documentation</a> for
 instructions on how to configure handlers to provide visibility and
 control into PageSpeed's operation.
 
+<h2 id="on_off">Turning the module on and off</h2>
+<!-- keep old anchors so as not to break existing links -->
+<a name="on_off_nginx"></a><a name="nginx_specific"></a>
+
+<h3 id=on>Setting the module on</h3>
+
+<p>
+
+To turn PageSpeed on, just set:
+
+<dl>
+  <dt>Apache:<dd><pre class="prettyprint">ModPagespeed on</pre>
+  <dt>Nginx:<dd><pre class="prettyprint">pagespeed on;</pre>
+</dl>
+
+<h3 id=standby>Setting the module to standby</h3>
+
+<p>
+
+PageSpeed has a standby mode where by default it won't make changes to your site
+but it will process two kinds of PageSpeed-specific requests:
+
+<ul>
+  <li><p>Requests with <a href="experiment#PerRequest">PageSpeed query
+      parameters</a>.  These allow you to have PageSpeed off in your main
+      configuration, but manually make requests to see how your site would look
+      under various combinations of filters and options.
+  <li><p>Requests for <code>.pagespeed.</code> resources.  When PageSpeed is
+      running it creates various kinds of optimized resources, and gives them
+      names containing <code>.pagespeed.</code>.  If you turned
+      PageSpeed <a href="#unplugged">fully off</a> then lingering requests to
+      these resorces would fail.  In standby mode these requests are still
+      served as if PageSpeed were enabled.
+</ul>
+
+<p>
+
+In versions 1.12 and earlier only mod_pagespeed supported standby mode, via
+the <code>off</code> setting:
+
+<dl>
+  <dt>Apache:<dd><pre class="prettyprint">ModPagespeed off</pre>
+</dl>
+
+<p>
+
+In versions UNRELEASED and later, both mod_pagespeed and ngx_pagespeed
+support <code>standby</code>:
+
+<dl>
+  <dt>Apache:<dd><pre class="prettyprint">ModPagespeed standby</pre>
+  <dt>Nginx:<dd><pre class="prettyprint">pagespeed standby;</pre>
+</dl>
+
+<h3 id=unplugged>Setting the module fully off</h3>
+
+To turn PageSpeed fully off, set:
+
+<dl>
+  <dt>Apache:<dd><pre class="prettyprint">ModPagespeed unplugged</pre>
+  <dt>Nginx:<dd><pre class="prettyprint">pagespeed unplugged;</pre>
+</dl>
+
+<p class=warning><b>Warning:</b> do not set ngx_pagespeed
+to <code>unplugged</code> in 1.12.34.1 and earlier.  That will result in
+crashes.  With those versions, use <code>off</code> instead
+of <code>unplugged</code>.
+
+<p>
+
+The <code>on</code>, <code>off</code>, and (in UNRELEASED and
+later) <code>standby</code> values can be used in
+<a href="#htaccess"><code>.htaccess</code> files,
+<code>&lt;Directory&gt;</code></a> scopes, <code>query parameters</code>, and
+<code>headers</code>.  The <code>unplugged</code> value can only be used in the
+top-level Apache configuration and in virtual hosts.  Note that
+<code>ModPagespeed on</code> in a virtual host can override a top-level
+unplugged directive.
+</p>
+
 <h2 id="apache_specific">Apache-Specific Configuration</h2>
 
 <h3 id="output_filter">Setting up the Output Filter</h3>
@@ -73,45 +153,6 @@ AddOutputFilterByType MOD_PAGESPEED_OUTPUT_FILTER text/html
 </pre>
 <p class="note"><strong>Note:</strong> mod_pagespeed automatically enables
 <code>mod_deflate</code> for compression.
-</p>
-
-<h3 id="on_off">Turning the module on and off</h3>
-<p>
-To turn mod_pagespeed ON, insert as the top line of pagespeed.conf:
-</p>
-<pre class="prettyprint">
-ModPagespeed on
-</pre>
-<p>
-There are two ways to disable mod_pagespeed. To disable HTML rewriting but
-continue to serve .pagespeed. resources and parse query options (for
-instance for <code>?ModPagespeed=on</code>) put this line in your configuration:
-</p>
-
-<pre class="prettyprint">
-ModPagespeed off
-</pre>
-
-<p>To completely disable mod_pagespeed (.pagespeed. resources will result in
-404s) use the following line:</p>
-<pre class="prettyprint">
-ModPagespeed unplugged
-</pre>
-
-<p>
-
-In versions UNRELEASED and later "off" is deprecated and "standby" has been
-added as a replacement.
-
-<p>
-The <code>on</code>, <code>off</code>, and (in UNRELEASED and
-later) <code>standby</code> values can be used in
-<a href="#htaccess"><code>.htaccess</code> files,
-<code>&lt;Directory&gt;</code></a> scopes, <code>query parameters</code>, and
-<code>headers</code>.  The <code>unplugged</code> value can only be used in the
-top-level Apache configuration and in virtual hosts.  Note that
-<code>ModPagespeed on</code> in a virtual host can override a top-level
-unplugged directive.
 </p>
 
 <h3 id="apache24">Support for Apache 2.4.x</h3>
@@ -154,34 +195,6 @@ to auto-detect. Builds against system Apache headers will only be compatible
 with that version family, and will always produce a single module named
 <code>mod_pagespeed.so</code>.
 </p>
-
-<h2 id="nginx_specific">Nginx-Specific Configuration</h2>
-
-<h3 id="on_off_nginx">Turning the module on and off</h3>
-
-<p>
-To turn ngx_pagespeed ON, put anywhere in your <code>http</code>
-or <code>server</code> block:
-</p>
-<pre class="prettyprint">
-pagespeed on;
-</pre>
-<p>
-To turn ngx_pagespeed OFF, use <code>off</code>:
-<pre class="prettyprint">
-pagespeed off;
-</pre>
-This is equivalent to the "unplugged" setting for mod_pagespeed, and entirely
-disables ngx_pagespeed.
-<p>
-
-As of UNRELEASED, "off" is deprecated, and replaced with the synonym
-"unplugged".  Additionally the "standby" setting has been added, which is
-equivalent to the "off" or "standby" setting for mod_pagespeed.
-
-<p class=warning><b>Warning:</b> do not set ngx_pagespeed to "unplugged" mode in
-1.12.34.1 and earlier.  That will trigger a crash on every request.  With those
-versions, use "off" instead.
 
 <h2 id="respectvary">Respecting Vary Headers</h2>
 <p>

--- a/html/doc/configuration.html
+++ b/html/doc/configuration.html
@@ -136,7 +136,7 @@ later) <code>standby</code> values can be used in
 <code>headers</code>.  The <code>unplugged</code> value can only be used in the
 top-level Apache configuration and in virtual hosts.  Note that
 <code>ModPagespeed on</code> in a virtual host can override a top-level
-unplugged directive.
+<code>ModPagespeed unplugged</code> directive.
 </p>
 
 <h2 id="apache_specific">Apache-Specific Configuration</h2>

--- a/install/debug.conf.template
+++ b/install/debug.conf.template
@@ -668,6 +668,38 @@ NameVirtualHost localhost:@@APACHE_SECONDARY_PORT@@
                            "@@APACHE_DOC_ROOT@@/mod_pagespeed_example/styles/"
 </VirtualHost>
 
+<VirtualHost localhost:@@APACHE_SECONDARY_PORT@@>
+  ServerName pagespeed-off.example.com
+  DocumentRoot "@@APACHE_DOC_ROOT@@"
+  ModPagespeedFileCachePath "@@MOD_PAGESPEED_CACHE@@"
+  ModPagespeed off
+  ModPagespeedEnableFilters collapse_whitespace
+</VirtualHost>
+
+<VirtualHost localhost:@@APACHE_SECONDARY_PORT@@>
+  ServerName pagespeed-on.example.com
+  DocumentRoot "@@APACHE_DOC_ROOT@@"
+  ModPagespeedFileCachePath "@@MOD_PAGESPEED_CACHE@@"
+  ModPagespeed on
+  ModPagespeedEnableFilters collapse_whitespace
+</VirtualHost>
+
+<VirtualHost localhost:@@APACHE_SECONDARY_PORT@@>
+  ServerName pagespeed-unplugged.example.com
+  DocumentRoot "@@APACHE_DOC_ROOT@@"
+  ModPagespeedFileCachePath "@@MOD_PAGESPEED_CACHE@@"
+  ModPagespeed unplugged
+  ModPagespeedEnableFilters collapse_whitespace
+</VirtualHost>
+
+<VirtualHost localhost:@@APACHE_SECONDARY_PORT@@>
+  ServerName pagespeed-standby.example.com
+  DocumentRoot "@@APACHE_DOC_ROOT@@"
+  ModPagespeedFileCachePath "@@MOD_PAGESPEED_CACHE@@"
+  ModPagespeed standby
+  ModPagespeedEnableFilters collapse_whitespace
+</VirtualHost>
+
 # Set the value of the X-Mod-Pagespeed header
 <VirtualHost localhost:@@APACHE_SECONDARY_PORT@@>
   ServerName xheader.example.com

--- a/net/instaweb/rewriter/rewrite_options.cc
+++ b/net/instaweb/rewriter/rewrite_options.cc
@@ -3346,6 +3346,8 @@ bool RewriteOptions::ParseFromString(StringPiece value_string,
     *value = bool_value ? kEnabledOn : kEnabledOff;
   } else if (StringCaseEqual(value_string, "unplugged")) {
     *value = kEnabledUnplugged;
+  } else if (StringCaseEqual(value_string, "standby")) {
+    *value = kEnabledStandby;
   } else {
     // value_string is not "true"/"false" or "on"/"off"/"unplugged".
     // Return a parse error.
@@ -4178,6 +4180,7 @@ GoogleString RewriteOptions::OptionsToString() const {
     case kEnabledOff:       StrAppend(&output, "off\n\n"); break;
     case kEnabledOn:        StrAppend(&output, "on\n\n"); break;
     case kEnabledUnplugged: StrAppend(&output, "unplugged\n\n"); break;
+    case kEnabledStandby:   StrAppend(&output, "standby\n\n"); break;
   }
   output += "Filters\n";
   for (int i = kFirstFilter; i != kEndOfFilters; ++i) {

--- a/net/instaweb/rewriter/rewrite_options_test.cc
+++ b/net/instaweb/rewriter/rewrite_options_test.cc
@@ -254,6 +254,9 @@ TEST_F(RewriteOptionsTest, EnabledStates) {
   options_.set_enabled(RewriteOptions::kEnabledOn);
   ASSERT_TRUE(options_.enabled());
   ASSERT_FALSE(options_.unplugged());
+  options_.set_enabled(RewriteOptions::kEnabledStandby);
+  ASSERT_FALSE(options_.enabled());
+  ASSERT_FALSE(options_.unplugged());
 }
 
 TEST_F(RewriteOptionsTest, DefaultEnabledFilters) {
@@ -2664,7 +2667,7 @@ TEST_F(RewriteOptionsTest, AccessAcrossThreads) {
   null_thread_system.set_current_thread(5);
 
   // Now make a modification.  We can continue to modify in the same thread.
-  options.set_enabled(RewriteOptions::kEnabledOff);
+  options.set_enabled(RewriteOptions::kEnabledStandby);
   EXPECT_TRUE(options.ModificationOK());
 
   // But from a different thread we must not modify.

--- a/net/instaweb/rewriter/rewrite_query.cc
+++ b/net/instaweb/rewriter/rewrite_query.cc
@@ -545,7 +545,7 @@ RewriteQuery::Status RewriteQuery::ScanNameValue(
       if (pairs[i] == "no-transform") {
         // TODO(jmarantz): A .pagespeed resource should return un-optimized
         // content with "Cache-Control: no-transform".
-        options->set_enabled(RewriteOptions::kEnabledOff);
+        options->set_enabled(RewriteOptions::kEnabledStandby);
         status = kSuccess;
         break;
       }

--- a/pagespeed/automatic/proxy_interface_test.cc
+++ b/pagespeed/automatic/proxy_interface_test.cc
@@ -1878,7 +1878,7 @@ TEST_F(ProxyInterfaceTest, AjaxRewritingWhenAuthorizationButPublic) {
 TEST_F(ProxyInterfaceTest, AjaxRewritingDisabledByGlobalDisable) {
   RewriteOptions* options = server_context()->global_options();
   options->ClearSignatureForTesting();
-  options->set_enabled(RewriteOptions::kEnabledOff);
+  options->set_enabled(RewriteOptions::kEnabledStandby);
   server_context()->ComputeSignature(options);
 
   SetResponseWithDefaultHeaders("a.css", kContentTypeCss, kCssContent,

--- a/pagespeed/system/system_caches_test.cc
+++ b/pagespeed/system/system_caches_test.cc
@@ -1215,6 +1215,16 @@ TEST_F(SystemCachesTest, ShareOnOff) {
   EXPECT_EQ(path1, path2);
 }
 
+TEST_F(SystemCachesTest, ShareOnStandby) {
+  options_->set_file_cache_path(kCachePath);
+  SystemCachePath* path1 = system_caches_->GetCache(options_.get());
+  SystemRewriteOptions options2(thread_system_.get());
+  options2.set_file_cache_path(kCachePath);
+  options2.set_enabled(RewriteOptions::kEnabledStandby);
+  SystemCachePath* path2 = system_caches_->GetCache(&options2);
+  EXPECT_EQ(path1, path2);
+}
+
 TEST_F(SystemCachesTest, NoShareOnUnplugged) {
   options_->set_file_cache_path("/a");
   options_->set_enabled(RewriteOptions::kEnabledUnplugged);

--- a/pagespeed/system/system_test.sh
+++ b/pagespeed/system/system_test.sh
@@ -75,7 +75,6 @@ SUDO=${SUDO:-}
 SYSTEM_TEST_DIR="$(dirname "${BASH_SOURCE[0]}")/system_tests/"
 run_test check_headers
 run_test aris
-run_test pagespeed_on_off_unplugged_standby
 run_test css_combining_authorization
 run_test add_instrumentation
 run_test cache_partial_html
@@ -103,6 +102,7 @@ if [ $statistics_enabled = "1" ]; then
 fi
 run_test prioritize_critical_css
 if [ "$SECONDARY_HOSTNAME" != "" ]; then
+  run_test pagespeed_on_off_unplugged_standby
   run_test ajax_overrides_experiments
 
   # The broken_fetch test can only run with a file-cache, not with

--- a/pagespeed/system/system_test.sh
+++ b/pagespeed/system/system_test.sh
@@ -75,6 +75,7 @@ SUDO=${SUDO:-}
 SYSTEM_TEST_DIR="$(dirname "${BASH_SOURCE[0]}")/system_tests/"
 run_test check_headers
 run_test aris
+run_test pagespeed_on_off_unplugged_standby
 run_test css_combining_authorization
 run_test add_instrumentation
 run_test cache_partial_html

--- a/pagespeed/system/system_tests/pagespeed_on_off_unplugged_standby.sh
+++ b/pagespeed/system/system_tests/pagespeed_on_off_unplugged_standby.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+start_test pagespeed on vs off vs unplugged vs standby
+
+# Each host has collapse_whitespace enabled, and some queries try to turn on
+# debug.
+
+function assert_debug_on() {
+  check_from "$OUT" grep "^mod_pagespeed on$"  
+}
+function assert_debug_off() {
+  check_not_from "$OUT" grep "^mod_pagespeed on$"
+}
+function assert_collapse_on() {
+  check_from "$OUT" grep "^<body>"
+}
+function assert_collapse_off() {
+  check_not_from "$OUT" grep "^<body>"
+}
+
+http_proxy=$SECONDARY_HOSTNAME
+
+start_test pagespeed on, no query params
+URL="pagespeed-on.example.com/mod_pagespeed_example/"
+OUT=$($WGET_DUMP "$URL")
+assert_collapse_on
+assert_debug_off
+
+start_test pagespeed on, with query params
+URL="pagespeed-on.example.com/mod_pagespeed_example/"
+URL+="?PageSpeed=on&PageSpeedFilters=+debug"
+OUT=$($WGET_DUMP "$URL")
+assert_collapse_on
+assert_debug_on
+
+start_test pagespeed on, resource url
+URL="pagespeed-on.example.com/mod_pagespeed_example/"
+URL+="rewrite_javascript.js.pagespeed.jm.0.js"
+check $WGET_DUMP "$URL" -O /dev/null
+
+start_test pagespeed standby, no query params
+URL="pagespeed-standby.example.com/mod_pagespeed_example/"
+OUT=$($WGET_DUMP "$URL")
+assert_collapse_off
+assert_debug_off
+
+start_test pagespeed standby, with query params
+URL="pagespeed-standby.example.com/mod_pagespeed_example/"
+URL+="?PageSpeed=on&PageSpeedFilters=+debug"
+OUT=$($WGET_DUMP "$URL")
+assert_collapse_on
+assert_debug_on
+
+start_test pagespeed standby, resource url
+URL="pagespeed-standby.example.com/mod_pagespeed_example/"
+URL+="rewrite_javascript.js.pagespeed.jm.0.js"
+check $WGET_DUMP "$URL" -O /dev/null
+
+start_test pagespeed unplugged, no query params
+URL="pagespeed-unplugged.example.com/mod_pagespeed_example/"
+OUT=$($WGET_DUMP "$URL")
+assert_collapse_off
+assert_debug_off
+
+start_test pagespeed unplugged, with query params
+URL="pagespeed-unplugged.example.com/mod_pagespeed_example/"
+URL+="?PageSpeed=on&PageSpeedFilters=+debug"
+OUT=$($WGET_DUMP "$URL")
+assert_collapse_off
+assert_debug_off
+
+start_test pagespeed unplugged, resource url
+URL="pagespeed-unplugged.example.com/mod_pagespeed_example/"
+URL+="rewrite_javascript.js.pagespeed.jm.0.js"
+check_not $WGET_DUMP "$URL" -O /dev/null
+
+start_test pagespeed off, no query params
+URL="pagespeed-off.example.com/mod_pagespeed_example/"
+OUT=$($WGET_DUMP "$URL")
+assert_collapse_off
+assert_debug_off
+
+start_test pagespeed off, with query params
+URL="pagespeed-off.example.com/mod_pagespeed_example/"
+URL+="?PageSpeed=on&PageSpeedFilters=+debug"
+OUT=$($WGET_DUMP "$URL")
+
+URL="pagespeed-off.example.com/mod_pagespeed_example/"
+URL+="rewrite_javascript.js.pagespeed.jm.0.js"
+if [ "$SERVER_NAME" = "nginx" ]; then
+  # In ngx_pagespeed off=unplugged for historical reasons.
+  assert_collapse_off
+  assert_debug_off
+
+  start_test pagespeed off, resource url, expect unplugged behavior
+  check_not $WGET_DUMP "$URL" -O /dev/null
+else
+  # Everywhere else off=standby.
+  assert_collapse_on
+  assert_debug_on
+
+  start_test pagespeed off, resource url, expect standby behavior
+  check $WGET_DUMP "$URL" -O /dev/null
+fi
+
+unset http_proxy

--- a/pagespeed/system/system_tests/pagespeed_on_off_unplugged_standby.sh
+++ b/pagespeed/system/system_tests/pagespeed_on_off_unplugged_standby.sh
@@ -26,10 +26,10 @@ function assert_debug_off() {
   check_not_from "$OUT" grep "^mod_pagespeed on$"
 }
 function assert_collapse_on() {
-  check_from "$OUT" grep "^<body>"
+  check_from "$OUT" grep "^</table>"
 }
 function assert_collapse_off() {
-  check_not_from "$OUT" grep "^<body>"
+  check_not_from "$OUT" grep "^</table>"
 }
 
 http_proxy=$SECONDARY_HOSTNAME


### PR DESCRIPTION
In standby mode PageSpeed is off, except it serves .pagespeed. resources and
PageSpeed query parameters are interpreted.  This is equivalent to "off" in
mod_pagespeed.

With this change, "off" in mod_pagespeed is deprecated, and people should use
"standby" instead.

See also: https://github.com/pagespeed/ngx_pagespeed/pull/1365

Fixes: https://github.com/pagespeed/ngx_pagespeed/issues/968