### PR TITLE
mps-load-test: Specify BUILDTYPE=Debug

### DIFF
--- a/devel/Makefile
+++ b/devel/Makefile
@@ -125,8 +125,6 @@ DEVEL_DIR = $(GIT_SRC)/devel
 INSTALL_DATA_DIR = $(GIT_SRC)/install
 
 # Where binaries go.
-GIT_RELEASE_BIN = $(GIT_SRC)/out/Release
-GIT_DEBUG_BIN = $(GIT_SRC)/out/Debug
 GIT_BIN = $(GIT_SRC)/out/$(BUILDTYPE)
 
 # GYP_MANIFEST holds a cached copy of the gyp files in this client.  When we
@@ -296,19 +294,19 @@ apache_debug : $(HOOKS_STAMP)
 	@echo "building Apache module $@ ..."
 	cd $(GIT_SRC) && $(MAKE)
 	@echo Built mod_pagespeed successfully:
-	ls -l $(GIT_DEBUG_BIN)/libmod_pagespeed.so
+	ls -l $(GIT_BIN)/libmod_pagespeed.so
 	@echo To install, type
-	@echo "   " cp $(GIT_DEBUG_BIN)/libmod_pagespeed.so \
+	@echo "   " cp $(GIT_BIN)/libmod_pagespeed.so \
 		$(APACHE_DEBUG_ROOT)/modules/mod_pagespeed.so
 
 apache_debug_psol : apache_debug
 	cd $(GIT_SRC)/pagespeed/automatic && $(MAKE) \
 		MOD_PAGESPEED_ROOT=$(GIT_SRC) \
-		OUTPUT_DIR=$(GIT_DEBUG_BIN) \
+		OUTPUT_DIR=$(GIT_BIN) \
 		BUILDTYPE=Debug \
 		CXXFLAGS=$(CXXFLAGS) \
 		all
-	@echo Built PSOL successfully under in $(GIT_DEBUG_BIN)
+	@echo Built PSOL successfully under in $(GIT_BIN)
 
 .PHONY : submodule_update
 submodule_update:
@@ -561,9 +559,9 @@ TMP_PREFIX = /tmp/mod_pagespeed.$(USER).install
 internal_release_test :
 	cd $(GIT_SRC) && \
 	  BUILDTYPE=Release install/run_program_with_ext_caches.sh \
-	    $(GIT_RELEASE_BIN)/mod_pagespeed_test  $(TEST_ARG) && \
+	    $(GIT_BIN)/mod_pagespeed_test  $(TEST_ARG) && \
 	  BUILDTYPE=Release install/run_program_with_ext_caches.sh \
-	    $(GIT_RELEASE_BIN)/pagespeed_automatic_test $(TEST_ARG)
+	    $(GIT_BIN)/pagespeed_automatic_test $(TEST_ARG)
 
 # Configuration root for Apache file-system and cache directories, to
 # be written into config file.
@@ -622,15 +620,15 @@ apache_release : internal_release_build
 	@echo "   " sudo make install
 	@echo "or"
 	@echo "   " sudo cp \
-		$(GIT_RELEASE_BIN)/libmod_pagespeed.so \
+		$(GIT_BIN)/libmod_pagespeed.so \
 		$(APACHE_RELEASE_MODULES_DIR)/mod_pagespeed.so
 
 apache_release_install : apache_release
 	@echo "Copy the module to your Apache2 modules directory."
 	@echo "Then, restart your Apache server."
-	install -c $(GIT_RELEASE_BIN)/libmod_pagespeed.so \
+	install -c $(GIT_BIN)/libmod_pagespeed.so \
 	           $(APACHE_RELEASE_MODULES_DIR)/mod_pagespeed.so
-	install -c $(GIT_RELEASE_BIN)/libmod_pagespeed_ap24.so \
+	install -c $(GIT_BIN)/libmod_pagespeed_ap24.so \
 	           $(APACHE_RELEASE_MODULES_DIR)/mod_pagespeed_ap24.so
 	/etc/init.d/apache2 stop
 	/etc/init.d/apache2 start

--- a/devel/loadtest_collect/loadtest_collect_corpus.sh
+++ b/devel/loadtest_collect/loadtest_collect_corpus.sh
@@ -55,6 +55,7 @@ make apache_debug_stop
 sed -e "s^#HOME^$HOME^" -e "s^#SLURP_DIR^$SLURP_DIR^" \
   -e "s^#LOG_PATH^$LOG_PATH^" \
   < loadtest_collect/loadtest_collect.conf > ~/apache2/conf/pagespeed.conf
+cat ~/apache2/conf/pagespeed.conf
 make -j8 apache_debug_restart
 
 for site in $(cat $1); do

--- a/devel/mps_load_test.sh
+++ b/devel/mps_load_test.sh
@@ -14,12 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Note: this script is not yet usable outside Google, because it depends on a
-# corpus database that we can't open source.  It should be possible to create a
-# db with a combination of mod_pagespeed's slurping and a headless browser, but
-# we don't currently have a script or instructions on how to do this.
-# TODO(jefftk): resolve this
-#
 # This script runs a mod_pagespeed load-test.  The typical
 # configuration is to run this on your development workstation and
 # mps_generate_load.sh will be run (via ssh) on a different machine
@@ -208,7 +202,8 @@ cd "$src/devel"
 
 # Build a version of mod_pagespeed with all optimizations enabled, but with
 # a build that includes DCHECKs.
-make -j8 CONF=$compile_mode apache_trace_stress_test_server \
+# TODO(oschaaf): can we skip this step if we have a custom .so?
+make BUILDTYPE=Debug -j8 CONF=$compile_mode apache_trace_stress_test_server \
   DUMP_DIR="$corpus" \
   APACHE_DEBUG_ROOT="${APACHE_DEBUG_ROOT}" \
   MOD_PAGESPEED_CACHE=/var/run/pagespeed/cache

--- a/devel/mps_load_test.sh
+++ b/devel/mps_load_test.sh
@@ -203,7 +203,7 @@ cd "$src/devel"
 # Build a version of mod_pagespeed with all optimizations enabled, but with
 # a build that includes DCHECKs.
 # TODO(oschaaf): can we skip this step if we have a custom .so?
-make BUILDTYPE=Debug -j8 CONF=$compile_mode apache_trace_stress_test_server \
+make -j8 CONF=$compile_mode apache_trace_stress_test_server \
   DUMP_DIR="$corpus" \
   APACHE_DEBUG_ROOT="${APACHE_DEBUG_ROOT}" \
   MOD_PAGESPEED_CACHE=/var/run/pagespeed/cache


### PR DESCRIPTION
On a clean checkout I noticed the tests failed with this on the terminal:

```
Built mod_pagespeed successfully:
ls -l /mps/out/Debug/libmod_pagespeed.so
ls: cannot access /mps/out/Debug/libmod_pagespeed.so: No such file or directory
```

- Specify BUILDTYPE=Debug, to build libmod_pagespeed.so at the
expected location
- Remove obsolete comment/TODO
- Add TODO