### PR TITLE
CSP prep: add a notion of input role, and wire it to CreateInputResource

### DIFF
--- a/net/instaweb/rewriter/cache_extender.cc
+++ b/net/instaweb/rewriter/cache_extender.cc
@@ -171,15 +171,19 @@ void CacheExtender::StartElementImpl(HtmlElement* element) {
   resource_tag_scanner::ScanElement(element, driver()->options(), &attributes);
   for (int i = 0, n = attributes.size(); i < n; ++i) {
     bool may_load = false;
+    RewriteDriver::InputRole input_role = RewriteDriver::InputRole::kUnknown;
     switch (attributes[i].category) {
       case semantic_type::kStylesheet:
         may_load = driver()->MayCacheExtendCss();
+        input_role = RewriteDriver::InputRole::kStyle;
         break;
       case semantic_type::kImage:
         may_load = driver()->MayCacheExtendImages();
+        input_role = RewriteDriver::InputRole::kImg;
         break;
       case semantic_type::kScript:
         may_load = driver()->MayCacheExtendScripts();
+        input_role = RewriteDriver::InputRole::kScript;
         break;
       default:
         // Does the url in the attribute end in .pdf, ignoring query params?
@@ -202,7 +206,7 @@ void CacheExtender::StartElementImpl(HtmlElement* element) {
     // resources are non-cacheable or privately cacheable.
     if (driver()->IsRewritable(element)) {
       ResourcePtr input_resource(CreateInputResourceOrInsertDebugComment(
-          attributes[i].url->DecodedValueOrNull(), element));
+          attributes[i].url->DecodedValueOrNull(), input_role, element));
       if (input_resource.get() == NULL) {
         continue;
       }

--- a/net/instaweb/rewriter/cache_extender_test.cc
+++ b/net/instaweb/rewriter/cache_extender_test.cc
@@ -278,7 +278,8 @@ class CacheExtenderTest : public RewriteTestBase {
         "<script src='http://unauth.example.com/unauth.js'></script>";
     GoogleUrl gurl("http://unauth.example.com/unauth.xxx");
     const GoogleString kDebugMessage = StrCat(
-        "<!--", RewriteDriver::GenerateUnauthorizedDomainDebugComment(gurl),
+        "<!--", RewriteDriver::GenerateUnauthorizedDomainDebugComment(
+                    gurl, RewriteDriver::InputRole::kScript),
         "-->");
     const char kCssReference[] =
         "<link rel=stylesheet href='http://unauth.example.com/unauth.css'>";

--- a/net/instaweb/rewriter/collect_dependencies_filter.cc
+++ b/net/instaweb/rewriter/collect_dependencies_filter.cc
@@ -324,8 +324,15 @@ void CollectDependenciesFilter::StartElementImpl(HtmlElement* element) {
         }
       }
 
+      // Code below relies on this being the guard here for it to be safe.
+      CHECK(attributes[i].category == semantic_type::kStylesheet ||
+            attributes[i].category == semantic_type::kScript);
+      RewriteDriver::InputRole role =
+          (attributes[i].category == semantic_type::kStylesheet
+           ? RewriteDriver::InputRole::kStyle
+           : RewriteDriver::InputRole::kScript);
       ResourcePtr resource(
-          CreateInputResourceOrInsertDebugComment(url, element));
+          CreateInputResourceOrInsertDebugComment(url, role, element));
       if (resource.get() == nullptr) {
         // TODO(morlovich): This may mean a valid 3rd party resource;
         // we also probably don't want a warning in that case.

--- a/net/instaweb/rewriter/common_filter.cc
+++ b/net/instaweb/rewriter/common_filter.cc
@@ -160,6 +160,7 @@ void CommonFilter::ResolveUrl(StringPiece input_url, GoogleUrl* out_url) {
 }
 
 ResourcePtr CommonFilter::CreateInputResource(StringPiece input_url,
+                                              RewriteDriver::InputRole role,
                                               bool* is_authorized) {
   *is_authorized = true;  // Must be false iff input_url is not authorized.
   ResourcePtr resource;
@@ -172,19 +173,22 @@ ResourcePtr CommonFilter::CreateInputResource(StringPiece input_url,
         (IntendedForInlining()
          ? RewriteDriver::kIntendedForInlining
          : RewriteDriver::kIntendedForGeneral),
+        role,
         is_authorized);
   }
   return resource;
 }
 
 ResourcePtr CommonFilter::CreateInputResourceOrInsertDebugComment(
-    StringPiece input_url, HtmlElement* element) {
+    StringPiece input_url, RewriteDriver::InputRole role,
+    HtmlElement* element) {
   DCHECK(element != NULL);
   bool is_authorized;
-  ResourcePtr input_resource(CreateInputResource(input_url, &is_authorized));
+  ResourcePtr input_resource(
+      CreateInputResource(input_url, role, &is_authorized));
   if (input_resource.get() == NULL) {
     if (!is_authorized) {
-      driver()->InsertUnauthorizedDomainDebugComment(input_url, element);
+      driver()->InsertUnauthorizedDomainDebugComment(input_url, role, element);
     }
   }
   return input_resource;

--- a/net/instaweb/rewriter/common_filter_test.cc
+++ b/net/instaweb/rewriter/common_filter_test.cc
@@ -70,7 +70,8 @@ class CommonFilterTest : public RewriteTestBase {
 
   bool CanRewriteResource(CommonFilter* filter, const StringPiece& url) {
     bool unused;
-    ResourcePtr resource(filter->CreateInputResource(url, &unused));
+    ResourcePtr resource(filter->CreateInputResource(
+        url, RewriteDriver::InputRole::kUnknown, &unused));
     return (resource.get() != NULL);
   }
 

--- a/net/instaweb/rewriter/css_combine_filter.cc
+++ b/net/instaweb/rewriter/css_combine_filter.cc
@@ -178,7 +178,7 @@ class CssCombineFilter::Context : public RewriteContext {
 
   bool AddElement(HtmlElement* element, HtmlElement::Attribute* href) {
     ResourcePtr resource(filter_->CreateInputResourceOrInsertDebugComment(
-        href->DecodedValueOrNull(), element));
+        href->DecodedValueOrNull(), RewriteDriver::InputRole::kStyle, element));
     if (resource.get() == NULL) {
       return false;
     }

--- a/net/instaweb/rewriter/css_filter.cc
+++ b/net/instaweb/rewriter/css_filter.cc
@@ -544,7 +544,10 @@ bool CssFilter::Context::FallbackRewriteUrls(
       CHECK(url.IsAnyValid()) << it->first;
       // Add slot.
       bool is_authorized;
-      ResourcePtr resource = Driver()->CreateInputResource(url, &is_authorized);
+      // This can be both an image or CSS at very least, so have to be
+      // conservative wrt to policy.
+      ResourcePtr resource = Driver()->CreateInputResource(
+          url, RewriteDriver::InputRole::kUnknown, &is_authorized);
       if (resource.get()) {
         ResourceSlotPtr slot(new AssociationSlot(
             resource, fallback_transformer_->map(), url.Spec()));
@@ -1053,7 +1056,7 @@ void CssFilter::StartExternalRewrite(HtmlElement* link,
   }
   // Create the input resource for the slot.
   ResourcePtr input_resource(CreateInputResourceOrInsertDebugComment(
-      src->DecodedValueOrNull(), link));
+      src->DecodedValueOrNull(), RewriteDriver::InputRole::kStyle, link));
   if (input_resource.get() == NULL) {
     return;
   }

--- a/net/instaweb/rewriter/css_filter_test.cc
+++ b/net/instaweb/rewriter/css_filter_test.cc
@@ -2287,7 +2287,8 @@ TEST_F(CssFilterTest, UnauthorizedCssResource) {
   GoogleUrl gurl("http://unauth.example.com/style.css");
   DebugWithMessage(StrCat(
       "<!--",
-      RewriteDriver::GenerateUnauthorizedDomainDebugComment(gurl),
+      RewriteDriver::GenerateUnauthorizedDomainDebugComment(
+          gurl, RewriteDriver::InputRole::kStyle),
       "-->"));
   ValidateRewriteExternalCssUrl("unauth", gurl.Spec(),
                                 kInputStyle, kInputStyle, kExpectNoChange);

--- a/net/instaweb/rewriter/css_image_rewriter.cc
+++ b/net/instaweb/rewriter/css_image_rewriter.cc
@@ -95,8 +95,8 @@ bool CssImageRewriter::RewriteImport(RewriteContext* parent,
                                      CssHierarchy* hierarchy,
                                      bool* is_authorized) {
   GoogleUrl import_url(hierarchy->url());
-  ResourcePtr resource = driver()->CreateInputResource(import_url,
-                                                       is_authorized);
+  ResourcePtr resource = driver()->CreateInputResource(
+      import_url, RewriteDriver::InputRole::kStyle, is_authorized);
   if (resource.get() == NULL) {
     return false;
   }
@@ -115,8 +115,8 @@ bool CssImageRewriter::RewriteImage(int64 image_inline_max_bytes,
                                     size_t value_index,
                                     bool* is_authorized) {
   const RewriteOptions* options = driver()->options();
-  ResourcePtr resource = driver()->CreateInputResource(original_url,
-                                                       is_authorized);
+  ResourcePtr resource = driver()->CreateInputResource(
+      original_url, RewriteDriver::InputRole::kImg, is_authorized);
   if (resource.get() == NULL) {
     return false;
   }

--- a/net/instaweb/rewriter/css_inline_filter.cc
+++ b/net/instaweb/rewriter/css_inline_filter.cc
@@ -82,6 +82,9 @@ class CssInlineFilter::Context : public InlineRewriteContext {
   }
 
   virtual const char* id() const { return filter_->id_; }
+  RewriteDriver::InputRole InputRole() const override {
+    return RewriteDriver::InputRole::kStyle;
+  }
 
  private:
   CssInlineFilter* filter_;
@@ -162,7 +165,8 @@ void CssInlineFilter::EndElementImpl(HtmlElement* element) {
 
 ResourcePtr CssInlineFilter::CreateResource(const char* url,
                                             bool* is_authorized) {
-  return CreateInputResource(url, is_authorized);
+  return CreateInputResource(
+      url, RewriteDriver::InputRole::kStyle, is_authorized);
 }
 
 bool CssInlineFilter::HasClosingStyleTag(StringPiece contents) {

--- a/net/instaweb/rewriter/css_inline_filter_test.cc
+++ b/net/instaweb/rewriter/css_inline_filter_test.cc
@@ -341,7 +341,8 @@ TEST_F(CssInlineFilterTest, DoNotInlineCssDifferentDomain) {
   GoogleUrl gurl("http://unauth.com/styles.css");
   TestNoInlineCss("http://www.example.com/index.html", gurl.Spec().as_string(),
                   "", "BODY { color: red; }\n", "",
-                  RewriteDriver::GenerateUnauthorizedDomainDebugComment(gurl));
+                  RewriteDriver::GenerateUnauthorizedDomainDebugComment(
+                      gurl, RewriteDriver::InputRole::kStyle));
   EXPECT_EQ(0,
             statistics()->GetVariable(CssInlineFilter::kNumCssInlined)->Get());
 }

--- a/net/instaweb/rewriter/css_summarizer_base.cc
+++ b/net/instaweb/rewriter/css_summarizer_base.cc
@@ -449,8 +449,9 @@ void CssSummarizerBase::StartExternalRewrite(
     HtmlElement* link, HtmlElement::Attribute* src, StringPiece rel) {
   // Create the input resource for the slot.
   bool is_authorized;
-  ResourcePtr input_resource(CreateInputResource(src->DecodedValueOrNull(),
-                                                 &is_authorized));
+  ResourcePtr input_resource(CreateInputResource(
+      src->DecodedValueOrNull(), RewriteDriver::InputRole::kStyle,
+      &is_authorized));
   if (input_resource.get() == NULL) {
     // Record a failure, so the subclass knows of it.
     summaries_.push_back(SummaryInfo());

--- a/net/instaweb/rewriter/fake_filter.cc
+++ b/net/instaweb/rewriter/fake_filter.cc
@@ -100,7 +100,8 @@ void FakeFilter::StartElementImpl(HtmlElement* element) {
   for (int i = 0, n = attributes.size(); i < n; ++i) {
     if (attributes[i].category == category_) {
       ResourcePtr input_resource(CreateInputResourceOrInsertDebugComment(
-          attributes[i].url->DecodedValueOrNull(), element));
+          attributes[i].url->DecodedValueOrNull(),
+          RewriteDriver::InputRole::kUnknown, element));
       if (input_resource.get() == NULL) {
         return;
       }

--- a/net/instaweb/rewriter/image_combine_filter.cc
+++ b/net/instaweb/rewriter/image_combine_filter.cc
@@ -1179,7 +1179,8 @@ bool ImageCombineFilter::AddCssBackgroundContext(
                                                    decls));
   future->Initialize(values->at(value_index));
 
-  ResourcePtr resource = CreateInputResource(url_piece, is_authorized);
+  ResourcePtr resource = CreateInputResource(
+      url_piece, RewriteDriver::InputRole::kImg, is_authorized);
   if (resource.get() == NULL) {
     return false;
   }

--- a/net/instaweb/rewriter/image_rewrite_filter.cc
+++ b/net/instaweb/rewriter/image_rewrite_filter.cc
@@ -1481,7 +1481,7 @@ void ImageRewriteFilter::BeginRewriteImageUrl(HtmlElement* element,
   EncodeUserAgentIntoResourceContext(resource_context.get());
 
   ResourcePtr input_resource(CreateInputResourceOrInsertDebugComment(
-      src->DecodedValueOrNull(), element));
+      src->DecodedValueOrNull(), RewriteDriver::InputRole::kImg, element));
   if (input_resource.get() == NULL) {
     return;
   }

--- a/net/instaweb/rewriter/image_rewrite_filter_test.cc
+++ b/net/instaweb/rewriter/image_rewrite_filter_test.cc
@@ -3991,7 +3991,8 @@ TEST_F(ImageRewriteTest, DebugMessageUnauthorized) {
       "noise, and has no animation.-->"
       "<img src=", kUnauthorizedPath, ">",
       "<!--",
-      RewriteDriver::GenerateUnauthorizedDomainDebugComment(unauth_gurl),
+      RewriteDriver::GenerateUnauthorizedDomainDebugComment(
+          unauth_gurl, RewriteDriver::InputRole::kImg),
       "-->");
 
   EXPECT_THAT(output_buffer_, HasSubstr(expected));

--- a/net/instaweb/rewriter/inline_rewrite_context.cc
+++ b/net/instaweb/rewriter/inline_rewrite_context.cc
@@ -58,7 +58,7 @@ bool InlineRewriteContext::StartInlining() {
       return true;
     }
     if (!is_authorized) {
-      driver->InsertUnauthorizedDomainDebugComment(url, element_);
+      driver->InsertUnauthorizedDomainDebugComment(url, InputRole(), element_);
     }
   } else if (driver->DebugMode()) {
     driver->InsertDebugComment("Following resource not rewritten because its "
@@ -70,7 +70,7 @@ bool InlineRewriteContext::StartInlining() {
 
 ResourcePtr InlineRewriteContext::CreateResource(const char* url,
                                                  bool* is_authorized) {
-  return filter_->CreateInputResource(url, is_authorized);
+  return filter_->CreateInputResource(url, InputRole(), is_authorized);
 }
 
 bool InlineRewriteContext::Partition(OutputPartitions* partitions,

--- a/net/instaweb/rewriter/javascript_filter.cc
+++ b/net/instaweb/rewriter/javascript_filter.cc
@@ -481,7 +481,7 @@ void JavascriptFilter::RewriteExternalScript(
     HtmlElement* script_in_progress, HtmlElement::Attribute* script_src) {
   const StringPiece script_url(script_src->DecodedValueOrNull());
   ResourcePtr resource(CreateInputResourceOrInsertDebugComment(
-      script_url, script_in_progress));
+      script_url, RewriteDriver::InputRole::kScript, script_in_progress));
   if (resource.get() == nullptr) {
     return;
   }

--- a/net/instaweb/rewriter/javascript_filter_test.cc
+++ b/net/instaweb/rewriter/javascript_filter_test.cc
@@ -227,7 +227,8 @@ TEST_P(JavascriptFilterTest, DebugForUnauthorizedDomain) {
   GoogleUrl gurl(kUnauthorizedJs);
   StrAppend(&html_output,
             "<!--",
-            RewriteDriver::GenerateUnauthorizedDomainDebugComment(gurl),
+            RewriteDriver::GenerateUnauthorizedDomainDebugComment(
+                gurl, RewriteDriver::InputRole::kScript),
             "-->"
             "\n");
   html_output = AddHtmlBody(html_output);

--- a/net/instaweb/rewriter/js_combine_filter.cc
+++ b/net/instaweb/rewriter/js_combine_filter.cc
@@ -220,7 +220,8 @@ class JsCombineFilter::Context : public RewriteContext {
   // Create and add the slot that corresponds to this element.
   bool AddElement(HtmlElement* element, HtmlElement::Attribute* href) {
     ResourcePtr resource(filter_->CreateInputResourceOrInsertDebugComment(
-        href->DecodedValueOrNull(), element));
+        href->DecodedValueOrNull(), RewriteDriver::InputRole::kScript,
+        element));
     if (resource.get() == NULL) {
       return false;
     }

--- a/net/instaweb/rewriter/js_combine_filter_test.cc
+++ b/net/instaweb/rewriter/js_combine_filter_test.cc
@@ -467,7 +467,8 @@ TEST_F(JsFilterAndCombineFilterTest, TestCrossDomainRejectUnauthEnabled) {
   server_context()->ComputeSignature(options());
   GoogleUrl gurl(StrCat(other_domain_, kJsUrl1));
   GoogleString debug_message = StrCat(
-      "<!--", RewriteDriver::GenerateUnauthorizedDomainDebugComment(gurl),
+      "<!--", RewriteDriver::GenerateUnauthorizedDomainDebugComment(
+                  gurl, RewriteDriver::InputRole::kScript),
       "-->");
   // Note that we get the debug message twice, once for the combining attempt
   // and once for the rewriting attempt, both of which fail due to the domain

--- a/net/instaweb/rewriter/js_inline_filter.cc
+++ b/net/instaweb/rewriter/js_inline_filter.cc
@@ -56,6 +56,9 @@ class JsInlineFilter::Context : public InlineRewriteContext {
   }
 
   virtual const char* id() const { return RewriteOptions::kJavascriptInlineId; }
+  RewriteDriver::InputRole InputRole() const override {
+    return RewriteDriver::InputRole::kScript;
+  }
 
  private:
   JsInlineFilter* filter_;

--- a/net/instaweb/rewriter/js_inline_filter_test.cc
+++ b/net/instaweb/rewriter/js_inline_filter_test.cc
@@ -247,7 +247,7 @@ TEST_F(JsInlineFilterTest, DoNotInlineJavascriptDifferentDomain) {
                          "",
                          "function id(x) { return x; }\n",
                          RewriteDriver::GenerateUnauthorizedDomainDebugComment(
-                             gurl));
+                             gurl, RewriteDriver::InputRole::kScript));
   EXPECT_EQ(0, statistics()->GetVariable(JsInlineFilter::kNumJsInlined)->Get());
 }
 
@@ -308,7 +308,7 @@ TEST_F(JsInlineFilterTest, DontInlineDisallowed) {
                          "",
                          "function close() { return 'inline!'; }\n",
                          RewriteDriver::GenerateUnauthorizedDomainDebugComment(
-                             gurl));
+                             gurl, RewriteDriver::InputRole::kScript));
 }
 
 TEST_F(JsInlineFilterTest, DoInlineDisallowedIfAllowedWhenInlining) {

--- a/net/instaweb/rewriter/public/common_filter.h
+++ b/net/instaweb/rewriter/public/common_filter.h
@@ -97,14 +97,17 @@ class CommonFilter : public EmptyHtmlFilter {
   // the return value: for example if we are allowing inlining of resources
   // from unauthorized domains we will return non-NULL but *is_authorized will
   // be false; converse cases are possible too (e.g. input_url is a data URI).
-  ResourcePtr CreateInputResource(StringPiece input_url, bool* is_authorized);
+  ResourcePtr CreateInputResource(StringPiece input_url,
+                                  RewriteDriver::InputRole role,
+                                  bool* is_authorized);
 
   // Similar to CreateInputResource except that if the input_url is not
   // authorized we insert a debug comment after the given element if possible
   // (debug is enabled and the element is writable). The returned ResourcePtr
   // is guaranteed to be non-NULL iff the input_url is authorized.
-  ResourcePtr CreateInputResourceOrInsertDebugComment(StringPiece input_url,
-                                                      HtmlElement* element);
+  ResourcePtr CreateInputResourceOrInsertDebugComment(
+      StringPiece input_url, RewriteDriver::InputRole role,
+      HtmlElement* element);
 
   // Resolves input_url based on the driver's location and any base tag into
   // out_url. If resolution fails, the resulting URL may be invalid.

--- a/net/instaweb/rewriter/public/inline_rewrite_context.h
+++ b/net/instaweb/rewriter/public/inline_rewrite_context.h
@@ -22,6 +22,7 @@
 #include "net/instaweb/rewriter/public/output_resource_kind.h"
 #include "net/instaweb/rewriter/public/resource.h"
 #include "net/instaweb/rewriter/public/rewrite_context.h"
+#include "net/instaweb/rewriter/public/rewrite_driver.h"
 #include "net/instaweb/rewriter/public/server_context.h"
 #include "pagespeed/kernel/base/basictypes.h"
 #include "pagespeed/kernel/base/string.h"
@@ -61,6 +62,7 @@ class InlineRewriteContext : public RewriteContext {
   virtual void RenderInline(const ResourcePtr& resource,
                             const StringPiece& text,
                             HtmlElement* element) = 0;
+  virtual RewriteDriver::InputRole InputRole() const = 0;
 
   // Subclasses of InlineRewriteContext may override this to customize
   // resource creation. Default version just uses

--- a/net/instaweb/rewriter/public/render_blocking_html_computation.h
+++ b/net/instaweb/rewriter/public/render_blocking_html_computation.h
@@ -21,6 +21,7 @@
 
 #include "pagespeed/kernel/base/basictypes.h"
 #include "pagespeed/kernel/base/string.h"
+#include "net/instaweb/rewriter/public/rewrite_driver.h"
 
 namespace net_instaweb {
 

--- a/net/instaweb/rewriter/render_blocking_html_computation.cc
+++ b/net/instaweb/rewriter/render_blocking_html_computation.cc
@@ -100,8 +100,11 @@ void RenderBlockingHtmlComputation::Compute(const GoogleString& url) {
   }
 
   bool is_authorized = false;
+  // Note: this is for HTML, so may be kReconstruction would be appropriate,
+  // but it's tough to audit since this doesn't seem to have any users?
   ResourcePtr resource(
-      parent_driver_->CreateInputResource(gurl, &is_authorized));
+      parent_driver_->CreateInputResource(
+          gurl, RewriteDriver::InputRole::kUnknown, &is_authorized));
   if (resource.get() == NULL) {
     ReportResult(false);
     return;

--- a/net/instaweb/rewriter/resource_combiner_test.cc
+++ b/net/instaweb/rewriter/resource_combiner_test.cc
@@ -257,7 +257,8 @@ class ResourceCombinerTest : public RewriteTestBase {
   bool AddResource(const StringPiece& url, MessageHandler* handler) {
     // See if we have the source loaded, or start loading it.
     bool unused;
-    ResourcePtr resource(filter_->CreateInputResource(url, &unused));
+    ResourcePtr resource(filter_->CreateInputResource(
+        url, RewriteDriver::InputRole::kUnknown, &unused));
     bool ret = false;
 
     if (resource.get() == NULL) {

--- a/net/instaweb/rewriter/resource_slot_test.cc
+++ b/net/instaweb/rewriter/resource_slot_test.cc
@@ -169,7 +169,8 @@ TEST_F(ResourceSlotTest, RenderUpdate) {
 
   GoogleUrl gurl("http://html.parse.test/new_css.css");
   bool unused;
-  ResourcePtr updated(rewrite_driver()->CreateInputResource(gurl, &unused));
+  ResourcePtr updated(rewrite_driver()->CreateInputResource(
+      gurl, RewriteDriver::InputRole::kStyle, &unused));
   slot(0)->SetResource(updated);
   slot(0)->Render();
 

--- a/net/instaweb/rewriter/rewrite_context.cc
+++ b/net/instaweb/rewriter/rewrite_context.cc
@@ -2328,7 +2328,8 @@ ResourcePtr RewriteContext::CreateUrlResource(const StringPiece& input_url) {
   const GoogleUrl resource_url(input_url);
   ResourcePtr resource;
   if (resource_url.IsWebValid()) {
-    resource = Driver()->CreateInputResource(resource_url, &unused);
+    resource = Driver()->CreateInputResource(
+        resource_url, RewriteDriver::InputRole::kReconstruction, &unused);
   }
   return resource;
 }
@@ -2518,7 +2519,8 @@ bool RewriteContext::PrepareFetch(
       }
 
       bool is_authorized;
-      ResourcePtr resource(driver->CreateInputResource(*url, &is_authorized));
+      ResourcePtr resource(driver->CreateInputResource(
+          *url, RewriteDriver::InputRole::kReconstruction, &is_authorized));
       if (resource.get() == NULL) {
         // TODO(jmarantz): bump invalid-input-resource count
         // TODO(matterbury): Add DCHECK(is_authorized) ...

--- a/net/instaweb/rewriter/rewrite_context_test.cc
+++ b/net/instaweb/rewriter/rewrite_context_test.cc
@@ -3002,7 +3002,8 @@ class TestNotifyFilter : public CommonFilter {
     if (href != NULL) {
       bool unused;
       ResourcePtr input_resource(CreateInputResource(
-          href->DecodedValueOrNull(), &unused));
+          href->DecodedValueOrNull(), RewriteDriver::InputRole::kUnknown,
+          &unused));
       ResourceSlotPtr slot(driver()->GetSlot(input_resource, element, href));
       Context* context = new Context(driver(), sync_);
       context->AddSlot(slot);

--- a/net/instaweb/rewriter/rewrite_context_test_base.cc
+++ b/net/instaweb/rewriter/rewrite_context_test_base.cc
@@ -108,7 +108,8 @@ void NestedFilter::Context::RewriteSingle(
       GoogleUrl url(base, pieces[i]);
       if (url.IsWebValid()) {
         bool unused;
-        ResourcePtr resource(Driver()->CreateInputResource(url, &unused));
+        ResourcePtr resource(Driver()->CreateInputResource(
+            url, RewriteDriver::InputRole::kUnknown, &unused));
         if (resource.get() != NULL) {
           ResourceSlotPtr slot(new NestedSlot(resource));
           RewriteContext* nested_context =
@@ -168,8 +169,9 @@ void NestedFilter::StartElementImpl(HtmlElement* element) {
   HtmlElement::Attribute* attr = element->FindAttribute(HtmlName::kHref);
   if (attr != NULL) {
     bool unused;
-    ResourcePtr resource = CreateInputResource(attr->DecodedValueOrNull(),
-                                               &unused);
+    ResourcePtr resource = CreateInputResource(
+        attr->DecodedValueOrNull(), RewriteDriver::InputRole::kUnknown,
+        &unused);
     if (resource.get() != NULL) {
       ResourceSlotPtr slot(driver()->GetSlot(resource, element, attr));
 
@@ -318,8 +320,9 @@ void CombiningFilter::StartElementImpl(HtmlElement* element) {
     HtmlElement::Attribute* href = element->FindAttribute(HtmlName::kHref);
     if (href != NULL) {
       bool unused;
-      ResourcePtr resource(CreateInputResource(href->DecodedValueOrNull(),
-                                               &unused));
+      ResourcePtr resource(CreateInputResource(
+          href->DecodedValueOrNull(), RewriteDriver::InputRole::kUnknown,
+          &unused));
       if (resource.get() != NULL) {
         if (context_.get() == NULL) {
           context_.reset(new Context(driver(), this, scheduler_));

--- a/net/instaweb/rewriter/rewrite_driver.cc
+++ b/net/instaweb/rewriter/rewrite_driver.cc
@@ -2000,16 +2000,18 @@ bool RewriteDriver::MatchesBaseUrl(const GoogleUrl& input_url) const {
 }
 
 ResourcePtr RewriteDriver::CreateInputResource(const GoogleUrl& input_url,
+                                               InputRole role,
                                                bool* is_authorized) {
   return CreateInputResource(
       input_url, kInlineOnlyAuthorizedResources, kIntendedForGeneral,
-      is_authorized);
+      role, is_authorized);
 }
 
 ResourcePtr RewriteDriver::CreateInputResource(
     const GoogleUrl& input_url,
     InlineAuthorizationPolicy inline_authorization_policy,
     IntendedFor intended_for,
+    InputRole role,
     bool* is_authorized) {
   *is_authorized = true;  // Must be false iff we fail b/c of authorization.
   ResourcePtr resource;
@@ -3246,18 +3248,19 @@ void RewriteDriver::InsertDebugComments(
   }
 }
 
-void RewriteDriver::InsertUnauthorizedDomainDebugComment(StringPiece url,
-                                                         HtmlElement* element) {
+void RewriteDriver::InsertUnauthorizedDomainDebugComment(
+    StringPiece url, InputRole role, HtmlElement* element) {
   if (DebugMode() && element != NULL && IsRewritable(element)) {
     GoogleUrl gurl(url);
     InsertNodeAfterNode(
-        element, NewCommentNode(element->parent(),
-                                GenerateUnauthorizedDomainDebugComment(gurl)));
+        element,
+        NewCommentNode(element->parent(),
+                       GenerateUnauthorizedDomainDebugComment(gurl, role)));
   }
 }
 
 GoogleString RewriteDriver::GenerateUnauthorizedDomainDebugComment(
-    const GoogleUrl& gurl) {
+    const GoogleUrl& gurl, InputRole role) {
   GoogleString comment("The preceding resource was not rewritten because ");
   // Note: this is all being defensive - at the time of writing I believe
   // url will always be a valid URL.

--- a/net/instaweb/rewriter/rewrite_driver_test.cc
+++ b/net/instaweb/rewriter/rewrite_driver_test.cc
@@ -1283,8 +1283,8 @@ TEST_F(RewriteDriverTest, RejectDataResourceGracefully) {
   MockRewriteContext context(rewrite_driver());
   GoogleUrl dataUrl("data:");
   bool is_authorized;
-  ResourcePtr resource(rewrite_driver()->CreateInputResource(dataUrl,
-                                                             &is_authorized));
+  ResourcePtr resource(rewrite_driver()->CreateInputResource(
+      dataUrl, RewriteDriver::InputRole::kImg, &is_authorized));
   EXPECT_TRUE(resource.get() == NULL);
   EXPECT_TRUE(is_authorized);
 }
@@ -1301,8 +1301,8 @@ TEST_F(RewriteDriverTest, NoCreateInputResourceUnauthorized) {
   // Test that an unauthorized resource is not allowed to be created.
   GoogleUrl unauthorized_url("http://unauthorized.domain.com/a.js");
   bool is_authorized;
-  ResourcePtr resource(rewrite_driver()->CreateInputResource(unauthorized_url,
-                                                             &is_authorized));
+  ResourcePtr resource(rewrite_driver()->CreateInputResource(
+      unauthorized_url, RewriteDriver::InputRole::kScript, &is_authorized));
   EXPECT_TRUE(resource.get() == NULL);
   EXPECT_FALSE(is_authorized);
 
@@ -1313,6 +1313,7 @@ TEST_F(RewriteDriverTest, NoCreateInputResourceUnauthorized) {
       authorized_url,
       RewriteDriver::kInlineUnauthorizedResources,
       RewriteDriver::kIntendedForGeneral,
+      RewriteDriver::InputRole::kScript,
       &is_authorized));
   EXPECT_TRUE(resource2.get() != NULL);
   EXPECT_TRUE(is_authorized);
@@ -1338,6 +1339,7 @@ TEST_F(RewriteDriverTest, CreateInputResourceUnauthorized) {
       unauthorized_url,
       RewriteDriver::kInlineUnauthorizedResources,
       RewriteDriver::kIntendedForGeneral,
+      RewriteDriver::InputRole::kScript,
       &is_authorized));
   EXPECT_TRUE(resource.get() != NULL);
   EXPECT_FALSE(is_authorized);
@@ -1351,6 +1353,7 @@ TEST_F(RewriteDriverTest, CreateInputResourceUnauthorized) {
       authorized_url,
       RewriteDriver::kInlineUnauthorizedResources,
       RewriteDriver::kIntendedForGeneral,
+      RewriteDriver::InputRole::kScript,
       &is_authorized));
   EXPECT_TRUE(resource2.get() != NULL);
   EXPECT_TRUE(is_authorized);
@@ -1363,6 +1366,7 @@ TEST_F(RewriteDriverTest, CreateInputResourceUnauthorized) {
       unauthorized_url,
       RewriteDriver::kInlineOnlyAuthorizedResources,
       RewriteDriver::kIntendedForGeneral,
+      RewriteDriver::InputRole::kScript,
       &is_authorized));
   EXPECT_TRUE(resource3.get() == NULL);
   EXPECT_FALSE(is_authorized);
@@ -1370,7 +1374,8 @@ TEST_F(RewriteDriverTest, CreateInputResourceUnauthorized) {
   // Test that an unauthorized resource is not created with the default
   // CreateInputResource call.
   ResourcePtr resource4(
-      rewrite_driver()->CreateInputResource(unauthorized_url, &is_authorized));
+      rewrite_driver()->CreateInputResource(
+          unauthorized_url, RewriteDriver::InputRole::kScript, &is_authorized));
   EXPECT_TRUE(resource4.get() == NULL);
   EXPECT_FALSE(is_authorized);
 }
@@ -1393,6 +1398,7 @@ TEST_F(RewriteDriverTest, CreateInputResourceUnauthorizedWithDisallow) {
       unauthorized_url,
       RewriteDriver::kInlineUnauthorizedResources,
       RewriteDriver::kIntendedForGeneral,
+      RewriteDriver::InputRole::kScript,
       &is_authorized));
   EXPECT_TRUE(resource.get() == NULL);
   EXPECT_FALSE(is_authorized);
@@ -1415,6 +1421,7 @@ TEST_F(RewriteDriverTest, AllowWhenInliningOverridesDisallow) {
       js_url,
       RewriteDriver::kInlineUnauthorizedResources,
       RewriteDriver::kIntendedForInlining,
+      RewriteDriver::InputRole::kScript,
       &is_authorized));
   EXPECT_FALSE(resource.get() == NULL);
   EXPECT_TRUE(is_authorized);
@@ -1437,6 +1444,7 @@ TEST_F(RewriteDriverTest, AllowWhenInliningDoesntOverrideDisallow) {
       js_url,
       RewriteDriver::kInlineUnauthorizedResources,
       RewriteDriver::kIntendedForGeneral,
+      RewriteDriver::InputRole::kScript,
       &is_authorized));
   EXPECT_TRUE(resource.get() == NULL);
   EXPECT_FALSE(is_authorized);

--- a/net/instaweb/rewriter/rewrite_single_resource_filter_test.cc
+++ b/net/instaweb/rewriter/rewrite_single_resource_filter_test.cc
@@ -99,8 +99,9 @@ class TestRewriter : public RewriteFilter {
       HtmlElement::Attribute* src = element->FindAttribute(HtmlName::kSrc);
       if (src != NULL) {
         bool unused;
-        ResourcePtr resource = CreateInputResource(src->DecodedValueOrNull(),
-                                                   &unused);
+        ResourcePtr resource = CreateInputResource(
+            src->DecodedValueOrNull(), RewriteDriver::InputRole::kUnknown,
+            &unused);
         if (resource.get() != NULL) {
           ResourceSlotPtr slot(driver()->GetSlot(resource, element, src));
           Context* context = new Context(driver(), this);

--- a/net/instaweb/rewriter/rewrite_test_base.cc
+++ b/net/instaweb/rewriter/rewrite_test_base.cc
@@ -301,7 +301,8 @@ ResourcePtr RewriteTestBase::CreateResource(const StringPiece& base,
   GoogleUrl base_url(base);
   GoogleUrl resource_url(base_url, url);
   bool unused;
-  return rewrite_driver_->CreateInputResource(resource_url, &unused);
+  return rewrite_driver_->CreateInputResource(
+      resource_url, RewriteDriver::InputRole::kUnknown, &unused);
 }
 
 void RewriteTestBase::PopulateDefaultHeaders(

--- a/net/instaweb/rewriter/server_context_test.cc
+++ b/net/instaweb/rewriter/server_context_test.cc
@@ -182,8 +182,8 @@ class ServerContextTest : public RewriteTestBase {
     rewrite_driver()->SetBaseUrlForFetch(url);
     GoogleUrl resource_url(url);
     bool unused;
-    ResourcePtr resource(rewrite_driver()->CreateInputResource(resource_url,
-                                                               &unused));
+    ResourcePtr resource(rewrite_driver()->CreateInputResource(
+        resource_url, RewriteDriver::InputRole::kUnknown, &unused));
     if ((resource.get() != NULL) && !ReadIfCached(resource)) {
       resource.clear();
     }
@@ -305,7 +305,8 @@ class ServerContextTest : public RewriteTestBase {
     GoogleUrl gurl(AbsolutifyUrl(url));
     rewrite_driver()->SetBaseUrlForFetch(kTestDomain);
     bool unused;
-    ResourcePtr resource(rewrite_driver()->CreateInputResource(gurl, &unused));
+    ResourcePtr resource(rewrite_driver()->CreateInputResource(
+        gurl, RewriteDriver::InputRole::kUnknown, &unused));
     VerifyContentsCallback callback(resource, "payload");
     resource->LoadAsync(Resource::kLoadEvenIfNotCacheable,
                         rewrite_driver()->request_context(),
@@ -321,7 +322,8 @@ class ServerContextTest : public RewriteTestBase {
     SetCustomCachingResponse(url, 100, "foo");
     GoogleUrl gurl(AbsolutifyUrl(url));
     bool unused;
-    ResourcePtr resource(rewrite_driver()->CreateInputResource(gurl, &unused));
+    ResourcePtr resource(rewrite_driver()->CreateInputResource(
+        gurl, RewriteDriver::InputRole::kImg, &unused));
     if (!is_background_fetch) {
       rewrite_driver()->SetRequestHeaders(*headers);
     }
@@ -1705,8 +1707,8 @@ TEST_F(ServerContextTest, PartlyFailedFetch) {
   GoogleUrl gurl(abs_url);
   SetBaseUrlForFetch(abs_url);
   bool is_authorized;
-  ResourcePtr resource = rewrite_driver()->CreateInputResource(gurl,
-                                                               &is_authorized);
+  ResourcePtr resource = rewrite_driver()->CreateInputResource(
+      gurl, RewriteDriver::InputRole::kStyle, &is_authorized);
   ASSERT_TRUE(resource.get() != NULL);
   EXPECT_TRUE(is_authorized);
   MockResourceCallback callback(resource, factory()->thread_system());
@@ -1736,15 +1738,16 @@ TEST_F(ServerContextTest, LoadFromFileReadAsync) {
 
   SetBaseUrlForFetch("http://test.com");
   bool unused;
-  ResourcePtr resource(rewrite_driver()->CreateInputResource(test_url,
-                                                             &unused));
+  ResourcePtr resource(rewrite_driver()->CreateInputResource(
+      test_url, RewriteDriver::InputRole::kStyle, &unused));
   VerifyContentsCallback callback(resource, kContents);
   resource->LoadAsync(Resource::kReportFailureIfNotCacheable,
                       rewrite_driver()->request_context(),
                       &callback);
   callback.AssertCalled();
 
-  resource = rewrite_driver()->CreateInputResource(test_url, &unused);
+  resource = rewrite_driver()->CreateInputResource(
+      test_url, RewriteDriver::InputRole::kStyle, &unused);
   VerifyContentsCallback callback2(resource, kContents);
   resource->LoadAsync(Resource::kReportFailureIfNotCacheable,
                       rewrite_driver()->request_context(),
@@ -1784,7 +1787,8 @@ TEST_F(ServerContextTest, FillInPartitionInputInfo) {
   SetFetchResponse(kUrl, headers, kContents);
   GoogleUrl gurl(kUrl);
   bool unused;
-  ResourcePtr resource(rewrite_driver()->CreateInputResource(gurl, &unused));
+  ResourcePtr resource(rewrite_driver()->CreateInputResource(
+      gurl, RewriteDriver::InputRole::kUnknown, &unused));
   VerifyContentsCallback callback(resource, kContents);
   resource->LoadAsync(Resource::kReportFailureIfNotCacheable,
                       rewrite_driver()->request_context(),

--- a/net/instaweb/rewriter/simple_text_filter.cc
+++ b/net/instaweb/rewriter/simple_text_filter.cc
@@ -77,7 +77,7 @@ void SimpleTextFilter::StartElementImpl(HtmlElement* element) {
     return;
   }
   ResourcePtr resource(CreateInputResourceOrInsertDebugComment(
-      attr->DecodedValueOrNull(), element));
+      attr->DecodedValueOrNull(), RewriteDriver::InputRole::kUnknown, element));
   if (resource.get() == NULL) {
     return;
   }

--- a/net/instaweb/rewriter/srcset_slot.cc
+++ b/net/instaweb/rewriter/srcset_slot.cc
@@ -58,7 +58,7 @@ void SrcSetSlotCollection::Initialize(CommonFilter* filter) {
       // inlining unknown; make it explicit somewhere that this relies on
       // them being consistent about it if shared between filters.
       ResourcePtr resource(filter->CreateInputResourceOrInsertDebugComment(
-                               candidates_[i].url, element_));
+          candidates_[i].url, RewriteDriver::InputRole::kImg, element_));
       if (resource.get() != nullptr) {
         candidates_[i].slot = new SrcSetSlot(resource, this, i);
       }

--- a/net/instaweb/rewriter/srcset_slot_test.cc
+++ b/net/instaweb/rewriter/srcset_slot_test.cc
@@ -145,15 +145,18 @@ TEST_F(SrcSetSlotTest, BasicOperation) {
   bool unused;
   GoogleUrl optimized_a("http://www.example.com/dir/a.pagespeed.webp");
   slot0->SetResource(
-    rewrite_driver()->CreateInputResource(optimized_a, &unused));
+    rewrite_driver()->CreateInputResource(
+        optimized_a, RewriteDriver::InputRole::kImg, &unused));
 
   GoogleUrl optimized_b("http://www.example.com/dir/b.pagespeed.webp");
   slot1->SetResource(
-    rewrite_driver()->CreateInputResource(optimized_b, &unused));
+    rewrite_driver()->CreateInputResource(
+        optimized_b, RewriteDriver::InputRole::kImg, &unused));
 
   GoogleUrl optimized_c("http://www.example.com/dir/c.pagespeed.png");
   slot2->SetResource(
-    rewrite_driver()->CreateInputResource(optimized_c, &unused));
+    rewrite_driver()->CreateInputResource(
+        optimized_c, RewriteDriver::InputRole::kImg, &unused));
 
   slot0->set_disable_rendering(true);
   slot0->Render();


### PR DESCRIPTION
This is needed to eventually know which policy to check.
(The enum is similar to SemanticRole, but it was made separate to give
 the cases other than image/style/script clear semantics).

This change itself should be a no-op functionally.

OutputResource methods will likely need a similar treatment.