### PR TITLE
Ensure deb files we build use gz and not xz

### DIFF
--- a/install/debian/build.sh
+++ b/install/debian/build.sh
@@ -91,7 +91,7 @@ do_package_in_fakeroot() {
   fakeroot -s "${FAKEROOTFILE}" -i "${FAKEROOTFILE}" -- \
     chown -R ${APACHE_USER}:${APACHE_USER} ${STAGEDIR}${MOD_PAGESPEED_LOG}
   fakeroot -i "${FAKEROOTFILE}" -- \
-    dpkg-deb -b "${STAGEDIR}" .
+    dpkg-deb -Zgzip -b "${STAGEDIR}" .
   rm -f "${FAKEROOTFILE}"
 }
 


### PR DESCRIPTION
This makes sure deb files contain data.tar.gz and not data.tar.xz

(Found by running extract_so_from_deb.sh which choked on
data.tar.gz file not being present)