### PR TITLE
Not adding type attribute in script tag, adding attribute when pedantic filter is enabled : Bug fix #1207

### DIFF
--- a/install/mod_pagespeed_test/type_attribute_pedantic.html
+++ b/install/mod_pagespeed_test/type_attribute_pedantic.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>pedantic example for type attribute</title>
+    <style>h1 {color : #ff0000;}</style>
+    <script>var x=1;</script>
+  </head>
+  <body>
+    Here is a disabled button:
+      <button name="ok" disabled="disabled">button</button><br/>
+    Here is a text input: <input name="email" type="text"/>
+  </body>
+</html>

--- a/net/instaweb/rewriter/add_instrumentation_filter.cc
+++ b/net/instaweb/rewriter/add_instrumentation_filter.cc
@@ -101,11 +101,11 @@ void AddInstrumentationFilter::AddHeadScript(HtmlElement* element) {
     added_head_script_ = true;
     // TODO(abliss): add an actual element instead, so other filters can
     // rewrite this JS
-    HtmlCharactersNode* script = NULL;
-    if(driver()->options()->Enabled(RewriteOptions::kPedantic)){
-        script = driver()->NewCharactersNode(NULL, kHeadScriptPedantic);
+    HtmlCharactersNode* script = nullptr;
+    if (driver()->options()->Enabled(RewriteOptions::kPedantic)) {
+        script = driver()->NewCharactersNode(nullptr, kHeadScriptPedantic);
     } else {
-        script = driver()->NewCharactersNode(NULL, kHeadScriptNonPedantic);
+        script = driver()->NewCharactersNode(nullptr, kHeadScriptNonPedantic);
     }
     driver()->InsertNodeBeforeCurrent(script);
     instrumentation_script_added_count_->Add(1);
@@ -149,7 +149,7 @@ void AddInstrumentationFilter::EndDocument() {
     return;
   }
   GoogleString js = GetScriptJs(kLoadTag);
-  HtmlElement* script = driver()->NewElement(NULL, HtmlName::kScript);
+  HtmlElement* script = driver()->NewElement(nullptr, HtmlName::kScript);
   if (!driver()->defer_instrumentation_script()) {
     driver()->AddAttribute(script, HtmlName::kDataPagespeedNoDefer,
                            StringPiece());
@@ -207,7 +207,7 @@ GoogleString AddInstrumentationFilter::GetScriptJs(StringPiece event) {
   }
 
   // Append the http response code.
-  if (driver()->response_headers() != NULL &&
+  if (driver()->response_headers() != nullptr &&
       driver()->response_headers()->status_code() > 0 &&
       driver()->response_headers()->status_code() != HttpStatus::kOK) {
     StrAppend(&extra_params, "&rc=", IntegerToString(

--- a/net/instaweb/rewriter/add_instrumentation_filter.cc
+++ b/net/instaweb/rewriter/add_instrumentation_filter.cc
@@ -45,8 +45,14 @@ namespace {
 
 // The javascript tag to insert in the top of the <head> element.  We want this
 // as early as possible in the html.  It must be short and fast.
-const char kHeadScript[] =
+const char kHeadScriptPedantic[] =
     "<script type='text/javascript'>"
+    "window.mod_pagespeed_start = Number(new Date());"
+    "</script>";
+
+// script tag without type attribute
+const char kHeadScriptNonPedantic[] =
+    "<script>"
     "window.mod_pagespeed_start = Number(new Date());"
     "</script>";
 
@@ -95,7 +101,12 @@ void AddInstrumentationFilter::AddHeadScript(HtmlElement* element) {
     added_head_script_ = true;
     // TODO(abliss): add an actual element instead, so other filters can
     // rewrite this JS
-    HtmlCharactersNode* script = driver()->NewCharactersNode(NULL, kHeadScript);
+    HtmlCharactersNode* script = NULL;
+    if(driver()->options()->Enabled(RewriteOptions::kPedantic)){
+        script = driver()->NewCharactersNode(NULL, kHeadScriptPedantic);
+    } else {
+        script = driver()->NewCharactersNode(NULL, kHeadScriptNonPedantic);
+    }
     driver()->InsertNodeBeforeCurrent(script);
     instrumentation_script_added_count_->Add(1);
   }

--- a/net/instaweb/rewriter/add_instrumentation_filter_test.cc
+++ b/net/instaweb/rewriter/add_instrumentation_filter_test.cc
@@ -274,14 +274,19 @@ TEST_F(AddInstrumentationFilterTest, TestScriptTagTypeAttribute) {
 
   SetupWriter();
   rewrite_driver()->StartParse(kTestDomain);
-  rewrite_driver()->ParseText("<!DOCTYPE html><html><head></head><body><img src='Puzzle.jpg'/></body></html>");
+  rewrite_driver()->ParseText("<!DOCTYPE html><html><head></head><body>"
+                              "<img src='Puzzle.jpg'/></body></html>");
   rewrite_driver()->FinishParse();
 
   // check html without type attribute in head
-  EXPECT_TRUE(output_buffer_.find("<script>window.mod_pagespeed_start")!= StringPiece::npos);
+  EXPECT_TRUE(output_buffer_.find(
+      "<script>window.mod_pagespeed_start") !=
+          StringPiece::npos);
 
   // check html without type attribute in data-pagespeed-no-defer tag
-  EXPECT_TRUE(output_buffer_.find("<script data-pagespeed-no-defer>")!= StringPiece::npos);
+  EXPECT_TRUE(output_buffer_.find(
+      "<script data-pagespeed-no-defer>") !=
+          StringPiece::npos);
 }
 
 // Test script tag and type attribute with pedantic filter
@@ -292,14 +297,19 @@ TEST_F(AddInstrumentationFilterTest, TestScriptTagTypeAttributePedantic) {
 
   SetupWriter();
   rewrite_driver()->StartParse(kTestDomain);
-  rewrite_driver()->ParseText("<!DOCTYPE html><html><head></head><body><img src='Puzzle.jpg'/></body></html>");
+  rewrite_driver()->ParseText("<!DOCTYPE html><html><head></head><body>"
+                              "<img src='Puzzle.jpg'/></body></html>");
   rewrite_driver()->FinishParse();
 
   // check html with type attribute in head
-  EXPECT_TRUE(output_buffer_.find("<script type='text/javascript'>window.mod_pagespeed_start")!= StringPiece::npos);
+  EXPECT_TRUE(output_buffer_.find(
+      "<script type='text/javascript'>window.mod_pagespeed_start") !=
+          StringPiece::npos);
 
   // check html with type attribute in data-pagespeed-no-defer tag
-  EXPECT_TRUE(output_buffer_.find("<script data-pagespeed-no-defer type=\"text/javascript\">")!= StringPiece::npos);
+  EXPECT_TRUE(output_buffer_.find(
+      "<script data-pagespeed-no-defer type=\"text/javascript\">")!=
+          StringPiece::npos);
 }
 
 const char kBeaconUrl[] = "http://example.com/beacon?org=xxx";

--- a/net/instaweb/rewriter/add_instrumentation_filter_test.cc
+++ b/net/instaweb/rewriter/add_instrumentation_filter_test.cc
@@ -267,6 +267,41 @@ TEST_F(AddInstrumentationFilterTest, TestDisableForBots) {
                     "<head></head><head></head><body></body><body></body>");
 }
 
+// Test script tag and type attribute without pedantic filter
+TEST_F(AddInstrumentationFilterTest, TestScriptTagTypeAttribute) {
+  options()->EnableFilter(RewriteOptions::kAddInstrumentation);
+  AddFilters();
+
+  SetupWriter();
+  rewrite_driver()->StartParse(kTestDomain);
+  rewrite_driver()->ParseText("<!DOCTYPE html><html><head></head><body><img src='Puzzle.jpg'/></body></html>");
+  rewrite_driver()->FinishParse();
+
+  // check html without type attribute in head
+  EXPECT_TRUE(output_buffer_.find("<script>window.mod_pagespeed_start")!= StringPiece::npos);
+
+  // check html without type attribute in data-pagespeed-no-defer tag
+  EXPECT_TRUE(output_buffer_.find("<script data-pagespeed-no-defer>")!= StringPiece::npos);
+}
+
+// Test script tag and type attribute with pedantic filter
+TEST_F(AddInstrumentationFilterTest, TestScriptTagTypeAttributePedantic) {
+  options()->EnableFilter(RewriteOptions::kAddInstrumentation);
+  options()->EnableFilter(RewriteOptions::kPedantic);
+  AddFilters();
+
+  SetupWriter();
+  rewrite_driver()->StartParse(kTestDomain);
+  rewrite_driver()->ParseText("<!DOCTYPE html><html><head></head><body><img src='Puzzle.jpg'/></body></html>");
+  rewrite_driver()->FinishParse();
+
+  // check html with type attribute in head
+  EXPECT_TRUE(output_buffer_.find("<script type='text/javascript'>window.mod_pagespeed_start")!= StringPiece::npos);
+
+  // check html with type attribute in data-pagespeed-no-defer tag
+  EXPECT_TRUE(output_buffer_.find("<script data-pagespeed-no-defer type=\"text/javascript\">")!= StringPiece::npos);
+}
+
 const char kBeaconUrl[] = "http://example.com/beacon?org=xxx";
 
 class AddInstrumentationAmpTest : public AddInstrumentationFilterTest {

--- a/net/instaweb/rewriter/common_filter.cc
+++ b/net/instaweb/rewriter/common_filter.cc
@@ -300,7 +300,8 @@ void CommonFilter::AddJsToElement(StringPiece js, HtmlElement* script) {
   }
 
   // is pedantic filter only check sufficient for adding type attribute?
-  if (!driver_->doctype().IsVersion5() || driver_->options()->Enabled(RewriteOptions::kPedantic)) {
+  if (!driver_->doctype().IsVersion5() ||
+          driver_->options()->Enabled(RewriteOptions::kPedantic)) {
     driver_->AddAttribute(script, HtmlName::kType, "text/javascript");
   }
   HtmlCharactersNode* script_content = driver_->NewCharactersNode(script, js);

--- a/net/instaweb/rewriter/common_filter.cc
+++ b/net/instaweb/rewriter/common_filter.cc
@@ -299,7 +299,8 @@ void CommonFilter::AddJsToElement(StringPiece js, HtmlElement* script) {
     js = js_str;
   }
 
-  if (!driver_->doctype().IsVersion5()) {
+  // is pedantic filter only check sufficient for adding type attribute?
+  if (!driver_->doctype().IsVersion5() || driver_->options()->Enabled(RewriteOptions::kPedantic)) {
     driver_->AddAttribute(script, HtmlName::kType, "text/javascript");
   }
   HtmlCharactersNode* script_content = driver_->NewCharactersNode(script, js);

--- a/pagespeed/system/system_test.sh
+++ b/pagespeed/system/system_test.sh
@@ -77,6 +77,7 @@ run_test check_headers
 run_test aris
 run_test css_combining_authorization
 run_test add_instrumentation
+run_test type_attribute_pedantic
 run_test cache_partial_html
 run_test flush_subresources
 run_test respect_custom_options

--- a/pagespeed/system/system_tests/type_attribute_pedantic.sh
+++ b/pagespeed/system/system_tests/type_attribute_pedantic.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# fetch html with pedantic filter enabled
+start_test HTML check type attribute with pedantic
+$WGET -O $WGET_OUTPUT $TEST_ROOT/type_attribute_pedantic.html\
+?PageSpeedFilters=add_instrumentation,pedantic
+# check for type attribute in html
+check [ $(grep -c "<script type='text/javascript'>window.mod_pagespeed_start" $WGET_OUTPUT) = 1 ]
+check [ $(grep -c "<script data-pagespeed-no-defer type=\"text/javascript\">" $WGET_OUTPUT) = 1 ]
+
+# fetch html without pedantic filter
+start_test HTML check type attribute
+$WGET -O $WGET_OUTPUT $TEST_ROOT/type_attribute_pedantic.html\
+?PageSpeedFilters=add_instrumentation
+# check for type attribute
+check [ $(grep -c "<script>window.mod_pagespeed_start" $WGET_OUTPUT) = 1 ]
+check [ $(grep -c "<script data-pagespeed-no-defer>" $WGET_OUTPUT) = 1 ]
+


### PR DESCRIPTION
- In add_instrumentation_filter.cc, I have added pedantic filter check when adding type attribute to script tag.

- In common_filter.cc file, function AddJsToElement, adds type attribute based on HTML5 version check. I have added 'OR' condition of pedantic filter enabled check. So if it **not HTML5 OR pedantic filter enabled**, it will **add type attribute**.
Is this check appropriate ? Or only pedantic filter check is sufficient?
Let me know your thoughts on this.