### PR TITLE
Tweak to avoid tar warning in loadtest corpus generation

### DIFF
--- a/devel/loadtest_collect/loadtest_collect_corpus.sh
+++ b/devel/loadtest_collect/loadtest_collect_corpus.sh
@@ -63,5 +63,5 @@ for site in $(cat $1); do
 done
 cat $LOG_PATH | grep ^GET | cut -d ' ' -f 2 > $URLS_PATH
 cd $SLURP_TOP_DIR
-tar cvjf $2 .
+tar cvjf $2 *
 


### PR DESCRIPTION
(Warning is: "tar: .: file changed as we read it")
