### PR TITLE
CSP: Handle restrictions on output URL, base

### DIFF
--- a/net/instaweb/rewriter/cache_extender.cc
+++ b/net/instaweb/rewriter/cache_extender.cc
@@ -65,13 +65,15 @@ const int64 kMinThresholdMs = Timer::kMonthMs;
 
 class CacheExtender::Context : public SingleRewriteContext {
  public:
-  Context(CacheExtender* extender, RewriteDriver* driver,
+  Context(RewriteDriver::InputRole input_role,
+          CacheExtender* extender, RewriteDriver* driver,
           RewriteContext* parent)
       : SingleRewriteContext(driver, parent,
                              NULL /* no resource context */),
-        extender_(extender) {}
+        input_role_(input_role), extender_(extender) {}
   virtual ~Context() {}
 
+  bool PolicyPermitsRendering() const override;
   virtual void Render();
   virtual void RewriteSingle(const ResourcePtr& input,
                              const OutputResourcePtr& output);
@@ -101,6 +103,7 @@ class CacheExtender::Context : public SingleRewriteContext {
   }
 
  private:
+  RewriteDriver::InputRole input_role_;
   CacheExtender* extender_;
   DISALLOW_COPY_AND_ASSIGN(Context);
 };
@@ -218,7 +221,8 @@ void CacheExtender::StartElementImpl(HtmlElement* element) {
 
       ResourceSlotPtr slot(driver()->GetSlot(
           input_resource, element, attributes[i].url));
-      Context* context = new Context(this, driver(), NULL /* not nested */);
+      Context* context = new Context(input_role, this, driver(),
+                                     NULL /* not nested */);
       context->AddSlot(slot);
       driver()->InitiateRewrite(context);
     }
@@ -237,7 +241,9 @@ void CacheExtender::StartElementImpl(HtmlElement* element) {
         if (slot == nullptr) {
           continue;
         }
-        Context* context = new Context(this, driver(), nullptr /* !nested */);
+        Context* context = new Context(
+              RewriteDriver::InputRole::kImg, this,
+              driver(), nullptr /* !nested */);
         context->AddSlot(RefCountedPtr<ResourceSlot>(slot));
         driver()->InitiateRewrite(context);
       }
@@ -258,6 +264,19 @@ void CacheExtender::Context::RewriteSingle(
   RewriteDone(
       extender_->RewriteLoadedResource(
           input_resource, output_resource, mutable_output_partition(0)), 0);
+}
+
+bool CacheExtender::Context::PolicyPermitsRendering() const {
+  if (num_output_partitions() == 1 && output(0).get() != nullptr
+      && output(0)->has_hash()) {
+    // This uses the InputRole rather than CspDirective variant to
+    // handle kUnknown (and to get bonus handling of kReconstruction,
+    // which wouldn't actually call this, but for which we still need to
+    // override).
+    return Driver()->IsLoadPermittedByCsp(
+        GoogleUrl(output(0)->url()), input_role_);
+  }
+  return true;  // e.g. failure cases -> still want to permit error to render.
 }
 
 void CacheExtender::Context::Render() {
@@ -398,12 +417,14 @@ RewriteResult CacheExtender::RewriteLoadedResource(
 }
 
 RewriteContext* CacheExtender::MakeRewriteContext() {
-  return new Context(this, driver(), NULL /*not nested*/);
+  return new Context(RewriteDriver::InputRole::kReconstruction, this,
+                     driver(), NULL /*not nested*/);
 }
 
 RewriteContext* CacheExtender::MakeNestedContext(
     RewriteContext* parent, const ResourceSlotPtr& slot) {
-  Context* context = new Context(this, NULL /* driver*/, parent);
+  Context* context = new Context(
+      RewriteDriver::InputRole::kUnknown, this, NULL /* driver*/, parent);
   context->AddSlot(slot);
   return context;
 }

--- a/net/instaweb/rewriter/cache_extender.cc
+++ b/net/instaweb/rewriter/cache_extender.cc
@@ -222,7 +222,7 @@ void CacheExtender::StartElementImpl(HtmlElement* element) {
       ResourceSlotPtr slot(driver()->GetSlot(
           input_resource, element, attributes[i].url));
       Context* context = new Context(input_role, this, driver(),
-                                     NULL /* not nested */);
+                                     nullptr /* not nested */);
       context->AddSlot(slot);
       driver()->InitiateRewrite(context);
     }
@@ -418,13 +418,13 @@ RewriteResult CacheExtender::RewriteLoadedResource(
 
 RewriteContext* CacheExtender::MakeRewriteContext() {
   return new Context(RewriteDriver::InputRole::kReconstruction, this,
-                     driver(), NULL /*not nested*/);
+                     driver(), nullptr /*not nested*/);
 }
 
 RewriteContext* CacheExtender::MakeNestedContext(
     RewriteContext* parent, const ResourceSlotPtr& slot) {
   Context* context = new Context(
-      RewriteDriver::InputRole::kUnknown, this, NULL /* driver*/, parent);
+      RewriteDriver::InputRole::kUnknown, this, nullptr /* driver*/, parent);
   context->AddSlot(slot);
   return context;
 }

--- a/net/instaweb/rewriter/cache_extender_test.cc
+++ b/net/instaweb/rewriter/cache_extender_test.cc
@@ -1159,6 +1159,7 @@ TEST_F(CacheExtenderTest, VaryOrigin) {
 
 TEST_F(CacheExtenderTest, RenderCsp) {
   InitTest(100);
+  EnableDebug();
 
   InitResource("a.jpg", kContentTypeJpeg, kImageData, 100);
   InitResource("b.js", kContentTypeJavascript, kJsData, 100);
@@ -1166,7 +1167,7 @@ TEST_F(CacheExtenderTest, RenderCsp) {
 
   const char kCsp[] =
       "<meta http-equiv=\"Content-Security-Policy\" "
-      "content=\"img-src *; script-src b.js; style-src c.css;\">";
+      "content=\"img-src *; script-src */b.js; style-src */c.css;\">";
 
   // First rewrite w/o CSP, everything is expanded.
   ValidateExpected("no_csp",
@@ -1186,7 +1187,10 @@ TEST_F(CacheExtenderTest, RenderCsp) {
       StrCat(kCsp,
              "<img src=a.jpg.pagespeed.ce.0.jpg>"
              "<script src=b.js></script>"
-             "<link rel=stylesheet href=c.css>"));
+             "<!--PageSpeed output not permitted by Content Security Policy-->"
+             "<link rel=stylesheet href=c.css>"
+             "<!--PageSpeed output not permitted by Content Security Policy"
+             "-->"));
 }
 
 }  // namespace

--- a/net/instaweb/rewriter/cache_extender_test.cc
+++ b/net/instaweb/rewriter/cache_extender_test.cc
@@ -1187,9 +1187,11 @@ TEST_F(CacheExtenderTest, RenderCsp) {
       StrCat(kCsp,
              "<img src=a.jpg.pagespeed.ce.0.jpg>"
              "<script src=b.js></script>"
-             "<!--PageSpeed output not permitted by Content Security Policy-->"
+             "<!--PageSpeed output (by CacheExtender) not permitted by Content "
+             "Security Policy-->"
              "<link rel=stylesheet href=c.css>"
-             "<!--PageSpeed output not permitted by Content Security Policy"
+             "<!--PageSpeed output (by CacheExtender) not permitted by Content "
+             "Security Policy"
              "-->"));
 }
 

