### PR TITLE
Log errors if serf error rate seems too high.

### DIFF
--- a/html/doc/faq.html
+++ b/html/doc/faq.html
@@ -701,16 +701,16 @@ are <code>display:&nbsp;inline</code>.
 <h2 id="warning-fetch-rate">I've got a warning saying
 "Serf fetch failure rate extremely high". What does this mean?</h2>
 
-<p>The warning means that when PageSpeed tried to fetch resources inside your
-web page for optimization over 50% of attempts inside a 30-minute period
+<p>The warning means that, when PageSpeed tried to fetch resources inside your
+web page for optimization, over 50% of attempts inside a 30-minute period
 failed. This may just mean you have some broken resource includes in your
 pages (in which case, it may be a good idea to fix them for better performance),
 but might indicate that PageSpeed's fetching is not working right. If you have
-in-place resource optimization on, that can result in things failing
-intermittently.</p>
+in-place resource optimization on, that can result in user requests for
+<code>.pagespeed.</code> URLs returning error 404 intermittently.</p>
 
 <p>First of all, check to see if the log mentions anything else about fetch
-trouble. If what's there not helpful, the root cause may be more obvious
+trouble. If what's there is not helpful, the root cause may be more obvious
 if you follow these steps:</p>
 <ol>
 <li>Disable <a href="system#ipro">in-place resource optimization temporarily.

--- a/html/doc/faq.html
+++ b/html/doc/faq.html
@@ -705,8 +705,8 @@ are <code>display:&nbsp;inline</code>.
 web page for optimization, over 50% of attempts inside a 30-minute period
 failed. This may just mean you have some broken resource includes in your
 pages (in which case, it may be a good idea to fix them for better performance),
-but might indicate that PageSpeed's fetching is not working right. If you have
-in-place resource optimization on, that can result in user requests for
+but might indicate that PageSpeed's fetching is not working properly. If you
+have in-place resource optimization on, that can result in user requests for
 <code>.pagespeed.</code> URLs returning error 404 intermittently.</p>
 
 <p>First of all, check to see if the log mentions anything else about fetch
@@ -722,7 +722,7 @@ if you follow these steps:</p>
 <li>Revert the config changes.</li>
 </ol>
 
-<p> Most likely you may need to configure an <a href="domains#mapping_origin">
+<p>Most likely you may need to configure an <a href="domains#mapping_origin">
 origin domain, to specify the host or IP to talk to fetch resources.</p>
 
 <p>You may also want to consider using <a href="domains#ModPagespeedLoadFromFile">

--- a/html/doc/faq.html
+++ b/html/doc/faq.html
@@ -698,7 +698,36 @@ elements are <code>display:&nbsp;block</code> while the other pair
 are <code>display:&nbsp;inline</code>.
 </p>
 
+<h2 id="warning-fetch-rate">I've got a warning saying
+"Serf fetch failure rate extremely high". What does this mean?</h2>
 
+<p>The warning means that when PageSpeed tried to fetch resources inside your
+web page for optimization over 50% of attempts inside a 30-minute period
+failed. This may just mean you have some broken resource includes in your
+pages (in which case, it may be a good idea to fix them for better performance),
+but might indicate that PageSpeed's fetching is not working right. If you have
+in-place resource optimization on, that can result in things failing
+intermittently.</p>
+
+<p>First of all, check to see if the log mentions anything else about fetch
+trouble. If what's there not helpful, the root cause may be more obvious
+if you follow these steps:</p>
+<ol>
+<li>Disable <a href="system#ipro">in-place resource optimization temporarily.
+    </li>
+<li>Clear PageSpeed cache.</li>
+<li>Open a test page with a <code>?PagespeedFilters=+debug</code> query
+   parameter, reload it a few times, and see if resources are getting optimized,
+   and if not if there is an error message.
+<li>Revert the config changes.</li>
+</ol>
+
+<p> Most likely you may need to configure an <a href="domains#mapping_origin">
+origin domain, to specify the host or IP to talk to fetch resources.</p>
+
+<p>You may also want to consider using <a href="domains#ModPagespeedLoadFromFile">
+<code>LoadFromFile</code></a> functionality, as that performs much better if
+your resources are static.</p>
   </div>
   <!--#include virtual="_footer.html" -->
   </body>

