### PR TITLE
Clean the response headers when sending kNotInCache

### DIFF
--- a/net/instaweb/rewriter/in_place_rewrite_context.cc
+++ b/net/instaweb/rewriter/in_place_rewrite_context.cc
@@ -139,6 +139,7 @@ void RecordingFetch::HandleHeadersComplete() {
       // kNotInCacheStatus instead to fall back to the server's native method of
       // serving the url and indicate we do want it recorded.
       if (!response_headers()->IsErrorStatus()) {
+        response_headers()->Clear();
         response_headers()->set_status_code(
             CacheUrlAsyncFetcher::kNotInCacheStatus);
       }

--- a/net/instaweb/rewriter/in_place_rewrite_context.cc
+++ b/net/instaweb/rewriter/in_place_rewrite_context.cc
@@ -139,6 +139,9 @@ void RecordingFetch::HandleHeadersComplete() {
       // kNotInCacheStatus instead to fall back to the server's native method of
       // serving the url and indicate we do want it recorded.
       if (!response_headers()->IsErrorStatus()) {
+        // Clear the response headers to ensure stray headers do not end up
+        // being put on the wire:
+        // https://github.com/pagespeed/mod_pagespeed/issues/1496
         response_headers()->Clear();
         response_headers()->set_status_code(
             CacheUrlAsyncFetcher::kNotInCacheStatus);


### PR DESCRIPTION
When we send out a 501 in the IPRO path for a http cache
hit, clear the response headers so we do not leave
behind stray headers.

Fixes https://github.com/pagespeed/mod_pagespeed/issues/1496