### PR TITLE
Dont inline css from style link element in body when pedantic filter enabled. This is to maintain w3c validation of page. Bug fix #1153

### DIFF
--- a/install/mod_pagespeed_test/inline_style_link_in_body/inlining_style_link_body.html
+++ b/install/mod_pagespeed_test/inline_style_link_in_body/inlining_style_link_body.html
@@ -1,0 +1,11 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <title>Inline css example</title>
+    <script>var x=1;</script>
+    <meta charset="UTF-8">
+  </head>
+  <body>
+    <link property="stylesheet" rel="stylesheet" href="style.css">
+  </body>
+</html>

--- a/install/mod_pagespeed_test/inline_style_link_in_body/style.css
+++ b/install/mod_pagespeed_test/inline_style_link_in_body/style.css
@@ -1,0 +1,5 @@
+.foo {
+    background-color: lightblue;
+    width: 100px;
+    height: 100px;
+}

--- a/net/instaweb/rewriter/css_inline_filter.cc
+++ b/net/instaweb/rewriter/css_inline_filter.cc
@@ -97,7 +97,8 @@ class CssInlineFilter::Context : public InlineRewriteContext {
 CssInlineFilter::CssInlineFilter(RewriteDriver* driver)
     : CommonFilter(driver),
       id_(RewriteOptions::kCssInlineId),
-      size_threshold_bytes_(driver->options()->css_inline_max_bytes()) {
+      size_threshold_bytes_(driver->options()->css_inline_max_bytes()),
+      in_body_(false) {
   Statistics* stats = server_context()->statistics();
   num_css_inlined_ = stats->GetVariable(kNumCssInlined);
 }
@@ -111,11 +112,22 @@ void CssInlineFilter::StartDocumentImpl() {
 
 CssInlineFilter::~CssInlineFilter() {}
 
+void CssInlineFilter::StartElementImpl(HtmlElement* element) {
+  if (element->keyword() == HtmlName::kBody) {
+    in_body_ = true;
+  }
+}
+
 void CssInlineFilter::EndElementImpl(HtmlElement* element) {
   // Don't inline if the CSS element is under <noscript>.
   if (noscript_element() != NULL) {
     return;
   }
+
+  if (element->keyword() == HtmlName::kBody) {
+    in_body_ = false;
+  }
+
   HtmlElement::Attribute* href = NULL;
   const char* media = NULL;
   if (CssTagScanner::ParseCssElement(element, &href, &media) &&
@@ -138,6 +150,19 @@ void CssInlineFilter::EndElementImpl(HtmlElement* element) {
           "CSS not inlined because media does not match screen", element);
       return;
     }
+
+    // Dont inline if style <link> element is in html body AND
+    // move_css_to_head is not enabled. Pedantic used for html compatibility.
+    // This is to maintain w3c validation since style element is
+    // not recommended in html body. Issue fix #1153.
+    if (in_body_ &&
+        driver()->options()->Enabled(RewriteOptions::kPedantic) &&
+        !driver()->options()->Enabled(RewriteOptions::kMoveCssToHead)) {
+      driver()->InsertDebugComment(
+          "CSS not inlined because style link element in html body", element);
+      return;
+    }
+
     // Ask the LSC filter to work out how to handle this element. A return
     // value of true means we don't have to rewrite it so can skip that.
     // The state is carried forward to after we initiate rewriting since

--- a/net/instaweb/rewriter/css_inline_filter.cc
+++ b/net/instaweb/rewriter/css_inline_filter.cc
@@ -97,7 +97,8 @@ class CssInlineFilter::Context : public InlineRewriteContext {
 CssInlineFilter::CssInlineFilter(RewriteDriver* driver)
     : CommonFilter(driver),
       id_(RewriteOptions::kCssInlineId),
-      size_threshold_bytes_(driver->options()->css_inline_max_bytes()) {
+      size_threshold_bytes_(driver->options()->css_inline_max_bytes()),
+      in_body_(false) {
   Statistics* stats = server_context()->statistics();
   num_css_inlined_ = stats->GetVariable(kNumCssInlined);
 }

--- a/net/instaweb/rewriter/public/css_inline_filter.h
+++ b/net/instaweb/rewriter/public/css_inline_filter.h
@@ -47,7 +47,7 @@ class CssInlineFilter : public CommonFilter {
   virtual ~CssInlineFilter();
 
   virtual void StartDocumentImpl();
-  virtual void StartElementImpl(HtmlElement* element) {}
+  virtual void StartElementImpl(HtmlElement* element);
   virtual void EndElementImpl(HtmlElement* element);
   virtual const char* Name() const { return "InlineCss"; }
   // Inlining css from unauthorized domains into HTML is considered
@@ -93,6 +93,7 @@ class CssInlineFilter : public CommonFilter {
   GoogleString domain_;
 
   Variable* num_css_inlined_;
+  bool in_body_;
 
   DISALLOW_COPY_AND_ASSIGN(CssInlineFilter);
 };

--- a/net/instaweb/rewriter/public/css_inline_filter.h
+++ b/net/instaweb/rewriter/public/css_inline_filter.h
@@ -93,7 +93,7 @@ class CssInlineFilter : public CommonFilter {
   GoogleString domain_;
 
   Variable* num_css_inlined_;
-  bool inlining_not_pedantically_spec_;
+  bool in_body_;
 
   DISALLOW_COPY_AND_ASSIGN(CssInlineFilter);
 };

--- a/net/instaweb/rewriter/public/css_inline_filter.h
+++ b/net/instaweb/rewriter/public/css_inline_filter.h
@@ -93,7 +93,7 @@ class CssInlineFilter : public CommonFilter {
   GoogleString domain_;
 
   Variable* num_css_inlined_;
-  bool in_body_;
+  bool inlining_not_pedantically_spec_;
 
   DISALLOW_COPY_AND_ASSIGN(CssInlineFilter);
 };

--- a/pagespeed/system/system_test.sh
+++ b/pagespeed/system/system_test.sh
@@ -78,6 +78,7 @@ run_test aris
 run_test css_combining_authorization
 run_test add_instrumentation
 run_test type_attribute_pedantic
+run_test inline_css_link_element_in_body
 run_test cache_partial_html
 run_test flush_subresources
 run_test respect_custom_options

--- a/pagespeed/system/system_tests/inline_css_link_element_in_body.sh
+++ b/pagespeed/system/system_tests/inline_css_link_element_in_body.sh
@@ -26,7 +26,6 @@ $WGET -O $WGET_OUTPUT $TEST_ROOT/inline_style_link_in_body/inlining_style_link_b
 check [ $(grep -c "href=\"style.css\"" $WGET_OUTPUT) = 1 ]
 
 # css inlined and moved to head
-URL="http://localhost:8080/mod_pagespeed_test/inline_style_link_in_body/inlining_style_link_body.html?PageSpeedFilters=pedantic,inline_css,move_css_to_head"
+URL="$TEST_ROOT/inline_style_link_in_body/inlining_style_link_body.html?PageSpeedFilters=pedantic,inline_css,move_css_to_head"
 # checking contents of inlined css
-# check [ $(grep -c ".foo" $WGET_OUTPUT) = 1 ]
 http_proxy=$SECONDARY_HOSTNAME fetch_until -save "$URL" 'fgrep -c .foo' 1

--- a/pagespeed/system/system_tests/inline_css_link_element_in_body.sh
+++ b/pagespeed/system/system_tests/inline_css_link_element_in_body.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Testing css inline for style link element in html body,
+# with pedantic, move_css_to_head filters.
+
+start_test CSS inline with style element in html body.
+
+# css not inlined because style link element in body
+# AND pedantic filter is enabled
+$WGET -O $WGET_OUTPUT $TEST_ROOT/inline_style_link_in_body/inlining_style_link_body.html\
+?PageSpeedFilters=pedantic,inline_css
+# checking for no inlining of css
+check [ $(grep -c "href=\"style.css\"" $WGET_OUTPUT) = 1 ]
+
+# css inlined and moved to head
+$WGET -O $WGET_OUTPUT $TEST_ROOT/inline_style_link_in_body/inlining_style_link_body.html\
+?PageSpeedFilters=pedantic,inline_css,move_css_to_head
+# checking contents of inlined css
+check [ $(grep -c ".foo" $WGET_OUTPUT) = 1 ]

--- a/pagespeed/system/system_tests/inline_css_link_element_in_body.sh
+++ b/pagespeed/system/system_tests/inline_css_link_element_in_body.sh
@@ -25,6 +25,11 @@ $WGET -O $WGET_OUTPUT $TEST_ROOT/inline_style_link_in_body/inlining_style_link_b
 # checking for no inlining of css
 check [ $(grep -c "href=\"style.css\"" $WGET_OUTPUT) = 1 ]
 
+# css inlined in html body because pedantic filter not enabled
+URL="$TEST_ROOT/inline_style_link_in_body/inlining_style_link_body.html?PageSpeedFilters=inline_css"
+# checking contents of inlined css
+http_proxy=$SECONDARY_HOSTNAME fetch_until -save "$URL" 'fgrep -c .foo' 1
+
 # css inlined and moved to head
 URL="$TEST_ROOT/inline_style_link_in_body/inlining_style_link_body.html?PageSpeedFilters=pedantic,inline_css,move_css_to_head"
 # checking contents of inlined css

--- a/pagespeed/system/system_tests/inline_css_link_element_in_body.sh
+++ b/pagespeed/system/system_tests/inline_css_link_element_in_body.sh
@@ -26,7 +26,7 @@ $WGET -O $WGET_OUTPUT $TEST_ROOT/inline_style_link_in_body/inlining_style_link_b
 check [ $(grep -c "href=\"style.css\"" $WGET_OUTPUT) = 1 ]
 
 # css inlined and moved to head
-$WGET -O $WGET_OUTPUT $TEST_ROOT/inline_style_link_in_body/inlining_style_link_body.html\
-?PageSpeedFilters=pedantic,inline_css,move_css_to_head
+URL="http://localhost:8080/mod_pagespeed_test/inline_style_link_in_body/inlining_style_link_body.html?PageSpeedFilters=pedantic,inline_css,move_css_to_head"
 # checking contents of inlined css
-check [ $(grep -c ".foo" $WGET_OUTPUT) = 1 ]
+# check [ $(grep -c ".foo" $WGET_OUTPUT) = 1 ]
+http_proxy=$SECONDARY_HOSTNAME fetch_until -save "$URL" 'fgrep -c .foo' 1


### PR DESCRIPTION
When pedantic filter is enabled, style link element in body is not inlined. When move_css_to_head filter is enabled, inlining is allowed because css is moved to head which is valid as per w3c standard.
