### PR TITLE
CSS minification issues fix. Issue #1538 and #1572 fix.

### DIFF
--- a/install/mod_pagespeed_test/css_minify_calc_function_value_zero.html
+++ b/install/mod_pagespeed_test/css_minify_calc_function_value_zero.html
@@ -1,0 +1,5 @@
+<html>
+  <head>
+     <style property="stylesheet">@font-face{width: calc(50ex - 0px)}</style>
+  </head>
+</html>

--- a/install/mod_pagespeed_test/css_minify_unicode_range_descriptor.html
+++ b/install/mod_pagespeed_test/css_minify_unicode_range_descriptor.html
@@ -1,0 +1,5 @@
+<html>
+  <head>
+     <style property="stylesheet">@font-face{unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;}</style>
+  </head>
+</html>

--- a/net/instaweb/rewriter/css_minify_test.cc
+++ b/net/instaweb/rewriter/css_minify_test.cc
@@ -255,5 +255,36 @@ TEST_F(CssMinifyTest, StraySingleQuote3) {
   EXPECT_STREQ(".view_all a{display:block;margin:1px}", minified);
 }
 
+// checking whether unit is retained for zero value in calc function
+TEST_F(CssMinifyTest, CalcFunctionWithZeroValueAndUnit) {
+  static const char kCss[] =
+      "@font-face {\n"
+      " width: calc(600px - 0px)"
+      "}";
+
+  GoogleString minified;
+  StringWriter writer(&minified);
+  CssMinify minify(&writer, &handler_);
+
+  EXPECT_TRUE(minify.ParseStylesheet(kCss));
+  EXPECT_HAS_SUBSTR("width:calc(600px - 0px)", minified);
+}
+
+// checking unicode-range descriptor minification
+TEST_F(CssMinifyTest, CssUnicodeRangeDescriptor) {
+  static const char kCss[] =
+      "@font-face {\n"
+      " unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;\n"
+      "}";
+
+  GoogleString minified;
+  StringWriter writer(&minified);
+  CssMinify minify(&writer, &handler_);
+
+  EXPECT_TRUE(minify.ParseStylesheet(kCss));
+  EXPECT_HAS_SUBSTR("unicode-range:U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116",
+      minified);
+}
+
 }  // namespace
 }  // namespace net_instaweb

--- a/net/instaweb/rewriter/public/css_minify.h
+++ b/net/instaweb/rewriter/public/css_minify.h
@@ -123,12 +123,15 @@ class CssMinify {
   bool Equals(const Css::MediaExpression& a,
               const Css::MediaExpression& b) const;
 
+  bool UnitsRequiredForValueZero(const GoogleString& unit);
+
   Writer* writer_;
   Writer* error_writer_;
   MessageHandler* handler_;
   bool ok_;
 
   StringVector* url_collector_;
+  bool in_css_calc_function_;
 
   DISALLOW_COPY_AND_ASSIGN(CssMinify);
 };

--- a/pagespeed/system/system_test.sh
+++ b/pagespeed/system/system_test.sh
@@ -76,6 +76,8 @@ SYSTEM_TEST_DIR="$(dirname "${BASH_SOURCE[0]}")/system_tests/"
 run_test check_headers
 run_test aris
 run_test css_combining_authorization
+run_test css_minify_calc_function_value_zero
+run_test css_minify_unicode_range_descriptor
 run_test add_instrumentation
 run_test type_attribute_pedantic
 run_test cache_partial_html

--- a/pagespeed/system/system_tests/css_minify_calc_function_value_zero.sh
+++ b/pagespeed/system/system_tests/css_minify_calc_function_value_zero.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Testing css minify for retained unit in calc function and with 0 value.
+
+start_test CSS minify with calc function and value 0.
+
+URL="$TEST_ROOT/css_minify_calc_function_value_zero.html?PageSpeedFilters=+inline_css"
+RESPONSE_OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP $URL)
+
+# checking for minified css with unit retained for 0 value 
+MATCHES=$(echo "$RESPONSE_OUT" | fgrep -c "width:calc(50ex - 0px)")
+check [ $MATCHES -eq 1 ]

--- a/pagespeed/system/system_tests/css_minify_unicode_range_descriptor.sh
+++ b/pagespeed/system/system_tests/css_minify_unicode_range_descriptor.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Testing css minification for unicode range descriptor in font-face
+
+start_test CSS minify for unicode-range descriptor.
+
+URL="$TEST_ROOT/css_minify_unicode_range_descriptor.html?PageSpeedFilters=+inline_css"
+RESPONSE_OUT=$(http_proxy=$SECONDARY_HOSTNAME $WGET_DUMP $URL)
+
+# checking for unicode range with valid construct 
+MATCHES=$(echo "$RESPONSE_OUT" | fgrep -c "unicode-range:U+0400-045F,U+0490-0491,U+04B0-04B1,U+2116")
+check [ $MATCHES -eq 1 ]


### PR DESCRIPTION
- UnitsRequiredForValueZero() function from css_minify.cc was in the anonymous namespace.I have moved it to default(net_instaweb) namespace.The reason being I need to use member variable(in_css_calc_function_) in this function to check whether unit is required or not.
I could have checked this variable by ORing here https://github.com/pagespeed/mod_pagespeed/blob/master/net/instaweb/rewriter/css_minify.cc#L465
But I find it more appropriate inside UnitsRequiredForValueZero() function.

- In CssMinify::Minify(const Css::Declaration& declaration) function, there is switch case where css property element gets resolved. I could not find appropriate enum for unicode-range property in that (third party css parser implementation). Else the implementation would have been much cleaner.
There is TODO for implementing parser for unicode-range descriptor.
https://github.com/pagespeed/mod_pagespeed/blob/master/third_party/css_parser/src/webutil/css/parser_unittest.cc#L2424