### PR TITLE
update deps for checkin test

### DIFF
--- a/devel/check_for_leaks
+++ b/devel/check_for_leaks
@@ -160,7 +160,7 @@ function check_system_test_for_leaks() {
     $apache_debug_root/bin/httpd --enable-pool-debug \
     >& $outfile &
 
-  local apache_timeout=300
+  local apache_timeout=30
   echo -n Waiting up to "$apache_timeout" seconds for valgrind/httpd \
           to start listening
   if ! wait_cmd_with_timeout "$apache_timeout" \

--- a/devel/check_for_leaks
+++ b/devel/check_for_leaks
@@ -160,7 +160,7 @@ function check_system_test_for_leaks() {
     $apache_debug_root/bin/httpd --enable-pool-debug \
     >& $outfile &
 
-  local apache_timeout=30
+  local apache_timeout=300
   echo -n Waiting up to "$apache_timeout" seconds for valgrind/httpd \
           to start listening
   if ! wait_cmd_with_timeout "$apache_timeout" \

--- a/install/ubuntu/install_required_packages.sh
+++ b/install/ubuntu/install_required_packages.sh
@@ -59,7 +59,7 @@ function first_available_package() {
 install_redis_from_src=false
 if "$additional_dev_packages"; then
   binary_packages+=(memcached autoconf valgrind libev-dev libssl-dev
-    libpcre3-dev openjdk-7-jre language-pack-tr-base gperf uuid-dev)
+    libpcre3-dev openjdk-7-jre language-pack-tr-base gperf uuid-dev pkg-config)
 
   if version_compare $(lsb_release -sr) -ge 16.04; then
     binary_packages+=(redis-server)


### PR DESCRIPTION
* add pkg-config, which is needed to test httpd24. (as that will build nghttp2 which depends on pkg-config)
* update httpd24 from `2.4.10` to `2.4.26`

httpd `2.4.10` gets us:
```
[proxy_balancer:emerg] [pid 20781] AH01177: Failed to lookup provider 'shm' for 'slotmem': is mod_slotmem_shm loaded??
[:emerg] [pid 20781] AH00020: Configuration Failed, exiting
```
