### PR TITLE
CSP: Parse details in host-scheme

### DIFF
--- a/net/instaweb/rewriter/csp.cc
+++ b/net/instaweb/rewriter/csp.cc
@@ -49,43 +49,139 @@ inline bool IsAsciiAlpha(char ch) {
           ((ch >= 'A') && (ch <= 'Z')));
 }
 
+inline bool IsAsciiDigit(char ch) {
+  return ((ch >= '0') && (ch <= '9'));
+}
+
 }  // namespace
+
+bool CspSourceExpression::TryParseScheme(StringPiece* input) {
+  if (input->size() < 2) {
+    // Need at least a: or such.
+    return false;
+  }
+  
+  if (!IsAsciiAlpha((*input)[0])) {
+    return false;
+  }
+  
+  size_t pos = 1;
+  while (pos < input->size() &&
+         (IsAsciiAlphaNumeric((*input)[pos]) 
+          || (*input)[pos] == '+' 
+          || (*input)[pos] == '-' 
+          || (*input)[pos] == '.')) {
+    ++pos;
+  }
+  
+  if (pos == input->size() || (*input)[pos] != ':') {
+    // All schema characters, but no : or :// afterwards -> something else.
+    return false;
+  }
+  
+  if (pos == (input->size() - 1)) {
+    // Last character was also : -> clearly a scheme-source
+    kind_ = kSchemeSource;
+    input->substr(0, pos).CopyToString(&mutable_url_data()->scheme_part);
+    input->remove_prefix(pos + 1);
+    return true;
+  }
+  
+  // We now want to see if it's actually foo://
+  if ((pos + 2 < input->size())
+       && ((*input)[pos + 1] == '/') && ((*input)[pos + 2] == '/')) {
+    input->substr(0, pos).CopyToString(&mutable_url_data()->scheme_part);
+    input->remove_prefix(pos + 3);
+  }
+  
+  // Either way, it's not a valid scheme-source at this point, even if it's
+  // a valid host-source
+  return false;
+}
 
 CspSourceExpression CspSourceExpression::Parse(StringPiece input) {
   TrimCspWhitespace(&input);
   if (input.empty()) {
-    return CspSourceExpression(kUnknown);
+    return CspSourceExpression();
   }
 
   if (input.size() > 2 && input[0] == '\'' && Last(input) == '\'') {
     return ParseQuoted(input.substr(1, input.size() - 2));
   }
-
-  // Check for scheme-source.
-  if (input.size() >= 2 && Last(input) == ':') {
-    // scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
-    bool is_scheme = true;
-    if (IsAsciiAlpha(input[0])) {
-      for (size_t i = 1; i < (input.size() - 1); ++i) {
-        char c = input[i];
-        if (!IsAsciiAlphaNumeric(c) && (c != '+') && (c != '-') && (c != '.')) {
-          is_scheme = false;
-          break;
-        }
+  
+  CspSourceExpression result;
+  if (!result.TryParseScheme(&input)) {
+    // This looks like a host-source, and we have already skipped 
+    // over a scheme, and ://, if any.
+    // From the spec:
+    // host-source = [ scheme-part "://" ] host-part [ port-part ] [ path-part ]
+    
+    // host-part   = "*" / [ "*." ] 1*host-char *( "." 1*host-char )
+    // host-char   = ALPHA / DIGIT / "-"
+    // port-part   = ":" ( 1*DIGIT / "*" )
+    //
+    // Key bit from path-part: it's either empty or starts with /
+    result.kind_ = kHostSource;    
+    if (input.empty()) {
+      return CspSourceExpression();
+    }
+    
+    if (input.starts_with("*.")) {
+      result.mutable_url_data()->host_part = "*.";
+      input.remove_prefix(2);
+    } else if (input.starts_with("*")) {
+      result.mutable_url_data()->host_part = "*";
+      input.remove_prefix(1);
+    }
+    
+    while (!input.empty()
+           && (IsAsciiAlphaNumeric(input[0]) 
+               || (input[0] == '-') || (input[0] == '.'))) {
+      result.mutable_url_data()->host_part.push_back(input[0]);
+      input.remove_prefix(1);
+    }
+    
+    // Verify accumulated host-part is valid.
+    StringPiece host_part(result.url_data().host_part);    
+    if (host_part.empty()) {
+      return CspSourceExpression();
+    }
+    
+    if (host_part.starts_with("*")) {
+      if (!host_part.starts_with("*.") && (host_part != "*")) {
+        return CspSourceExpression();
       }
-    } else {
-      is_scheme = false;
     }
-
-    if (is_scheme) {
-      return CspSourceExpression(kSchemeSource, input);
+    
+    // Start on port-part, if any
+    if (input.starts_with(":")) {
+      input.remove_prefix(1);
+      if (input.empty()) {
+        return CspSourceExpression();
+      }
+      
+      if (IsAsciiDigit(input[0])) {
+        while (!input.empty() && IsAsciiDigit(input[0])) {
+          result.mutable_url_data()->port_part.push_back(input[0]);
+          input.remove_prefix(1);
+        }
+      } else if (input[0] == '*') {
+        result.mutable_url_data()->port_part = "*";
+        input.remove_prefix(1);
+      } else {
+        return CspSourceExpression();
+      }
     }
+    
+    // path-part, if any.
+    if (!input.empty() && input[0] != '/') {
+      return CspSourceExpression();
+    }
+      
+    input.CopyToString(&result.mutable_url_data()->path_part);
   }
-
-  // Assume host-source. It might make sense to split this down further here,
-  // that will become clear once the actual URL matching algorithm is
-  // implemented.
-  return CspSourceExpression(kHostSource, input);
+  
+  return result;
 }
 
 CspSourceExpression CspSourceExpression::ParseQuoted(StringPiece input) {
@@ -120,11 +216,22 @@ std::unique_ptr<CspSourceList> CspSourceList::Parse(StringPiece input) {
   TrimCspWhitespace(&input);
   StringPieceVector tokens;
   SplitStringPieceToVector(input, " ", &tokens, true);
+  
+  // A single token of 'none' is equivalent to an empty list, and means reject.
+  //
+  // TODO(morlovich): There is some inconsistency with respect to the empty list
+  // case in the spec; the grammar doesn't permit one, but the algorithm 
+  // "Does url match source list in origin with redirect count?" assigns it
+  // semantics.    
+  if (tokens.size() == 1 && StringCaseEqual(tokens[0], "'none'")) {
+    return result;
+  }
+  
   for (StringPiece token : tokens) {
     TrimCspWhitespace(&token);
     CspSourceExpression expr = CspSourceExpression::Parse(token);
     if (expr.kind() != CspSourceExpression::kUnknown) {
-      result->expressions_.push_back(expr);
+      result->expressions_.push_back(std::move(expr));
     }
   }
 

--- a/net/instaweb/rewriter/csp_test.cc
+++ b/net/instaweb/rewriter/csp_test.cc
@@ -18,6 +18,7 @@
 
 #include "net/instaweb/rewriter/public/csp.h"
 
+#include <iostream>
 #include <memory>
 
 #include "pagespeed/kernel/base/basictypes.h"
@@ -27,6 +28,17 @@
 
 namespace net_instaweb {
 
+// Help gTest printing.
+  
+::std::ostream& operator<<(::std::ostream& os, const CspSourceExpression& expr) {
+  return os << expr.DebugString();
+}
+
+::std::ostream& operator<<(::std::ostream& os, 
+                           const CspSourceExpression::UrlData& url_data) {
+  return os << url_data.DebugString();
+}
+  
 namespace {
 
 TEST(CspParseSourceTest, Quoted) {
@@ -65,31 +77,51 @@ TEST(CspParseSourceTest, NonQuoted) {
       CspSourceExpression::Parse("   "));
 
   EXPECT_EQ(
-      CspSourceExpression(CspSourceExpression::kSchemeSource, "https:"),
+      CspSourceExpression(CspSourceExpression::kSchemeSource, 
+                          CspSourceExpression::UrlData("https", "", "", "")),
       CspSourceExpression::Parse(" https:"));
 
   EXPECT_EQ(
-      CspSourceExpression(CspSourceExpression::kSchemeSource,
-                          "weird-schema+-1.0:"),
-      CspSourceExpression::Parse("weird-schema+-1.0:"));
+      CspSourceExpression(
+            CspSourceExpression::kSchemeSource,
+            CspSourceExpression::UrlData("weird-scheme+-1.0", "", "", "")),
+      CspSourceExpression::Parse("weird-scheme+-1.0:"));
 
   EXPECT_EQ(
-      CspSourceExpression(CspSourceExpression::kHostSource, "*.example.com"),
+      CspSourceExpression(
+            CspSourceExpression::kHostSource, 
+            CspSourceExpression::UrlData("", "*.example.com", "", "")),
       CspSourceExpression::Parse("*.example.com"));
 
   EXPECT_EQ(
-      CspSourceExpression(CspSourceExpression::kHostSource,
-                          "http://www.example.com/dir"),
+      CspSourceExpression(
+            CspSourceExpression::kHostSource,
+            CspSourceExpression::UrlData("http", "www.example.com", "", 
+                                         "/dir")),
       CspSourceExpression::Parse("http://www.example.com/dir"));
 
   EXPECT_EQ(
-      CspSourceExpression(CspSourceExpression::kHostSource,
-                          "http://www.example.com/dir/file.js"),
+      CspSourceExpression(
+            CspSourceExpression::kHostSource,
+            CspSourceExpression::UrlData("http", "www.example.com", "", 
+                                         "/dir/file.js")),
       CspSourceExpression::Parse("http://www.example.com/dir/file.js"));
 
   EXPECT_EQ(
-      CspSourceExpression(CspSourceExpression::kHostSource, "*"),
+      CspSourceExpression(CspSourceExpression::kHostSource, 
+                          CspSourceExpression::UrlData("", "*", "", "")),
       CspSourceExpression::Parse("*"));
+}
+
+TEST(CspParseSourceListTest, None) {
+  // Special keyword "none", semantically equivalent to an empty 
+  // expressions list.
+  std::unique_ptr<CspSourceList> n1(CspSourceList::Parse(" 'None'  "));
+  std::unique_ptr<CspSourceList> n2(CspSourceList::Parse("'none'"));
+  ASSERT_TRUE(n1 != nullptr);
+  ASSERT_TRUE(n2 != nullptr);
+  EXPECT_TRUE(n1->expressions().empty());
+  EXPECT_TRUE(n2->expressions().empty());
 }
 
 TEST(CspParseTest, Empty) {
@@ -106,7 +138,8 @@ TEST(CspParseTest, Basic) {
       policy->SourceListFor(CspDirective::kDefaultSrc)->expressions();
   ASSERT_EQ(1, default_src.size());
   EXPECT_EQ(CspSourceExpression::kHostSource, default_src[0].kind());
-  EXPECT_EQ("*", default_src[0].param());
+  EXPECT_EQ(CspSourceExpression::UrlData("", "*", "", ""),
+            default_src[0].url_data());
 
   ASSERT_TRUE(policy->SourceListFor(CspDirective::kScriptSrc) != nullptr);
   const std::vector<CspSourceExpression>& script_src =

--- a/net/instaweb/rewriter/csp_test.cc
+++ b/net/instaweb/rewriter/csp_test.cc
@@ -77,6 +77,10 @@ TEST(CspParseSourceTest, Quoted) {
   EXPECT_EQ(
       CspSourceExpression(CspSourceExpression::kUnknown),
       CspSourceExpression::Parse("'nonce-qwertyu12345'"));
+
+  EXPECT_EQ(
+      CspSourceExpression(CspSourceExpression::kUnknown),
+      CspSourceExpression::Parse("''"));
 }
 
 TEST(CspParseSourceTest, NonQuoted) {

--- a/net/instaweb/rewriter/csp_test.cc
+++ b/net/instaweb/rewriter/csp_test.cc
@@ -30,7 +30,8 @@ namespace net_instaweb {
 
 // Help gTest printing.
 
-::std::ostream& operator<<(::std::ostream& os, const CspSourceExpression& expr) {
+::std::ostream& operator<<(::std::ostream& os,
+                           const CspSourceExpression& expr) {
   return os << expr.DebugString();
 }
 

--- a/net/instaweb/rewriter/public/csp.h
+++ b/net/instaweb/rewriter/public/csp.h
@@ -20,8 +20,8 @@
 // Content-Security-Policy that's relevant for PageSpeed Automatic.
 // CspContext is the main class.
 
-#ifndef NET_INSTAWEB_REWRITER_CSP_H_
-#define NET_INSTAWEB_REWRITER_CSP_H_
+#ifndef NET_INSTAWEB_REWRITER_PUBLIC_CSP_H_
+#define NET_INSTAWEB_REWRITER_PUBLIC_CSP_H_
 
 #include <memory>
 #include <string>
@@ -40,26 +40,26 @@ class CspSourceExpression {
     kUnsafeInline, kUnsafeEval, kStrictDynamic, kUnsafeHashedAttributes,
     kUnknown /* includes hash-or-nonce */
   };
-  
+
   struct UrlData {
     UrlData() {}
-    UrlData(StringPiece in_scheme, StringPiece in_host, 
+    UrlData(StringPiece in_scheme, StringPiece in_host,
             StringPiece in_port, StringPiece in_path)
         : scheme_part(in_scheme.as_string()),
           host_part(in_host.as_string()),
           port_part(in_port.as_string()),
           path_part(in_path.as_string()) {}
-    
+
     GoogleString scheme_part;  // doesn't include :
     GoogleString host_part;
     GoogleString port_part;
     GoogleString path_part;
-    
+
     GoogleString DebugString() const {
-      return StrCat("scheme:", scheme_part, " host:", host_part, 
+      return StrCat("scheme:", scheme_part, " host:", host_part,
                     " port:", port_part, " path:", path_part);
     }
-    
+
     bool operator==(const UrlData& other) const {
       return scheme_part == other.scheme_part &&
              host_part == other.host_part &&
@@ -75,9 +75,9 @@ class CspSourceExpression {
   }
 
   static CspSourceExpression Parse(StringPiece input);
-  
+
   GoogleString DebugString() const {
-    return StrCat("kind:", IntegerToString(kind_), 
+    return StrCat("kind:", IntegerToString(kind_),
                   " url_data:{", url_data().DebugString(), "}");
   }
 
@@ -86,30 +86,30 @@ class CspSourceExpression {
   }
 
   Kind kind() const { return kind_; }
-  
+
   const UrlData& url_data() const {
     if (url_data_.get() == nullptr) {
       url_data_.reset(new UrlData());
     }
     return *url_data_.get();
-  }  
+  }
 
  private:
   // input here is without the quotes, and non-empty.
   static CspSourceExpression ParseQuoted(StringPiece input);
-  
-  // Tries to see if the input is either an entire scheme-source, or the 
-  // scheme-part portion of a host-source, filling in url_data->scheme_part 
+
+  // Tries to see if the input is either an entire scheme-source, or the
+  // scheme-part portion of a host-source, filling in url_data->scheme_part
   // appropriately. Returns true only if this is a scheme-source, however.
   bool TryParseScheme(StringPiece* input);
-  
+
   UrlData* mutable_url_data() {
     if (url_data_.get() == nullptr) {
       url_data_.reset(new UrlData());
     }
     return url_data_.get();
   }
-  
+
   Kind kind_;
   mutable std::unique_ptr<UrlData> url_data_;
 };
@@ -176,4 +176,4 @@ class CspContext {
 
 }  // namespace net_instaweb
 
-#endif  // NET_INSTAWEB_REWRITER_CSP_H_
+#endif  // NET_INSTAWEB_REWRITER_PUBLIC_CSP_H_

--- a/net/instaweb/rewriter/public/csp_directive.h
+++ b/net/instaweb/rewriter/public/csp_directive.h
@@ -18,8 +18,8 @@
 //
 // Enum for Content-Security-Policy directives
 
-#ifndef NET_INSTAWEB_REWRITER_CSP_DIRECTIVE_H_
-#define NET_INSTAWEB_REWRITER_CSP_DIRECTIVE_H_
+#ifndef NET_INSTAWEB_REWRITER_PUBLIC_CSP_DIRECTIVE_H_
+#define NET_INSTAWEB_REWRITER_PUBLIC_CSP_DIRECTIVE_H_
 
 #include <memory>
 #include <string>
@@ -71,4 +71,4 @@ CspDirective LookupCspDirective(StringPiece name);
 
 }  // namespace net_instaweb
 
-#endif  // NET_INSTAWEB_REWRITER_CSP_DIRECTIVE_H_
+#endif  // NET_INSTAWEB_REWRITER_PUBLIC_CSP_DIRECTIVE_H_

--- a/pagespeed/kernel/base/string_util.h
+++ b/pagespeed/kernel/base/string_util.h
@@ -580,6 +580,10 @@ inline bool IsHexDigit(char c) {
          ('a' <= c && c <= 'f');
 }
 
+inline bool IsDecimalDigit(char c) {
+  return (c >= '0' && c <= '9');
+}
+
 // In-place removal of leading and trailing HTML whitespace.  Returns true if
 // any whitespace was trimmed.
 bool TrimWhitespace(StringPiece* str);


### PR DESCRIPTION
This is a bit complicated since those aren't URLs proper, as they can have wildcards in spot and 
can drop the scheme.
