### PR TITLE
Deflake test: CHECK failure in redis cache cluster setup

### DIFF
--- a/pagespeed/system/redis_cache_cluster_setup.cc
+++ b/pagespeed/system/redis_cache_cluster_setup.cc
@@ -38,7 +38,7 @@ namespace RedisCluster {
 
 namespace {
 
-static const int kReconfigurationPropagationTimeoutMs = 5000;
+static const int kReconfigurationPropagationTimeoutMs = 10000;
 
 GoogleString ReadBulkString(TcpConnectionForTesting* conn) {
   GoogleString length_str_storage = conn->ReadLineCrLf();


### PR DESCRIPTION
Allow some more time for nodes to report in after CLUSTER MEET. 

(Hopefully avoiding failing checkin tests on "Check failed: propagated. All nodes did not report in after
CLUSTER MEET")