--- a/pagespeed/system/serf_url_async_fetcher.cc
+++ b/pagespeed/system/serf_url_async_fetcher.cc
@@ -1394,23 +1394,21 @@ void SerfUrlAsyncFetcher::ReportFetchSuccessStats(
     int64 success = ultimate_success_->Get();
     int64 failure = ultimate_failure_->Get();
 
-    if (failure != 0) {
-      int64 now_ms = timer_->NowMs();
-      if (now_ms > (last_check_ms + kReliabilityCheckPeriodMs)) {
-        ultimate_failure_->Clear();
-        ultimate_success_->Clear();
-        last_check_timestamp_ms_->Set(now_ms);
+    int64 now_ms = timer_->NowMs();
+    if (now_ms > (last_check_ms + kReliabilityCheckPeriodMs)) {
+      ultimate_failure_->Clear();
+      ultimate_success_->Clear();
+      last_check_timestamp_ms_->Set(now_ms);
 
-        int64 total = success + failure;
-        if (total > kReliabilityCheckMinFetches &&
-            (double(success) / total) < 0.5) {
-          message_handler_->Message(
-            kError, "PageSpeed Serf fetch failure rate extremely high; "
-            "only %s of %s recent fetches fully successful; is fetching "
-            "working?",
-            Integer64ToString(success).c_str(),
-            Integer64ToString(total).c_str());
-        }
+      int64 total = success + failure;
+      if (total > kReliabilityCheckMinFetches &&
+          (double(success) / total) < 0.5) {
+        message_handler_->Message(
+          kError, "PageSpeed Serf fetch failure rate extremely high; "
+          "only %s of %s recent fetches fully successful; is fetching "
+          "working?",
+          Integer64ToString(success).c_str(),
+          Integer64ToString(total).c_str());
       }
     }
   }

--- a/pagespeed/system/serf_url_async_fetcher.cc
+++ b/pagespeed/system/serf_url_async_fetcher.cc
@@ -65,7 +65,7 @@ enum HttpsOptions {
   kAllowCertificateNotYetValid          = 1 << 3,
 };
 
-const int kReliabilityCheckPeriodMs = 30 * 60 * 1000; // 30 minutes
+const int kReliabilityCheckPeriodMs = 30 * net_instaweb::Timer::kMinuteMs;
 const int kReliabilityCheckMinFetches = 5;
 
 }  // namespace
@@ -1401,7 +1401,7 @@ void SerfUrlAsyncFetcher::ReportFetchSuccessStats(
       last_check_timestamp_ms_->Set(now_ms);
 
       int64 total = success + failure;
-      if (total > kReliabilityCheckMinFetches &&
+      if (total >= kReliabilityCheckMinFetches &&
           (double(success) / total) < 0.5) {
         message_handler_->Message(
           kError, "PageSpeed Serf fetch failure rate extremely high; "

--- a/pagespeed/system/serf_url_async_fetcher.h
+++ b/pagespeed/system/serf_url_async_fetcher.h
@@ -82,6 +82,10 @@ struct SerfStats {
   // A failure or an error status. Doesn't include fetches dropped due to
   // process exit and the like.
   static const char kSerfFetchUltimateFailure[];
+
+  // When we last checked the ultimate failure/success numbers for a
+  // possible concern.
+  static const char kSerfFetchLastCheckTimestampMs[];
 };
 
 enum class SerfCompletionResult {
@@ -283,6 +287,7 @@ class SerfUrlAsyncFetcher : public UrlAsyncFetcher {
   Variable* read_calls_count_;  // Non-NULL only on debug builds.
   Variable* ultimate_success_;
   Variable* ultimate_failure_;
+  UpDownCounter* last_check_timestamp_ms_;
   const int64 timeout_ms_;
   bool shutdown_ GUARDED_BY(mutex_);
   bool list_outstanding_urls_on_error_;

--- a/pagespeed/system/serf_url_async_fetcher.h
+++ b/pagespeed/system/serf_url_async_fetcher.h
@@ -142,9 +142,13 @@ class SerfUrlAsyncFetcher : public UrlAsyncFetcher {
   void FetchComplete(SerfFetch* fetch);
 
   // Update the statistics object with results of the (completed) fetch.
-  void ReportCompletedFetchStats(SerfCompletionResult result,
-                                 const ResponseHeaders* headers,
-                                 const SerfFetch* fetch);
+  void ReportCompletedFetchStats(const SerfFetch* fetch);
+
+  // Updates states used for success/failure monitoring.
+  void ReportFetchSuccessStats(SerfCompletionResult result,
+                               const ResponseHeaders* headers,
+                               const SerfFetch* fetch);
+
 
   apr_pool_t* pool() const { return pool_; }
 

--- a/pagespeed/system/serf_url_async_fetcher_test.cc
+++ b/pagespeed/system/serf_url_async_fetcher_test.cc
@@ -847,7 +847,7 @@ class SerfFetchTest : public SerfUrlAsyncFetcherTest {
 
   virtual void TearDown() {
     async_fetch_->response_headers()->set_status_code(200);
-    serf_fetch_->CallbackDone(SerfFetch::CompletionResult::kSuccess);
+    serf_fetch_->CallbackDone(SerfCompletionResult::kSuccess);
     // Fetch must be deleted before fetcher because it has a child pool.
     serf_fetch_.reset(NULL);
     SerfUrlAsyncFetcherTest::TearDown();

--- a/pagespeed/system/serf_url_async_fetcher_test.cc
+++ b/pagespeed/system/serf_url_async_fetcher_test.cc
@@ -847,7 +847,7 @@ class SerfFetchTest : public SerfUrlAsyncFetcherTest {
 
   virtual void TearDown() {
     async_fetch_->response_headers()->set_status_code(200);
-    serf_fetch_->CallbackDone(true /* success */);
+    serf_fetch_->CallbackDone(SerfFetch::CompletionResult::kSuccess);
     // Fetch must be deleted before fetcher because it has a child pool.
     serf_fetch_.reset(NULL);
     SerfUrlAsyncFetcherTest::TearDown();

--- a/pagespeed/system/serf_url_async_fetcher_test.cc
+++ b/pagespeed/system/serf_url_async_fetcher_test.cc
@@ -545,8 +545,15 @@ TEST_F(SerfUrlAsyncFetcherTest, TestCancelThreeThreaded) {
   StartFetches(kModpagespeedSite, kGoogleLogo);
   // Explicit shutdown, it's OK to call this twice.
   TearDown();
-  // Cancelled things don't contribute to stats.
-  ValidateMonitoringStats(0, 0);
+
+  // Some of the fetches may succeed in the tiny window above, but none should
+  // be considered failed due to the quick shutdown cancelling them.
+  EXPECT_LE(statistics_->GetVariable(
+                SerfStats::kSerfFetchUltimateSuccess)->Get(),
+            3);
+  EXPECT_EQ(0,
+            statistics_->GetVariable(
+                SerfStats::kSerfFetchUltimateFailure)->Get());
 }
 
 TEST_F(SerfUrlAsyncFetcherTest, TestWaitThreeThreaded) {

--- a/pagespeed/system/serf_url_async_fetcher_test.cc
+++ b/pagespeed/system/serf_url_async_fetcher_test.cc
@@ -213,6 +213,10 @@ class SerfUrlAsyncFetcherTest : public ::testing::Test {
       serf_url_async_fetcher_->SetSslCertificatesFile(ssl_cert_file);
     }
 #endif
+    // Set initial timestamp so we don't roll-over monitoring stats right after
+    // start.
+    statistics_->GetUpDownCounter(SerfStats::kSerfFetchLastCheckTimestampMs)
+        ->Set(timer_->NowMs());
   }
 
   virtual void TearDown() {


### PR DESCRIPTION
If we get > 50% fetch errors (including both physical failures and 4xx and 5xx) 
over a 30-minute period with > 5 fetches, this issues an error to the log.