### PR TITLE
doc: remove non-ascii characters

### DIFF
--- a/html/doc/domains.html
+++ b/html/doc/domains.html
@@ -948,7 +948,7 @@ http {
   The <code>InlineResourcesWithoutExplicitAuthorization</code>
   directive can be used to allow resources from third-party domains to be
   inlined into the HTML without requiring explicit authorization for each
-  domain. This option is “off” by default, and takes a
+  domain. This option is "off" by default, and takes a
   comma-separated list of strings representing resource categories for which
   the option should be enabled. The list of valid resource categories is
   given <a href="#categories">here</a>. Currently, only Script and

--- a/html/doc/experiment.html
+++ b/html/doc/experiment.html
@@ -273,7 +273,7 @@ be inlined:
 The format of client-options is
 </p>
 <pre>
-  name1=value1,name2=value2, …
+  name1=value1,name2=value2, ...
 </pre>
 
 <p>

--- a/html/doc/filter-image-optimize.html
+++ b/html/doc/filter-image-optimize.html
@@ -199,9 +199,9 @@ PageSpeed Modules support the most common image formats used on the web.
       In addition to superior compression performance, it includes features
       of all other formats: lossy mode, lossless mode, transparency,
       and animation. WebP has added support for these features over time,
-      so your visitor’s browser may support all, a subset, or none of these
+      so your visitor's browser may support all, a subset, or none of these
       features. PageSpeed automatically detects the features which your
-      visitor’s browser supports and only uses the supported features in
+      visitor's browser supports and only uses the supported features in
       optimization.
     </td>
   </tr>
@@ -212,7 +212,7 @@ PageSpeed Modules support the most common image formats used on the web.
 PageSpeed Modules provide specific filters so you can control exactly how
 your images are optimized. For each visitor, PageSpeed Modules choose the best
 format and mode from the ones you allowed and the ones supported by the
-visitor’s browser.
+visitor's browser.
 <p>
 </p>
 To simplify configuration, PageSpeed Modules provide
@@ -252,7 +252,7 @@ convert_jpeg_to_progressive</a>,
 <p>
 You can use any combination of the filter group and individual filters for
 your site. In each case, images are optimized only to the formats that are
-supported by your visitor’s browser, and images are replaced only when the
+supported by your visitor's browser, and images are replaced only when the
 optimized one is smaller than the original.
 </p>
 
@@ -346,7 +346,7 @@ of the qualities to -1 wastes CPU to achieve the same result.
 <h2>Image dimensions</h2>
 <p>
 PageSpeed Modules can shrink an image to its actual display dimensions based
-on the design of the page, the visitor’s device, and the visitor’s actions,
+on the design of the page, the visitor's device, and the visitor's actions,
 to ensure the best user experience without wasting pixels.
 <p>
 You can use the
@@ -379,7 +379,7 @@ pixels on an iPhone 6, and 300x300 device pixels on an iPhone 6+. For the best
 visual effect using the least bandwidth, you can resize your image to 100x100
 for iPhone 3, to 200x200 for iPhone 6, and to 300x300 for iPhone 6+. Using this
 filter, PageSpeed generates images at all of these dimensions, and then
-modifies the <code>&lt;img&gt;</code> tags so your visitor’s browser uses the
+modifies the <code>&lt;img&gt;</code> tags so your visitor's browser uses the
 best size.
 </p>
 <p>

--- a/html/doc/filter-insert-dns-prefetch.html
+++ b/html/doc/filter-insert-dns-prefetch.html
@@ -52,12 +52,12 @@ The example below shows the HTML before rewriting:
 
 <pre class="prettyprint">
 &lt;html&gt;
-  &lt;head&gt;
-  &lt;/head&gt;
-  &lt;body&gt;
-    &lt;img src="www.domain1.com/image1.jpeg"&gt;
-    &lt;script src="www.domain2.com/script1.js"&gt;
-  &lt;/body&gt;
+  &lt;head&gt;
+  &lt;/head&gt;
+  &lt;body&gt;
+    &lt;img src="www.domain1.com/image1.jpeg"&gt;
+    &lt;script src="www.domain2.com/script1.js"&gt;
+  &lt;/body&gt;
 &lt;/html&gt;
 </pre>
 

--- a/html/doc/release_notes.html
+++ b/html/doc/release_notes.html
@@ -1453,7 +1453,7 @@
     OpenSSL that was vulnerable to the issues detailed in
     the <a href="http://openssl.org/news/secadv_20150611.txt">June 11, 2015
     security advisory</a>.  We have updated our crypto library to fix these
-    issues. PageSpeed now builds with Google’s BoringSSL, an OpenSSL fork which
+    issues. PageSpeed now builds with Google's BoringSSL, an OpenSSL fork which
     includes this fix, and is expected to be more stable in future.
   </p>
   <p>
@@ -2194,8 +2194,8 @@
 
     <dt><a href="system#implicit_cache_ttl">
         Implicit cache-lifetime for resources</a></dt>
-    <dd>Specify the cache lifetime for resources that do not have “Expires”
-        or “Cache-Control” headers.</dd>
+    <dd>Specify the cache lifetime for resources that do not have "Expires"
+        or "Cache-Control" headers.</dd>
 
     <dt><a href="system#ipro_deadline">
         Maximum time for inplace resource rewriting</a></dt>

--- a/html/doc/system.html
+++ b/html/doc/system.html
@@ -963,9 +963,9 @@ gzip_http_version 1.0;
     and then replacing that URL by an optimized pagespeed URL. But what about
     resources that are loaded by JavaScript code? And what about links to your
     images from pages outside your domain? In-Place Resource Optimization (IPRO)
-    will optimize the content of a resource that’s requested using the original
+    will optimize the content of a resource that's requested using the original
     (non-pagespeed) URL, ensuring you are serving optimized content even when
-    that content isn’t explicitly linked in your html. This should be especially
+    that content isn't explicitly linked in your html. This should be especially
     helpful for sites with slide shows that use JavaScript to load images in the
     background; those images can now be optimized by PageSpeed by adding
     this command to your configuration file:</p>
@@ -983,7 +983,7 @@ gzip_http_version 1.0;
     resources; these will still be rewritten by IPRO, but they won't be replaced
     by a pagespeed URL. This is especially useful as an &quot;optimization is on
     by default&quot; setting for hosting providers and optimizing forward
-    proxies – cases where site-specific settings to blacklist URLs are
+    proxies &mdash; cases where site-specific settings to blacklist URLs are
     impractical.
   </p>
     <h3 id="s-maxage">Setting s-maxage on unoptimized resources</h3>
@@ -1095,7 +1095,7 @@ gzip_http_version 1.0;
     cached for a year by browser and proxy caches; in-place resources are not
     cache extended. Second, in-place resources can't be optimized specially for
     the context in which they occur on the page: images can't be resized to the
-    size they appear on the page, and multiple resources on a page can’t be
+    size they appear on the page, and multiple resources on a page can't be
     combined together. Finally, in-place resources that are eligible for
     browser-specific optimizations (such as conversion to the WebP image format)
     will be served with the <code>Vary: User-Agent</code> caching header,


### PR DESCRIPTION
The documentation html has a small number of non-ascii characters that aren't displayed properly on modpagespeed.com.  For example, see https://modpagespeed.com/doc/system#ipro right before 'cases where'. While serving the page unicode-compatible would be a better fix, we don't actually need any of these.  This PR just switches them for the ascii versions.