### PR TITLE
Deflake "But do proxy content if the Content-Type header is present."

### DIFF
--- a/pagespeed/apache/system_tests/proxying.sh
+++ b/pagespeed/apache/system_tests/proxying.sh
@@ -34,7 +34,7 @@ fi
 start_test Do not proxy content without a Content-Type header
 # These tests depend on modpagespeed.com being configured to serve an example
 # file with a content-type header on port 8091 and without one on port 8092.
-# scripts/serve_proxying_tests.sh can do this.
+# scripts/serve_proxying_tests.py can do this.
 URL="$PRIMARY_SERVER/content_type_absent/"
 CONTENTS="This file should not be proxied"
 


### PR DESCRIPTION
Replace serve_proxying_tests.sh with serve_proxying_test.py on
modpagespeed.com as nc isn't able to handle concurrent requests
very well, which made tests fail.

Replacement code (now up and runing @ modpagespeed.com):

```python
import tornado.ioloop
import tornado.web
class Handler(tornado.web.RequestHandler):
    def get(self):
        port = self.request.host.split(":")[1]
        print("request on port: %s" % port)
        if port == "8091":
            self.set_header('Content-Type', 'text/plain')
            self.write("This file should be proxied.")
        else:
            self.write("This file should not be proxyied.")
def make_app():
    return tornado.web.Application([
        (r"/", Handler),
    ])
if __name__ == "__main__":
    app = make_app()
    app.listen(8091)
    app.listen(8092)
    tornado.ioloop.IOLoop.current().start()
```