### PR TITLE
Consolidate external CSS, fix unauth. inlining test

### DIFF
--- a/install/mod_pagespeed_test/unauthorized/inline_css.html
+++ b/install/mod_pagespeed_test/unauthorized/inline_css.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>inline_css example</title>
+    <!-- modpagespeed.com is not authorized in the tests -->
     <link rel="stylesheet" href="http://modpagespeed.com/testfiles/google-cse-default.css">
     <link rel="stylesheet" href="../../mod_pagespeed_example/styles/all_styles.css">
   </head>

--- a/install/mod_pagespeed_test/unauthorized/inline_css.html
+++ b/install/mod_pagespeed_test/unauthorized/inline_css.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>inline_css example</title>
-    <link rel="stylesheet" href="http://cse.google.com/cse/style/look/default.css">
+    <link rel="stylesheet" href="http://modpagespeed.com/testfiles/google-cse-default.css">
     <link rel="stylesheet" href="../../mod_pagespeed_example/styles/all_styles.css">
   </head>
   <body>

--- a/install/mod_pagespeed_test/unauthorized/prioritize_critical_css.html
+++ b/install/mod_pagespeed_test/unauthorized/prioritize_critical_css.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>prioritize_critical_css example</title>
-    <link rel="stylesheet" type="text/css" href="http://cse.google.com/cse/style/look/default.css">
+    <link rel="stylesheet" type="text/css" href="http://modpagespeed.com/testfiles/google-cse-default.css">
     <link rel="stylesheet" type="text/css" href="with_unauthorized_imports.css">
   </head>
   <body>

--- a/pagespeed/system/system_tests/inline_unauth.sh
+++ b/pagespeed/system/system_tests/inline_unauth.sh
@@ -57,7 +57,7 @@ OUTFILE=$OUTDIR/blocking_rewrite.out.html
 $WGET_DUMP --header 'X-PSA-Blocking-Rewrite: psatest' $URL > $OUTFILE
 check egrep -q 'link[[:space:]]rel=' $OUTFILE
 EXPECTED_COMMENT_LINE="<!--The preceding resource was not rewritten because"
-EXPECTED_COMMENT_LINE+=" its domain (cse.google.com) is not authorized-->"
+EXPECTED_COMMENT_LINE+=" its domain (modpagespeed.com) is not authorized-->"
 check [ $(grep -o "$EXPECTED_COMMENT_LINE" $OUTFILE | wc -l) -eq 1 ]
 
 start_test inline_unauthorized_resources allows inlining

--- a/pagespeed/system/system_tests/no_critical_unauthorized_resources.sh
+++ b/pagespeed/system/system_tests/no_critical_unauthorized_resources.sh
@@ -34,7 +34,7 @@ check_not fgrep -q "interesting_color" $FETCH_FILE
 check [ $(fgrep -c "non_flattened_selector" $FETCH_FILE) -eq 1 ]
 EXPECTED_IMPORT_FAILURE_LINE="<!--Flattening failed: Cannot import http://www.google.com/css/maia.css as it is on an unauthorized domain-->"
 check [ $(grep -o "$EXPECTED_IMPORT_FAILURE_LINE" $FETCH_FILE | wc -l) -eq 1 ]
-EXPECTED_COMMENT_LINE="<!--The preceding resource was not rewritten because its domain (cse.google.com) is not authorized-->"
+EXPECTED_COMMENT_LINE="<!--The preceding resource was not rewritten because its domain (modpagespeed.com) is not authorized-->"
 check [ $(grep -o "$EXPECTED_COMMENT_LINE" $FETCH_FILE | wc -l) -eq 1 ]
 
 start_test inline_unauthorized_resources allows unauthorized css selectors


### PR DESCRIPTION
Move a css file to modpagespeed.com to avoid external changes to its response from breaking our tests