--- a/net/instaweb/rewriter/cache_extender_test.cc
+++ b/net/instaweb/rewriter/cache_extender_test.cc
@@ -1158,12 +1158,13 @@ TEST_F(CacheExtenderTest, VaryOrigin) {
 }
 
 TEST_F(CacheExtenderTest, RenderCsp) {
-  InitTest(100);
+  InitTest(kShortTtlSec);
   EnableDebug();
 
-  InitResource("a.jpg", kContentTypeJpeg, kImageData, 100);
-  InitResource("b.js", kContentTypeJavascript, kJsData, 100);
-  InitResource("c.css", kContentTypeCss, "* {display:   block; }", 100);
+  InitResource("a.jpg", kContentTypeJpeg, kImageData, kShortTtlSec);
+  InitResource("b.js", kContentTypeJavascript, kJsData, kShortTtlSec);
+  InitResource("c.css", kContentTypeCss, "* {display:   block; }",
+               kShortTtlSec);
 
   const char kCsp[] =
       "<meta http-equiv=\"Content-Security-Policy\" "

--- a/net/instaweb/rewriter/collect_dependencies_filter.cc
+++ b/net/instaweb/rewriter/collect_dependencies_filter.cc
@@ -192,6 +192,10 @@ class CollectDependenciesFilter::Context : public RewriteContext {
     return "cdf";
   }
 
+  bool PolicyPermitsRendering() const {
+    return true;  // We don't alter the doc...
+  }
+
   void Render() override {
     Report();
   }

--- a/net/instaweb/rewriter/common_filter.cc
+++ b/net/instaweb/rewriter/common_filter.cc
@@ -138,14 +138,15 @@ void CommonFilter::Characters(net_instaweb::HtmlCharactersNode* characters) {
 // Different browsers deal with such refs differently, but we shouldn't
 // change their behavior.
 bool CommonFilter::BaseUrlIsValid() const {
-  // If there are no href or src attributes before the base, it's
-  // always valid.
-  if (!driver_->refs_before_base()) {
+  // If there are no href or src attributes before the base, or a broken base,
+  // it's valid.
+  if (!driver_->refs_before_base() && !driver_->other_base_problem()) {
     return true;
   }
   // If the filter has already seen the base url, then it's now valid
-  // even if there were urls before it.
-  return seen_base_;
+  // even if there were urls before it --- unless something else was
+  // wrong.
+  return seen_base_ && !driver_->other_base_problem();
 }
 
 void CommonFilter::ResolveUrl(StringPiece input_url, GoogleUrl* out_url) {
@@ -156,6 +157,17 @@ void CommonFilter::ResolveUrl(StringPiece input_url, GoogleUrl* out_url) {
     } else if (base_url().IsWebValid()) {
       out_url->Reset(base_url(), input_url);
     }
+  }
+}
+
+bool CommonFilter::IsRelativeUrlLoadPermittedByCsp(
+    StringPiece url, CspDirective role) {
+  GoogleUrl abs_url;
+  ResolveUrl(url, &abs_url);
+  if (abs_url.IsWebValid()) {
+    return driver()->IsLoadPermittedByCsp(abs_url, role);
+  } else {
+    return false;
   }
 }
 

--- a/net/instaweb/rewriter/css_combine_filter.cc
+++ b/net/instaweb/rewriter/css_combine_filter.cc
@@ -270,6 +270,10 @@ class CssCombineFilter::Context : public RewriteContext {
     RewriteDone(result, partition_index);
   }
 
+  bool PolicyPermitsRendering() const override {
+    return AreOutputsAllowedByCsp(CspDirective::kStyleSrc);
+  }
+
   virtual void Render() {
     for (int p = 0, np = num_output_partitions(); p < np; ++p) {
       const CachedResult* partition = output_partition(p);

--- a/net/instaweb/rewriter/css_filter.cc
+++ b/net/instaweb/rewriter/css_filter.cc
@@ -290,6 +290,10 @@ bool CssFilter::Context::SendFallbackResponse(
   return ret;
 }
 
+bool CssFilter::Context::PolicyPermitsRendering() const {
+  return AreOutputsAllowedByCsp(CspDirective::kStyleSrc);
+}
+
 void CssFilter::Context::Render() {
   if (num_output_partitions() == 0) {
     return;

--- a/net/instaweb/rewriter/css_filter_test.cc
+++ b/net/instaweb/rewriter/css_filter_test.cc
@@ -2488,8 +2488,8 @@ TEST_F(CssFilterTest, RenderCsp) {
       "render_csp",
       StrCat(kCsp, CssLinkHref("styles/a.css")),
       StrCat(kCsp, CssLinkHref("styles/a.css"),
-             "<!--PageSpeed output not permitted by Content Security Policy"
-             "-->"));
+             "<!--PageSpeed output (by CssFilter) not permitted by "
+             "Content Security Policy-->"));
 }
 
 class CssFilterTestUrlNamer : public CssFilterTest {

--- a/net/instaweb/rewriter/css_filter_test.cc
+++ b/net/instaweb/rewriter/css_filter_test.cc
@@ -2468,6 +2468,7 @@ TEST_F(CssFilterTest, InlineCsp) {
 }
 
 TEST_F(CssFilterTest, RenderCsp) {
+  EnableDebug();
   SetResponseWithDefaultHeaders("styles/a.css",
                                 kContentTypeCss, kInputStyle, 100);
   SetResponseWithDefaultHeaders("uploads/sneaky.png",
@@ -2483,7 +2484,12 @@ TEST_F(CssFilterTest, RenderCsp) {
       CssLinkHref(Encode("styles/", "cf", "0", "a.css", "css")));
 
   // CSP applied at render time, from cached result.
-  ValidateNoChanges("render_csp", StrCat(kCsp, CssLinkHref("styles/a.css")));
+  ValidateExpected(
+      "render_csp",
+      StrCat(kCsp, CssLinkHref("styles/a.css")),
+      StrCat(kCsp, CssLinkHref("styles/a.css"),
+             "<!--PageSpeed output not permitted by Content Security Policy"
+             "-->"));
 }
 
 class CssFilterTestUrlNamer : public CssFilterTest {

--- a/net/instaweb/rewriter/css_filter_test.cc
+++ b/net/instaweb/rewriter/css_filter_test.cc
@@ -2467,6 +2467,25 @@ TEST_F(CssFilterTest, InlineCsp) {
              "<!--Avoiding modifying inline style with CSP present-->"));
 }
 
+TEST_F(CssFilterTest, RenderCsp) {
+  SetResponseWithDefaultHeaders("styles/a.css",
+                                kContentTypeCss, kInputStyle, 100);
+  SetResponseWithDefaultHeaders("uploads/sneaky.png",
+                                kContentTypeCss, kInputStyle, 100);
+
+  static const char kCsp[] = "<meta http-equiv=\"Content-Security-Policy\" "
+                             "content=\"style-src */styles/a.css \">";
+
+  // No CSP -> fine.
+  ValidateExpected(
+      "no_csp",
+      CssLinkHref("styles/a.css"),
+      CssLinkHref(Encode("styles/", "cf", "0", "a.css", "css")));
+
+  // CSP applied at render time, from cached result.
+  ValidateNoChanges("render_csp", StrCat(kCsp, CssLinkHref("styles/a.css")));
+}
+
 class CssFilterTestUrlNamer : public CssFilterTest {
  public:
   CssFilterTestUrlNamer() {

--- a/net/instaweb/rewriter/css_inline_filter.cc
+++ b/net/instaweb/rewriter/css_inline_filter.cc
@@ -60,6 +60,10 @@ class CssInlineFilter::Context : public InlineRewriteContext {
     return filter_->ShouldInline(resource, attrs_charset_, reason);
   }
 
+  bool PolicyPermitsRendering() const override {
+    return Driver()->content_security_policy().PermitsInlineStyle();
+  }
+
   virtual void Render() {
     if (num_output_partitions() < 1 ||
         !output_partition(0)->has_inlined_data()) {

--- a/net/instaweb/rewriter/css_inline_filter_test.cc
+++ b/net/instaweb/rewriter/css_inline_filter_test.cc
@@ -822,8 +822,9 @@ TEST_F(CssInlineFilterTest, BasicCsp) {
       "<meta http-equiv=\"Content-Security-Policy\" "
       "content=\"style-src * 'unsafe-inline';\">";
 
-  ValidateNoChanges(
+  ValidateExpected(
       "no_inline_csp",
+      StrCat(kCspNoInline, CssLinkHref("a.css")),
       StrCat(kCspNoInline, CssLinkHref("a.css"),
              "<!--PageSpeed output (by ci) not permitted by "
              "Content Security Policy-->"));

--- a/net/instaweb/rewriter/css_inline_filter_test.cc
+++ b/net/instaweb/rewriter/css_inline_filter_test.cc
@@ -825,8 +825,8 @@ TEST_F(CssInlineFilterTest, BasicCsp) {
   ValidateNoChanges(
       "no_inline_csp",
       StrCat(kCspNoInline, CssLinkHref("a.css"),
-             "<!--PageSpeed output not permitted by Content Security Policy"
-             "-->"));
+             "<!--PageSpeed output (by ci) not permitted by "
+             "Content Security Policy-->"));
   ValidateExpected("yes_inline_csp",
                    StrCat(kCspYesInline, CssLinkHref("a.css")),
                    StrCat(kCspYesInline, "<style>a{margin:0}</style>"));

--- a/net/instaweb/rewriter/css_inline_filter_test.cc
+++ b/net/instaweb/rewriter/css_inline_filter_test.cc
@@ -811,6 +811,24 @@ TEST_F(CssInlineFilterTest, CheckInliningOfLinkStyleTagInBodyNonPedantic) {
       "</head><body></body></html>");
 }
 
+TEST_F(CssInlineFilterTest, BasicCsp) {
+  AddFilter(RewriteOptions::kInlineCss);
+  SetResponseWithDefaultHeaders("a.css", kContentTypeCss, "a{margin:0}", 100);
+  TurnOnDebug();
+
+  const char kCspNoInline[] =
+      "<meta http-equiv=\"Content-Security-Policy\" content=\"style-src *;\">";
+  const char kCspYesInline[] =
+      "<meta http-equiv=\"Content-Security-Policy\" "
+      "content=\"style-src * 'unsafe-inline';\">";
+
+  ValidateNoChanges("no_inline_csp",
+                    StrCat(kCspNoInline, CssLinkHref("a.css")));
+  ValidateExpected("yes_inline_csp",
+                   StrCat(kCspYesInline, CssLinkHref("a.css")),
+                   StrCat(kCspYesInline, "<style>a{margin:0}</style>"));
+}
+
 }  // namespace
 
 }  // namespace net_instaweb

--- a/net/instaweb/rewriter/css_inline_filter_test.cc
+++ b/net/instaweb/rewriter/css_inline_filter_test.cc
@@ -822,8 +822,11 @@ TEST_F(CssInlineFilterTest, BasicCsp) {
       "<meta http-equiv=\"Content-Security-Policy\" "
       "content=\"style-src * 'unsafe-inline';\">";
 
-  ValidateNoChanges("no_inline_csp",
-                    StrCat(kCspNoInline, CssLinkHref("a.css")));
+  ValidateNoChanges(
+      "no_inline_csp",
+      StrCat(kCspNoInline, CssLinkHref("a.css"),
+             "<!--PageSpeed output not permitted by Content Security Policy"
+             "-->"));
   ValidateExpected("yes_inline_csp",
                    StrCat(kCspYesInline, CssLinkHref("a.css")),
                    StrCat(kCspYesInline, "<style>a{margin:0}</style>"));

--- a/net/instaweb/rewriter/css_summarizer_base.cc
+++ b/net/instaweb/rewriter/css_summarizer_base.cc
@@ -68,6 +68,11 @@ class CssSummarizerBase::Context : public SingleRewriteContext {
   void SetupExternalRewrite(HtmlElement* element);
 
  protected:
+  bool PolicyPermitsRendering() const override {
+    // Subclasses are responsible for dealing with CSP.
+    return true;
+  }
+
   virtual void Render();
   virtual void WillNotRender();
   virtual void Cancel();

--- a/net/instaweb/rewriter/image_combine_filter.cc
+++ b/net/instaweb/rewriter/image_combine_filter.cc
@@ -837,6 +837,10 @@ class ImageCombineFilter::Context : public RewriteContext {
     RewriteDone(result, partition_index);
   }
 
+  bool PolicyPermitsRendering() const {
+    return AreOutputsAllowedByCsp(CspDirective::kImgSrc);
+  }
+
   // Finalize the declarations for the sprited slots.
   // TODO(nforman): be smarter about when to sprite and when not.
   // e.g. if it turns out all the divs are too big to use the sprite

--- a/net/instaweb/rewriter/image_rewrite_filter.cc
+++ b/net/instaweb/rewriter/image_rewrite_filter.cc
@@ -405,6 +405,7 @@ class ImageRewriteFilter::Context : public SingleRewriteContext {
             is_resized_using_rendered_dimensions) {}
   virtual ~Context() {}
 
+  bool PolicyPermitsRendering() const override;
   virtual void Render();
   virtual void RewriteSingle(const ResourcePtr& input,
                              const OutputResourcePtr& output);
@@ -561,6 +562,10 @@ void ImageRewriteFilter::Context::RewriteSingle(
   FindServerContext()->central_controller()->ScheduleExpensiveOperation(
       new InvokeRewriteFunction(this, filter_, input_resource,
                                 output_resource));
+}
+
+bool ImageRewriteFilter::Context::PolicyPermitsRendering() const {
+  return AreOutputsAllowedByCsp(CspDirective::kImgSrc);
 }
 
 void ImageRewriteFilter::Context::Render() {

--- a/net/instaweb/rewriter/image_rewrite_filter_test.cc
+++ b/net/instaweb/rewriter/image_rewrite_filter_test.cc
@@ -4440,7 +4440,7 @@ TEST_F(ImageRewriteTest, RenderCsp) {
 
   // We want a policy that only affects output resources here (since the input
   // one will apply at CreateInputResource time, before the cache lookup)
-  const char kCsp[] =
+  static const char kCsp[] =
       "<meta http-equiv=\"Content-Security-Policy\" "
       "content=\"img-src */images/ */uploads/b.png\">";
 

--- a/net/instaweb/rewriter/image_rewrite_filter_test.cc
+++ b/net/instaweb/rewriter/image_rewrite_filter_test.cc
@@ -4467,7 +4467,9 @@ TEST_F(ImageRewriteTest, RenderCsp) {
              "<img src=\"", Encode("images/", "ic", "0", "a.jpg", "jpg"), "\">",
              "<!--Image http://test.com/images/a.jpg does not appear "
              "to need resizing.-->"
-             "<img src=\"uploads/b.png\">"));
+             "<img src=\"uploads/b.png\">"
+             "<!--PageSpeed output not permitted by "
+             "Content Security Policy-->"));
 }
 
 }  // namespace net_instaweb

--- a/net/instaweb/rewriter/image_rewrite_filter_test.cc
+++ b/net/instaweb/rewriter/image_rewrite_filter_test.cc
@@ -4468,7 +4468,7 @@ TEST_F(ImageRewriteTest, RenderCsp) {
              "<!--Image http://test.com/images/a.jpg does not appear "
              "to need resizing.-->"
              "<img src=\"uploads/b.png\">"
-             "<!--PageSpeed output not permitted by "
+             "<!--PageSpeed output (by ImageRewrite) not permitted by "
              "Content Security Policy-->"));
 }
 

--- a/net/instaweb/rewriter/in_place_rewrite_context.cc
+++ b/net/instaweb/rewriter/in_place_rewrite_context.cc
@@ -308,6 +308,11 @@ int64 InPlaceRewriteContext::GetRewriteDeadlineAlarmMs() const {
   return RewriteContext::GetRewriteDeadlineAlarmMs();
 }
 
+bool InPlaceRewriteContext::PolicyPermitsRendering() const {
+  // Doesn't realy render, so output check isn't relevant.
+  return true;
+}
+
 void InPlaceRewriteContext::Harvest() {
   if (num_nested() == 1) {
     RewriteContext* const nested_context = nested(0);

--- a/net/instaweb/rewriter/javascript_filter.cc
+++ b/net/instaweb/rewriter/javascript_filter.cc
@@ -244,6 +244,10 @@ class JavascriptFilter::Context : public SingleRewriteContext {
     RewriteDone(RewriteJavascript(input, output), 0);
   }
 
+  bool PolicyPermitsRendering() const override {
+    return AreOutputsAllowedByCsp(CspDirective::kScriptSrc);
+  }
+
   void Render() override {
     if (num_output_partitions() != 1) {
       return;

--- a/net/instaweb/rewriter/javascript_filter_test.cc
+++ b/net/instaweb/rewriter/javascript_filter_test.cc
@@ -1457,6 +1457,29 @@ TEST_P(JavascriptFilterTest, InlineCsp) {
              "<!--Avoiding modifying inline script with CSP present-->"));
 }
 
+TEST_P(JavascriptFilterTest, CspBaseUri) {
+  InitFilters();
+  EnableDebug();
+  SetResponseWithDefaultHeaders(
+      "scripts/a.js", kContentTypeJavascript, kJsData, 100);
+
+  const char kCspAndBase[] =
+      "<meta http-equiv=\"Content-Security-Policy\" "
+      "content=\"base-uri whatever; script-src *\">"
+      "<base href=\"http://test.com/\">";
+
+  ValidateExpected(
+      "base_uri_csp",
+      StrCat(kCspAndBase,
+             ScriptSrc("scripts/a.js"),
+             ScriptSrc("http://test.com/scripts/a.js")),
+      StrCat(kCspAndBase,
+             "<!--Unable to check safety of a base with CSP base-uri, "
+             "proceeding conservatively.-->",
+             ScriptSrc("scripts/a.js"),
+             ScriptSrc("http://test.com/scripts/a.js.pagespeed.jm.0.js")));
+}
+
 // We test with use_experimental_minifier == GetParam() as both true and false.
 INSTANTIATE_TEST_CASE_P(JavascriptFilterTestInstance, JavascriptFilterTest,
                         ::testing::Bool());

--- a/net/instaweb/rewriter/javascript_filter_test.cc
+++ b/net/instaweb/rewriter/javascript_filter_test.cc
@@ -1492,7 +1492,7 @@ TEST_P(JavascriptFilterTest, CspBaseUri) {
   SetResponseWithDefaultHeaders(
       "scripts/a.js", kContentTypeJavascript, kJsData, 100);
 
-  const char kCspAndBase[] =
+  static const char kCspAndBase[] =
       "<meta http-equiv=\"Content-Security-Policy\" "
       "content=\"base-uri whatever; script-src *\">"
       "<base href=\"http://test.com/\">";

--- a/net/instaweb/rewriter/javascript_filter_test.cc
+++ b/net/instaweb/rewriter/javascript_filter_test.cc
@@ -1464,8 +1464,8 @@ TEST_P(JavascriptFilterTest, RenderCsp) {
       "render_csp",
       StrCat(kCsp, ScriptSrc("scripts/a.js")),
       StrCat(kCsp, ScriptSrc("scripts/a.js"),
-             "<!--PageSpeed output not permitted by Content Security Policy"
-             "-->"));
+             "<!--PageSpeed output (by JavascriptFilter) not permitted by "
+             "Content Security Policy-->"));
 }
 
 TEST_P(JavascriptFilterTest, InlineCsp) {

--- a/net/instaweb/rewriter/javascript_filter_test.cc
+++ b/net/instaweb/rewriter/javascript_filter_test.cc
@@ -1460,7 +1460,12 @@ TEST_P(JavascriptFilterTest, RenderCsp) {
 
   // Now render again w/CSP -- blocked since .pagespeed. resource isn't
   //permitted.
-  ValidateNoChanges("render_csp", StrCat(kCsp, ScriptSrc("scripts/a.js")));
+  ValidateExpected(
+      "render_csp",
+      StrCat(kCsp, ScriptSrc("scripts/a.js")),
+      StrCat(kCsp, ScriptSrc("scripts/a.js"),
+             "<!--PageSpeed output not permitted by Content Security Policy"
+             "-->"));
 }
 
 TEST_P(JavascriptFilterTest, InlineCsp) {

--- a/net/instaweb/rewriter/js_combine_filter.cc
+++ b/net/instaweb/rewriter/js_combine_filter.cc
@@ -334,6 +334,10 @@ class JsCombineFilter::Context : public RewriteContext {
     RewriteDone(result, partition_index);
   }
 
+  bool PolicyPermitsRendering() const {
+    return AreOutputsAllowedByCsp(CspDirective::kScriptSrc);
+  }
+
   // For every partition, write a new script tag that points to the
   // combined resource.  Then create new script tags for each slot
   // in the partition that evaluate the variable that refers to the

--- a/net/instaweb/rewriter/js_inline_filter.cc
+++ b/net/instaweb/rewriter/js_inline_filter.cc
@@ -56,6 +56,11 @@ class JsInlineFilter::Context : public InlineRewriteContext {
   }
 
   virtual const char* id() const { return RewriteOptions::kJavascriptInlineId; }
+
+  bool PolicyPermitsRendering() const override {
+    return Driver()->content_security_policy().PermitsInlineScript();
+  }
+
   RewriteDriver::InputRole InputRole() const override {
     return RewriteDriver::InputRole::kScript;
   }

--- a/net/instaweb/rewriter/js_inline_filter_test.cc
+++ b/net/instaweb/rewriter/js_inline_filter_test.cc
@@ -509,8 +509,7 @@ TEST_F(JsInlineFilterTest, NoFlushSplittingScriptTag) {
 
 TEST_F(JsInlineFilterTest, BasicCsp) {
   SetHtmlMimetype();
-  options()->SoftEnableFilterForTesting(RewriteOptions::kInlineJavascript);
-  rewrite_driver()->AddFilters();
+  AddFilter(RewriteOptions::kInlineJavascript);
   EnableDebug();
 
   const char kJs[] = "function id(x) { return x; }\n";
@@ -522,8 +521,11 @@ TEST_F(JsInlineFilterTest, BasicCsp) {
       "<meta http-equiv=\"Content-Security-Policy\" "
       "content=\"script-src * 'unsafe-inline';\">";
 
-  ValidateNoChanges("no_inline_csp",
-                    StrCat(kCspNoInline, "<script src=script.js></script>"));
+  ValidateExpected("no_inline_csp",
+                   StrCat(kCspNoInline, "<script src=script.js></script>"),
+                   StrCat(kCspNoInline, "<script src=script.js></script>"
+                          "<!--PageSpeed output (by ji) not permitted by "
+                          "Content Security Policy-->"));
   ValidateExpected(
       "inline_csp",
       StrCat(kCspYesInline, "<script src=script.js></script>"),

--- a/net/instaweb/rewriter/js_inline_filter_test.cc
+++ b/net/instaweb/rewriter/js_inline_filter_test.cc
@@ -511,6 +511,7 @@ TEST_F(JsInlineFilterTest, BasicCsp) {
   SetHtmlMimetype();
   options()->SoftEnableFilterForTesting(RewriteOptions::kInlineJavascript);
   rewrite_driver()->AddFilters();
+  EnableDebug();
 
   const char kJs[] = "function id(x) { return x; }\n";
   SetResponseWithDefaultHeaders("script.js", kContentTypeJavascript, kJs, 3000);

--- a/net/instaweb/rewriter/js_inline_filter_test.cc
+++ b/net/instaweb/rewriter/js_inline_filter_test.cc
@@ -512,12 +512,12 @@ TEST_F(JsInlineFilterTest, BasicCsp) {
   AddFilter(RewriteOptions::kInlineJavascript);
   EnableDebug();
 
-  const char kJs[] = "function id(x) { return x; }\n";
+  static const char kJs[] = "function id(x) { return x; }\n";
   SetResponseWithDefaultHeaders("script.js", kContentTypeJavascript, kJs, 3000);
 
-  const char kCspNoInline[] =
+  static const char kCspNoInline[] =
       "<meta http-equiv=\"Content-Security-Policy\" content=\"script-src *;\">";
-  const char kCspYesInline[] =
+  static const char kCspYesInline[] =
       "<meta http-equiv=\"Content-Security-Policy\" "
       "content=\"script-src * 'unsafe-inline';\">";
 

--- a/net/instaweb/rewriter/public/common_filter.h
+++ b/net/instaweb/rewriter/public/common_filter.h
@@ -113,6 +113,8 @@ class CommonFilter : public EmptyHtmlFilter {
   // out_url. If resolution fails, the resulting URL may be invalid.
   void ResolveUrl(StringPiece input_url, GoogleUrl* out_url);
 
+  bool IsRelativeUrlLoadPermittedByCsp(StringPiece url, CspDirective role);
+
   // Returns whether or not the base url is valid.  This value will change
   // as a filter processes the document.  E.g. If there are url refs before
   // the base tag is reached, it will return false until the filter sees the

--- a/net/instaweb/rewriter/public/csp.h
+++ b/net/instaweb/rewriter/public/csp.h
@@ -261,6 +261,15 @@ class CspContext {
     return true;
   }
 
+  bool HasAny(CspDirective directive) const {
+    for (const auto& policy : policies_) {
+      if (policy->SourceListFor(directive) != nullptr) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   void AddPolicy(std::unique_ptr<CspPolicy> policy);
   void Clear() { policies_.clear(); }
   size_t policies_size() const { return policies_.size(); }

--- a/net/instaweb/rewriter/public/css_filter.h
+++ b/net/instaweb/rewriter/public/css_filter.h
@@ -283,6 +283,7 @@ class CssFilter::Context : public SingleRewriteContext {
   CssHierarchy* mutable_hierarchy() { return &hierarchy_; }
 
  protected:
+  bool PolicyPermitsRendering() const override;
   void Render() override;
   virtual void Harvest();
   virtual bool Partition(OutputPartitions* partitions,

--- a/net/instaweb/rewriter/public/css_flatten_imports_context.h
+++ b/net/instaweb/rewriter/public/css_flatten_imports_context.h
@@ -174,10 +174,6 @@ class CssFlattenImportsContext : public SingleRewriteContext {
 
   bool PolicyPermitsRendering() const {
     // We apply CSP policy for flattening at top-level, not here.
-    // DO NOT SUBMIT: Actually turn flattening off if non-trivial CSP.
-    // The reason it's tricky: the policy that permitted us to flatten may
-    // have gone away by the time we render, so unless we can accurately
-    // keep track of anything, we have to be conservative.
     return true;
   }
 

--- a/net/instaweb/rewriter/public/css_flatten_imports_context.h
+++ b/net/instaweb/rewriter/public/css_flatten_imports_context.h
@@ -172,6 +172,15 @@ class CssFlattenImportsContext : public SingleRewriteContext {
     }
   }
 
+  bool PolicyPermitsRendering() const {
+    // We apply CSP policy for flattening at top-level, not here.
+    // DO NOT SUBMIT: Actually turn flattening off if non-trivial CSP.
+    // The reason it's tricky: the policy that permitted us to flatten may
+    // have gone away by the time we render, so unless we can accurately
+    // keep track of anything, we have to be conservative.
+    return true;
+  }
+
   virtual void Render() {
     // If we have flattened the imported file ...
     if (num_output_partitions() == 1 && output_partition(0)->optimizable()) {

--- a/net/instaweb/rewriter/public/fake_filter.h
+++ b/net/instaweb/rewriter/public/fake_filter.h
@@ -61,6 +61,7 @@ class FakeFilter : public RewriteFilter {
 
     virtual const char* id() const { return filter_->id(); }
     virtual OutputResourceKind kind() const { return filter_->kind(); }
+    bool PolicyPermitsRendering() const override { return true; }
 
    private:
     FakeFilter* filter_;

--- a/net/instaweb/rewriter/public/in_place_rewrite_context.h
+++ b/net/instaweb/rewriter/public/in_place_rewrite_context.h
@@ -122,6 +122,7 @@ class InPlaceRewriteContext : public SingleRewriteContext {
 
  private:
   friend class RecordingFetch;
+  bool PolicyPermitsRendering() const override;
   // Implements RewriteContext::Harvest().
   virtual void Harvest();
   void StartFetchReconstructionParent();

--- a/net/instaweb/rewriter/public/javascript_filter.h
+++ b/net/instaweb/rewriter/public/javascript_filter.h
@@ -68,7 +68,7 @@ class JavascriptFilter : public RewriteFilter {
   void EndElementImpl(HtmlElement* element) override;
   void IEDirective(HtmlIEDirectiveNode* directive) override;
 
-  const char* Name() const override { return "Javascript"; }
+  const char* Name() const override { return "JavascriptFilter"; }
   const char* id() const override { return RewriteOptions::kJavascriptMinId; }
   RewriteContext* MakeRewriteContext() override;
   ScriptUsage GetScriptUsage() const override { return kWillInjectScripts; }

--- a/net/instaweb/rewriter/public/rewrite_context.h
+++ b/net/instaweb/rewriter/public/rewrite_context.h
@@ -54,6 +54,12 @@ class Statistics;
 class Variable;
 class FreshenMetadataUpdateManager;
 
+enum class RenderOp {
+  kDontRender,
+  kRenderOnlyCspWarning,
+  kRender
+};
+
 // RewriteContext manages asynchronous rewriting of some n >= 1 resources (think
 // CSS, JS, or images) into m >= 0 improved versions (typically, n = m = 1).
 // It also helps update the references in the containing document (called
@@ -767,7 +773,7 @@ class RewriteContext {
   // particular, each slot must be updated with any rewritten
   // resources, before the successors can be run, independent of
   // whether the slots can be rendered into HTML.
-  void Propagate(bool render_slots);
+  void Propagate(RenderOp render_op);
 
   // With all resources loaded, the rewrite can now be done, writing:
   //    The metadata into the cache
@@ -816,7 +822,7 @@ class RewriteContext {
   // successors if applicable. This is the tail portion of
   // FinalizeRewriteForHtml that must be called even if we didn't
   // actually get as far as computing a partition_key_.
-  void RetireRewriteForHtml(bool permit_render);
+  void RetireRewriteForHtml(RenderOp permit_render);
 
   // Marks this job and any dependents slow as appropriate, notifying the
   // RewriteDriver of any changes.

--- a/net/instaweb/rewriter/public/rewrite_context.h
+++ b/net/instaweb/rewriter/public/rewrite_context.h
@@ -25,6 +25,7 @@
 #include "net/instaweb/http/public/http_cache.h"
 #include "net/instaweb/rewriter/cached_result.pb.h"
 #include "net/instaweb/rewriter/input_info.pb.h"
+#include "net/instaweb/rewriter/public/csp_directive.h"
 #include "net/instaweb/rewriter/public/output_resource_kind.h"
 #include "net/instaweb/rewriter/public/resource.h"
 #include "net/instaweb/rewriter/public/resource_slot.h"
@@ -414,6 +415,16 @@ class RewriteContext {
   // do not require any nested RewriteContexts, it is OK to skip
   // overriding this method -- the empty default implementation is fine.
   virtual void Harvest();
+
+  // This method gives the context a chance to verify that rendering the
+  // result is consistent with the current document's (Content Security) Policy,
+  // which may be different than that of the page for which the result was first
+  // computed + cached. Most subclasses can just call AreOutputsAllowedByCsp(),
+  // with appropriate role.
+  virtual bool PolicyPermitsRendering() const = 0;
+
+  // Helper that checks that all output resources are OK with CSP as given role.
+  bool AreOutputsAllowedByCsp(CspDirective role) const;
 
   // Performs rendering activities that span multiple HTML slots.  For
   // example, in a filter that combines N slots to 1, N-1 of the HTML

--- a/net/instaweb/rewriter/public/rewrite_context_test_base.h
+++ b/net/instaweb/rewriter/public/rewrite_context_test_base.h
@@ -225,6 +225,7 @@ class NestedFilter : public RewriteFilter {
     virtual ~Context();
     virtual void RewriteSingle(
         const ResourcePtr& input, const OutputResourcePtr& output);
+    bool PolicyPermitsRendering() const override { return true; }
     virtual void Harvest();
 
    protected:
@@ -340,6 +341,7 @@ class CombiningFilter : public RewriteFilter {
     void DoRewrite(int partition_index,
                    CachedResult* partition,
                    OutputResourcePtr output);
+    bool PolicyPermitsRendering() const override { return true; }
     virtual void Render();
     virtual void WillNotRender();
     virtual void Cancel();

--- a/net/instaweb/rewriter/public/rewrite_driver.h
+++ b/net/instaweb/rewriter/public/rewrite_driver.h
@@ -703,13 +703,17 @@ class RewriteDriver : public HtmlParse {
   RewriteFilter* FindFilter(const StringPiece& id) const;
 
   // Returns refs_before_base.
-  bool refs_before_base() { return refs_before_base_; }
+  bool refs_before_base() const { return refs_before_base_; }
+  bool other_base_problem() const { return other_base_problem_; }
 
   // Sets whether or not there were references to urls before the
   // base tag (if there is a base tag).  This variable has document-level
   // scope.  It is reset at the beginning of every document by
   // ScanFilter.
   void set_refs_before_base() { refs_before_base_ = true; }
+
+  // Sets if we had other difficulty handling <base> tag.
+  void set_other_base_problem() { other_base_problem_ = true; }
 
   // Get/set the charset of the containing HTML page. See scan_filter.cc for
   // an explanation of how this is determined, but NOTE that the determined
@@ -1255,7 +1259,6 @@ class RewriteDriver : public HtmlParse {
   CspContext* mutable_content_security_policy() { return &csp_context_; }
   bool IsLoadPermittedByCsp(const GoogleUrl& url, InputRole role);
   bool IsLoadPermittedByCsp(const GoogleUrl& url, CspDirective role);
-  bool IsRelativeUrlLoadPermittedByCsp(StringPiece url, CspDirective role);
 
  protected:
   virtual void DetermineFiltersBehaviorImpl();
@@ -1441,6 +1444,9 @@ class RewriteDriver : public HtmlParse {
   // no base tag, this should be false.  If the base tag is before all
   // other url references, this should also be false.
   bool refs_before_base_;
+
+  // Stores if we had to reject the <base> tag for some reason.
+  bool other_base_problem_;
 
   // The charset of the containing HTML page.
   GoogleString containing_charset_;

--- a/net/instaweb/rewriter/public/rewrite_driver.h
+++ b/net/instaweb/rewriter/public/rewrite_driver.h
@@ -777,7 +777,7 @@ class RewriteDriver : public HtmlParse {
   //
   // If 'permit_render' is false, no rendering will be asked for even if
   // the context is still attached.
-  void RewriteComplete(RewriteContext* rewrite_context, bool permit_render);
+  void RewriteComplete(RewriteContext* rewrite_context, RenderOp permit_render);
 
   // Provides a mechanism for a RewriteContext to notify a
   // RewriteDriver that a certain number of rewrites have been discovered

--- a/net/instaweb/rewriter/public/simple_text_filter.h
+++ b/net/instaweb/rewriter/public/simple_text_filter.h
@@ -86,6 +86,9 @@ class SimpleTextFilter : public RewriteFilter {
     virtual bool OptimizationOnly() const {
       return rewriter_->OptimizationOnly();
     }
+    bool PolicyPermitsRendering() const override {
+      return true;
+    }
 
    private:
     RewriterPtr rewriter_;

--- a/net/instaweb/rewriter/responsive_image_filter.cc
+++ b/net/instaweb/rewriter/responsive_image_filter.cc
@@ -432,8 +432,8 @@ void ResponsiveImageSecondFilter::Cleanup(
 
 void ResponsiveImageSecondFilter::EndDocument() {
   if (zoom_filter_enabled_ && srcsets_added_ && !driver()->is_amp_document()) {
-    if (driver()->IsRelativeUrlLoadPermittedByCsp(
-          responsive_js_url_, CspDirective::kScriptSrc)) {
+    if (IsRelativeUrlLoadPermittedByCsp(
+            responsive_js_url_, CspDirective::kScriptSrc)) {
       HtmlElement* script = driver()->NewElement(nullptr, HtmlName::kScript);
       driver()->AddAttribute(script, HtmlName::kSrc, responsive_js_url_);
       InsertNodeAtBodyEnd(script);

--- a/net/instaweb/rewriter/rewrite_context.cc
+++ b/net/instaweb/rewriter/rewrite_context.cc
@@ -45,6 +45,7 @@
 #include "net/instaweb/rewriter/public/resource_namer.h"
 #include "net/instaweb/rewriter/public/resource_slot.h"
 #include "net/instaweb/rewriter/public/rewrite_driver.h"
+#include "net/instaweb/rewriter/public/rewrite_filter.h"
 #include "net/instaweb/rewriter/public/rewrite_options.h"
 #include "net/instaweb/rewriter/public/rewrite_stats.h"
 #include "net/instaweb/rewriter/public/server_context.h"
@@ -2038,8 +2039,14 @@ void RewriteContext::Propagate(RenderOp render_op) {
                                       slot(0)->element());
       }
       else if (render_op == RenderOp::kRenderOnlyCspWarning) {
+        StringPiece name = id();
+        RewriteFilter* filter = Driver()->FindFilter(id());
+        if (filter != nullptr) {
+          name = filter->Name();
+        }
         Driver()->InsertDebugComment(
-            "PageSpeed output not permitted by Content Security Policy",
+            StrCat("PageSpeed output (by ", name, ") not permitted by Content "
+                   "Security Policy"),
             slot(0)->element());
       }
     }

--- a/net/instaweb/rewriter/rewrite_context.cc
+++ b/net/instaweb/rewriter/rewrite_context.cc
@@ -1830,7 +1830,7 @@ void RewriteContext::FinalizeRewriteForHtml() {
   Driver()->DeregisterForPartitionKey(partition_key_, this);
   WritePartition();
 
-  RetireRewriteForHtml(true /* permit rendering, if attached */);
+  RetireRewriteForHtml(PolicyPermitsRendering());
 }
 
 void RewriteContext::RetireRewriteForHtml(bool permit_render) {
@@ -1994,6 +1994,20 @@ void RewriteContext::Harvest() {
 }
 
 void RewriteContext::Render() {
+}
+
+bool RewriteContext::AreOutputsAllowedByCsp(CspDirective role) const {
+  if (Driver()->content_security_policy().empty()) {
+   return true;
+  }
+
+  for (const OutputResourcePtr& o : outputs_) {
+    if (o.get() != nullptr && o->has_hash() && o->has_url() &&
+        !Driver()->IsLoadPermittedByCsp(GoogleUrl(o->url()), role)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 void RewriteContext::WillNotRender() {

--- a/net/instaweb/rewriter/rewrite_context_test.cc
+++ b/net/instaweb/rewriter/rewrite_context_test.cc
@@ -2980,6 +2980,7 @@ class TestNotifyFilter : public CommonFilter {
       RewriteDone(kRewriteFailed, 0);
     }
 
+    bool PolicyPermitsRendering() const override { return true; }
     virtual const char* id() const { return "testnotify"; }
     virtual OutputResourceKind kind() const { return kRewrittenResource; }
 
@@ -5102,6 +5103,7 @@ class FailOnHashMismatchFilter : public RewriteFilter {
 
     virtual bool FailOnHashMismatch() const { return true; }
 
+    bool PolicyPermitsRendering() const override { return true; }
     virtual const char* id() const { return kFilterId; }
     virtual OutputResourceKind kind() const { return kRewrittenResource; }
     virtual void RewriteSingle(

--- a/net/instaweb/rewriter/rewrite_driver.cc
+++ b/net/instaweb/rewriter/rewrite_driver.cc
@@ -236,6 +236,7 @@ RewriteDriver::RewriteDriver(MessageHandler* message_handler,
     : HtmlParse(message_handler),
       base_was_set_(false),
       refs_before_base_(false),
+      other_base_problem_(false),
       filters_added_(false),
       externally_managed_(false),
       ref_counts_(this),
@@ -450,6 +451,7 @@ void RewriteDriver::Clear() NO_THREAD_SAFETY_ANALYSIS {
   is_lazyload_script_flushed_ = false;
   base_was_set_ = false;
   refs_before_base_ = false;
+  other_base_problem_ = false;
   containing_charset_.clear();
   fully_rewrite_on_flush_ = false;
   fast_blocking_rewrite_ = true;
@@ -3553,15 +3555,6 @@ bool RewriteDriver::IsLoadPermittedByCsp(
   }
 
   return csp_context_.CanLoadUrl(role, google_url(), url);
-}
-
-bool RewriteDriver::IsRelativeUrlLoadPermittedByCsp(
-    StringPiece url, CspDirective role) {
-  if (refs_before_base_ || !base_url().IsWebValid()) {
-    return false;
-  }
-  GoogleUrl abs_url(base_url(), url);
-  return IsLoadPermittedByCsp(abs_url, role);
 }
 
 bool RewriteDriver::IsLoadPermittedByCsp(const GoogleUrl& url, InputRole role) {

--- a/net/instaweb/rewriter/rewrite_driver.cc
+++ b/net/instaweb/rewriter/rewrite_driver.cc
@@ -2249,7 +2249,7 @@ void RewriteDriver::SignalIfRequired(bool result_of_prepare_should_signal) {
 }
 
 void RewriteDriver::RewriteComplete(RewriteContext* rewrite_context,
-                                    bool permit_render) {
+                                    RenderOp render_op) {
   {
     ScopedMutex lock(rewrite_mutex());
     DCHECK_EQ(0, ref_counts_.QueryCountMutexHeld(kRefFetchUserFacing));
@@ -2287,7 +2287,10 @@ void RewriteDriver::RewriteComplete(RewriteContext* rewrite_context,
     // release_driver_ should be false since we moved a count between
     // categories, and didn't change the total.
     DCHECK(!release_driver_) << ref_counts_.DebugStringMutexHeld();
-    rewrite_context->Propagate(attached && permit_render);
+    if (!attached) {
+      render_op = RenderOp::kDontRender;
+    }
+    rewrite_context->Propagate(render_op);
     SignalIfRequired(signal_cookie);
   }
 }

--- a/net/instaweb/rewriter/rewrite_driver_test.cc
+++ b/net/instaweb/rewriter/rewrite_driver_test.cc
@@ -1235,6 +1235,7 @@ class MockRewriteContext : public SingleRewriteContext {
 
   virtual void RewriteSingle(const ResourcePtr& input,
                              const OutputResourcePtr& output) {}
+  bool PolicyPermitsRendering() const override { return true; }
   virtual const char* id() const { return "mock"; }
   virtual OutputResourceKind kind() const { return kOnTheFlyResource; }
 };

--- a/net/instaweb/rewriter/rewrite_single_resource_filter_test.cc
+++ b/net/instaweb/rewriter/rewrite_single_resource_filter_test.cc
@@ -168,6 +168,7 @@ class TestRewriter : public RewriteFilter {
       RewriteDone(filter_->RewriteLoadedResource(input, output), 0);
     }
 
+    bool PolicyPermitsRendering() const override { return true; }
     virtual OutputResourceKind kind() const { return kRewrittenResource; }
     virtual const char* id() const { return filter_->id(); }
     virtual const UrlSegmentEncoder* encoder() const {

--- a/net/instaweb/rewriter/scan_filter.cc
+++ b/net/instaweb/rewriter/scan_filter.cc
@@ -110,8 +110,8 @@ void ScanFilter::StartElement(HtmlElement* element) {
     // See http://www.whatwg.org/specs/web-apps/current-work/multipage
     // /semantics.html#the-base-element
     //
-    if (href != NULL) {
-      if (href->DecodedValueOrNull() == NULL) {
+    if (href != nullptr) {
+      if (href->DecodedValueOrNull() == nullptr) {
         // Can't decode base well, so give up on using.
         driver_->set_other_base_problem();
         return;

--- a/net/instaweb/rewriter/scan_filter.cc
+++ b/net/instaweb/rewriter/scan_filter.cc
@@ -61,6 +61,7 @@ void ScanFilter::StartDocument() {
   driver_->set_containing_charset(headers == NULL ? "" :
                                   headers->DetermineCharset());
 
+  driver_->mutable_content_security_policy()->Clear();
   if (driver_->options()->honor_csp() && headers != nullptr) {
     ConstStringStarVector values;
     if (headers->Lookup(HttpAttributes::kContentSecurityPolicy, &values)) {

--- a/net/instaweb/rewriter/scan_filter_test.cc
+++ b/net/instaweb/rewriter/scan_filter_test.cc
@@ -230,10 +230,10 @@ TEST_F(ScanFilterTest, CspBase1) {
   rewrite_driver()->AddFilters();
   EnableDebug();
   // The default base (the URL) is overridden by a base tag.
-  const char kTestName[] = "set_base";
-  const char kNewBase[] = "http://example.com/index.html";
-  const char kCsp[] = "<meta http-equiv=\"Content-Security-Policy\" "
-                      "content=\"img-src www.example.com\">";
+  static const char kTestName[] = "set_base";
+  static const char kNewBase[] = "http://example.com/index.html";
+  static const char kCsp[] = "<meta http-equiv=\"Content-Security-Policy\" "
+                             "content=\"img-src www.example.com\">";
   ValidateNoChanges(kTestName,
                     StrCat("<head>",
                            kCsp,
@@ -247,10 +247,10 @@ TEST_F(ScanFilterTest, CspBase2) {
   rewrite_driver()->AddFilters();
   EnableDebug();
   // The default base (the URL) is overridden by a base tag.
-  const char kTestName[] = "set_base";
-  const char kNewBase[] = "http://example.com/index.html";
-  const char kCsp[] = "<meta http-equiv=\"Content-Security-Policy\" "
-                      "content=\"base-uri www.example.com\">";
+  static const char kTestName[] = "set_base";
+  static const char kNewBase[] = "http://example.com/index.html";
+  static const char kCsp[] = "<meta http-equiv=\"Content-Security-Policy\" "
+                             "content=\"base-uri www.example.com\">";
   ValidateExpected(
       kTestName,
       StrCat("<head>",

--- a/net/instaweb/rewriter/scan_filter_test.cc
+++ b/net/instaweb/rewriter/scan_filter_test.cc
@@ -226,4 +226,44 @@ TEST_F(ScanFilterTest, CspParseOff) {
       GoogleUrl("http://www.example.org/foo.png"), CspDirective::kImgSrc));
 }
 
+TEST_F(ScanFilterTest, CspBase1) {
+  rewrite_driver()->AddFilters();
+  EnableDebug();
+  // The default base (the URL) is overridden by a base tag.
+  const char kTestName[] = "set_base";
+  const char kNewBase[] = "http://example.com/index.html";
+  const char kCsp[] = "<meta http-equiv=\"Content-Security-Policy\" "
+                      "content=\"img-src www.example.com\">";
+  ValidateNoChanges(kTestName,
+                    StrCat("<head>",
+                           kCsp,
+                           "<base href=\"", kNewBase, "\">"
+                           "</head>"));
+  EXPECT_FALSE(rewrite_driver()->other_base_problem());
+}
+
+
+TEST_F(ScanFilterTest, CspBase2) {
+  rewrite_driver()->AddFilters();
+  EnableDebug();
+  // The default base (the URL) is overridden by a base tag.
+  const char kTestName[] = "set_base";
+  const char kNewBase[] = "http://example.com/index.html";
+  const char kCsp[] = "<meta http-equiv=\"Content-Security-Policy\" "
+                      "content=\"base-uri www.example.com\">";
+  ValidateExpected(
+      kTestName,
+      StrCat("<head>",
+            kCsp,
+            "<base href=\"", kNewBase, "\">"
+            "</head>"),
+      StrCat("<head>",
+            kCsp,
+            "<base href=\"", kNewBase, "\">"
+            "<!--Unable to check safety of a base with CSP base-uri, "
+            "proceeding conservatively.-->"
+            "</head>"));
+  EXPECT_TRUE(rewrite_driver()->other_base_problem());
+}
+
 }  // namespace net_instaweb


### PR DESCRIPTION
Just because we are permitted to read the input by CSP doesn't mean the output we produce 
(whether URL or inline) would be permitted by the policy.  As same inputs may occur on pages 
with different output policies, this introduces a render-time check, calling new hook PolicyPermitsRenderingon the RewriteContext at Render time, proceeding largely the same as if we were detached if it failed (modulo adding a comment). 

This change also extends the base-validity checking to be aware of CSP (logically a separate change, really..)
