### PR TITLE
Fix possible buffer over-read in RewriteDriver::ParseTextInternal

### DIFF
--- a/net/instaweb/rewriter/rewrite_driver.cc
+++ b/net/instaweb/rewriter/rewrite_driver.cc
@@ -2178,7 +2178,8 @@ bool RewriteDriver::StartParseId(const StringPiece& url, const StringPiece& id,
 void RewriteDriver::ParseTextInternal(const char* content, int size) {
   num_bytes_in_ += size;
   if (ShouldSkipParsing()) {
-    writer()->Write(content, message_handler());
+    StringPiece sp(content, size);
+    writer()->Write(sp, message_handler());
   } else if (debug_filter_ != NULL) {
     debug_filter_->StartParse();
     HtmlParse::ParseTextInternal(content, size);


### PR DESCRIPTION
When RewriteDriver::ShouldSkipParsing returns true, Write is
called with content without size. This results in conversion
of content to StringPiece and relying on strlen to determine
size. This could result in buffer over-read if content is
not NULL-terminated.

Fixes https://github.com/pagespeed/mod_pagespeed/issues/1590