### PR TITLE
Force old configuration when installing packages for release

### DIFF
--- a/install/ubuntu/install_required_packages.sh
+++ b/install/ubuntu/install_required_packages.sh
@@ -40,7 +40,10 @@ if "$additional_test_packages"; then
   fi
 fi
 
-apt-get -y install "${binary_packages[@]}"
+# The 32 bits ubuntu 14.04 image has /etc/protocols modified which 
+# will cause a prompt here. Force retaining the old configuration here.
+apt-get -y -o Dpkg::Options::="--force-confdef" \
+  -o Dpkg::Options::="--force-confold" install "${binary_packages[@]}"
 
 # src_packages might be empty. The below placates set -u, see:
 # http://stackoverflow.com/questions/7577052/bash-empty-array-expansion-with-set-u


### PR DESCRIPTION
When building a release on the 32 bits Ubuntu 14.04, the automated
install runs into a prompt to choose an option with regard to
/etc/protocols being modified earlier.