### PR TITLE
IPRO+LFF: content length & handling of unoptimizable resources (draft)

### DIFF
--- a/net/instaweb/rewriter/in_place_rewrite_context.cc
+++ b/net/instaweb/rewriter/in_place_rewrite_context.cc
@@ -103,7 +103,6 @@ RecordingFetch::~RecordingFetch() {}
 void RecordingFetch::HandleHeadersComplete() {
   can_in_place_rewrite_ = CanInPlaceRewrite();
   streaming_ = ShouldStream();
-
   if (can_in_place_rewrite_) {
     // Save the headers, and wait to finalize them in HandleDone().
     saved_headers_.reset(new ResponseHeaders(*response_headers()));
@@ -659,12 +658,9 @@ void InPlaceRewriteContext::StartFetchReconstruction() {
     } else {
       ServerContext* server_context = resource->server_context();
       MessageHandler* handler = server_context->message_handler();
-
-     
-      NonHttpResourceCallback* callback = new NonHttpResourceCallback(
-          resource, proxy_mode_, this, async_fetch(), handler);
-
+      NonHttpResourceCallback* callback = NULL;
       bool optimizeable = true;
+      
       if (num_output_partitions() == 1)
         optimizeable = output_partition(0)->optimizable();
 


### PR DESCRIPTION
Putting this up here in a non-commitable state for early consideration/review.

Contains fixes in the IPRO flow for resources covered by LoadFromFile:

1. Attempts to fix s-maxage getting stuck: https://github.com/pagespeed/mod_pagespeed/issues/1485  
As a bonus this saves repeated cache writes to our own cache when this flow is hit.

2. Avoid chunked transfer-encodings in this flow by writing out a content-length header : https://github.com/pagespeed/mod_pagespeed/issues/1240

Not ready for committing yet: 
- It would be good to add a couple of tests to avoid regressions
- This needs to be double checked if and how this interacts with the (gzip) compression feature 
- Need to check if adding a Vary: header is appropriate in this flow, at this stage, while I'm at it. (because afaict it is missing in this flow).

Note: passes the mps smoke tests and the system tests on my machine
