### PR TITLE
Deflake 'embed image config'

### DIFF
--- a/install/debug.conf.template
+++ b/install/debug.conf.template
@@ -1930,7 +1930,7 @@ ModPagespeedMessagesDomains Allow localhost
 
   # Share a cache keyspace with embed-config-resources.example.com.
   ModPagespeedCacheFragment "embed-config"
-
+  ModPagespeedRewriteDeadlinePerFlushMs 5000
   ModPagespeedLoadFromFile "http://embed-config-resources.example.com/" \
       "@@APACHE_DOC_ROOT@@/mod_pagespeed_example/"
 </VirtualHost>

--- a/pagespeed/system/system_tests/embed_config.sh
+++ b/pagespeed/system/system_tests/embed_config.sh
@@ -18,6 +18,10 @@ start_test Embed image configuration in rewritten image URL.
 # *xPuzzle.jpg.pagespeed.gp+jp+pj+js+rj+rp+rw+ri+cp+md+iq=73.ic.oFXPiLYMka.jpg
 # We use a regex matching "gp+jp+pj+js+rj+rp+rw+ri+cp+md+iq=73" rather than
 # spelling it out to avoid test regolds when we add image filter IDs.
+# TODO(oschaaf): I have observed xPuzzle.pagespeed. partially optimized here, 
+# served with a short cache ttl. This would cause this test to flake.
+# For now, the rewrite deadline has been bumped in the configuration of this
+# vhost.
 http_proxy=$SECONDARY_HOSTNAME fetch_until -save -recursive \
     http://embed-config-html.example.org/embed_config.html \
     'fgrep -c .pagespeed.' 3 --save-headers


### PR DESCRIPTION
Attempt to deflake by bumping the rewrite deadline. (I think bumping the deadline will, in practice, make the test runs more predictable)