### PR TITLE
Debug builds may abort() when revalidating expired output resources

### DIFF
--- a/net/instaweb/rewriter/output_resource.cc
+++ b/net/instaweb/rewriter/output_resource.cc
@@ -221,8 +221,10 @@ void OutputResource::SetHash(StringPiece hash) {
 void OutputResource::LoadAndCallback(NotCacheablePolicy not_cacheable_policy,
                                      const RequestContextPtr& request_context,
                                      AsyncCallback* callback) {
-  LOG(DFATAL) << "Output resources shouldn't be loaded via "
-                 "LoadAsync, but rather through FetchResource";
+  // TODO(oschaaf): Output resources shouldn't be loaded via LoadAsync, but
+  // rather through FetchResource. Yet 
+  // ProxyInterfaceTest.TestNoDebugAbortAfterMoreThenOneYear does manage to hit
+  // this code. See https://github.com/pagespeed/mod_pagespeed/issues/1553
   callback->Done(false /* lock_failure */, writing_complete_);
 }
 

--- a/pagespeed/automatic/proxy_interface_test.cc
+++ b/pagespeed/automatic/proxy_interface_test.cc
@@ -386,23 +386,29 @@ TEST_F(ProxyInterfaceTest, TestNoDebugAbortAfterMoreThenOneYear) {
   GoogleString text;
   RequestHeaders request_headers;
   ResponseHeaders response_headers;
+  RewriteOptions* options = server_context()->global_options();
+  static const char* kUrl = "http://test.com/flush_subresources.html";
+
+  options->ClearSignatureForTesting();
+  options->EnableFilter(RewriteOptions::kExtendCacheCss);
+  options->DisableFilter(RewriteOptions::kInlineCss);
+  server_context()->ComputeSignature(options);
+
   response_headers.Add(HttpAttributes::kContentType,
-		       kContentTypeHtml.mime_type());
+                       kContentTypeHtml.mime_type());
   response_headers.SetStatusAndReason(HttpStatus::kOK);
 
-  GoogleString url = "http://test.com/flush_subresources.html"
-    "?PageSpeedFilters=+extend_cache_css,-inline_css";
   mock_url_fetcher_.SetResponse("http://test.com/flush_subresources.html",
-				response_headers,
+                                response_headers,
                                 "<html><head><link rel='stylesheet' "
-				"type='text/css' href='test.css'></head></html>");
+                                "type='text/css' href='test.css'></head></html>");
 
   response_headers.Replace(HttpAttributes::kContentType,
-			   kContentTypeCss.mime_type());
+                           kContentTypeCss.mime_type());
   mock_url_fetcher_.SetResponse("http://test.com/test.css", response_headers,
                                 kCssContent);
 
-  FetchFromProxy(url,
+  FetchFromProxy(kUrl,
                  request_headers,
                  true,  /* expect_success */
                  &text,
@@ -411,13 +417,14 @@ TEST_F(ProxyInterfaceTest, TestNoDebugAbortAfterMoreThenOneYear) {
 
   SetTimeMs(MockTimer::kApr_5_2010_ms + 2 * Timer::kYearMs);
 
-  // This second fetch would end up with VLOG(DFATAL)
-  FetchFromProxy(url,
+  // This second fetch would run into a VLOG(DFATAL) prior to changing that to a
+  // TODO.
+  FetchFromProxy(kUrl,
                  request_headers,
                  true,  /* expect_success */
                  &text,
                  &response_headers,
-		 false  /* proxy_fetch_property_callback_collector_created */);
+                 false  /* proxy_fetch_property_callback_collector_created */);
 }
 
 

--- a/pagespeed/automatic/proxy_interface_test.cc
+++ b/pagespeed/automatic/proxy_interface_test.cc
@@ -381,6 +381,46 @@ TEST_F(ProxyInterfaceTest, LoggingInfo) {
   EXPECT_TRUE(logging_info()->is_request_disabled());
 }
 
+// Regression test for https://github.com/pagespeed/mod_pagespeed/issues/1553
+TEST_F(ProxyInterfaceTest, TestNoDebugAbortAfterMoreThenOneYear) {
+  GoogleString text;
+  RequestHeaders request_headers;
+  ResponseHeaders response_headers;
+  response_headers.Add(HttpAttributes::kContentType,
+		       kContentTypeHtml.mime_type());
+  response_headers.SetStatusAndReason(HttpStatus::kOK);
+
+  GoogleString url = "http://test.com/flush_subresources.html"
+    "?PageSpeedFilters=+extend_cache_css,-inline_css";
+  mock_url_fetcher_.SetResponse("http://test.com/flush_subresources.html",
+				response_headers,
+                                "<html><head><link rel='stylesheet' "
+				"type='text/css' href='test.css'></head></html>");
+
+  response_headers.Replace(HttpAttributes::kContentType,
+			   kContentTypeCss.mime_type());
+  mock_url_fetcher_.SetResponse("http://test.com/test.css", response_headers,
+                                kCssContent);
+
+  FetchFromProxy(url,
+                 request_headers,
+                 true,  /* expect_success */
+                 &text,
+                 &response_headers,
+                 false  /* proxy_fetch_property_callback_collector_created */);
+
+  SetTimeMs(MockTimer::kApr_5_2010_ms + 2 * Timer::kYearMs);
+
+  // This second fetch would end up with VLOG(DFATAL)
+  FetchFromProxy(url,
+                 request_headers,
+                 true,  /* expect_success */
+                 &text,
+                 &response_headers,
+		 false  /* proxy_fetch_property_callback_collector_created */);
+}
+
+
 TEST_F(ProxyInterfaceTest, SkipPropertyCacheLookupIfOptionsNotEnabled) {
   GoogleString url = "http://www.example.com/";
   GoogleString text;


### PR DESCRIPTION
As a workaround, remove the LOG(DFATAL) and replace it with a TODO.

https://github.com/pagespeed/mod_pagespeed/issues/1553