### PR TITLE
modpagespeed.com: post-migration fixes for the system tests

### DIFF
--- a/install/Makefile
+++ b/install/Makefile
@@ -74,7 +74,7 @@ APACHE_PROGRAM           = /usr/sbin/apache2
 
 # For testing proxying of an external domain, this represents the domain we
 # are proxying from.
-PAGESPEED_TEST_HOST ?= modpagespeed.com
+PAGESPEED_TEST_HOST ?= selfsigned.modpagespeed.com
 export PAGESPEED_TEST_HOST
 
 # The installation directory for executables

--- a/install/mod_pagespeed_test/unauthorized/inline_css.html
+++ b/install/mod_pagespeed_test/unauthorized/inline_css.html
@@ -2,7 +2,7 @@
   <head>
     <title>inline_css example</title>
     <!-- modpagespeed.com is not authorized in the tests -->
-    <link rel="stylesheet" href="http://modpagespeed.com/testfiles/google-cse-default.css">
+    <link rel="stylesheet" href="https://www.modpagespeed.com/testfiles/google-cse-default.css">
     <link rel="stylesheet" href="../../mod_pagespeed_example/styles/all_styles.css">
   </head>
   <body>

--- a/install/mod_pagespeed_test/unauthorized/prioritize_critical_css.html
+++ b/install/mod_pagespeed_test/unauthorized/prioritize_critical_css.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>prioritize_critical_css example</title>
-    <link rel="stylesheet" type="text/css" href="http://modpagespeed.com/testfiles/google-cse-default.css">
+    <link rel="stylesheet" type="text/css" href="https://www.modpagespeed.com/testfiles/google-cse-default.css">
     <link rel="stylesheet" type="text/css" href="with_unauthorized_imports.css">
   </head>
   <body>

--- a/pagespeed/apache/system_test.sh
+++ b/pagespeed/apache/system_test.sh
@@ -49,7 +49,7 @@ SKIP_EXTERNAL_RESOURCE_TESTS=${SKIP_EXTERNAL_RESOURCE_TESTS:-false}
 SUDO=${SUDO:-}
 # TODO(jkarlin): Should we just use a vhost instead?  If so, remember to update
 # all scripts that use TEST_PROXY_ORIGIN.
-PAGESPEED_TEST_HOST=${PAGESPEED_TEST_HOST:-modpagespeed.com}
+PAGESPEED_TEST_HOST=${PAGESPEED_TEST_HOST:-selfsigned.modpagespeed.com}
 
 SERVER_NAME=apache
 

--- a/pagespeed/system/system_tests/inline_unauth.sh
+++ b/pagespeed/system/system_tests/inline_unauth.sh
@@ -57,7 +57,7 @@ OUTFILE=$OUTDIR/blocking_rewrite.out.html
 $WGET_DUMP --header 'X-PSA-Blocking-Rewrite: psatest' $URL > $OUTFILE
 check egrep -q 'link[[:space:]]rel=' $OUTFILE
 EXPECTED_COMMENT_LINE="<!--The preceding resource was not rewritten because"
-EXPECTED_COMMENT_LINE+=" its domain (modpagespeed.com) is not authorized-->"
+EXPECTED_COMMENT_LINE+=" its domain (www.modpagespeed.com) is not authorized-->"
 check [ $(grep -o "$EXPECTED_COMMENT_LINE" $OUTFILE | wc -l) -eq 1 ]
 
 start_test inline_unauthorized_resources allows inlining

--- a/pagespeed/system/system_tests/no_critical_unauthorized_resources.sh
+++ b/pagespeed/system/system_tests/no_critical_unauthorized_resources.sh
@@ -34,7 +34,7 @@ check_not fgrep -q "interesting_color" $FETCH_FILE
 check [ $(fgrep -c "non_flattened_selector" $FETCH_FILE) -eq 1 ]
 EXPECTED_IMPORT_FAILURE_LINE="<!--Flattening failed: Cannot import http://www.google.com/css/maia.css as it is on an unauthorized domain-->"
 check [ $(grep -o "$EXPECTED_IMPORT_FAILURE_LINE" $FETCH_FILE | wc -l) -eq 1 ]
-EXPECTED_COMMENT_LINE="<!--The preceding resource was not rewritten because its domain (modpagespeed.com) is not authorized-->"
+EXPECTED_COMMENT_LINE="<!--The preceding resource was not rewritten because its domain (www.modpagespeed.com) is not authorized-->"
 check [ $(grep -o "$EXPECTED_COMMENT_LINE" $FETCH_FILE | wc -l) -eq 1 ]
 
 start_test inline_unauthorized_resources allows unauthorized css selectors


### PR DESCRIPTION
http(s)://modpagespeed.com and https://modpagespeed.com now redirect to https://www.modpagespeed.com/. 

This change makes the system tests pass with that change.

