### PR TITLE
Add cPanel EasyApache 4 RPM build support

### DIFF
--- a/build/install.gyp
+++ b/build/install.gyp
@@ -41,6 +41,11 @@
           '<(install_path)/rpm/build.sh',
           '<(install_path)/rpm/mod-pagespeed.spec.template',
         ],
+        'packaging_files_cpanel': [
+          '<(install_path)/rpm/build.sh',
+          '<(install_path)/rpm/mod-pagespeed.spec.template',
+          '<(install_path)/rpm/pagespeed.cpanel.conf',
+        ],
         'packaging_files_binaries': [
           '<(PRODUCT_DIR)/libmod_pagespeed.so',
           '<(PRODUCT_DIR)/libmod_pagespeed_ap24.so',
@@ -48,6 +53,7 @@
         'flock_bash': ['flock', '--', '/tmp/linux_package_lock', 'bash'],
         'deb_build': '<(PRODUCT_DIR)/install/debian/build.sh',
         'rpm_build': '<(PRODUCT_DIR)/install/rpm/build.sh',
+        'cpanel_build': '<(PRODUCT_DIR)/install/rpm/build.sh',
         'deb_cmd': ['<@(flock_bash)', '<(deb_build)', '-o' '<(PRODUCT_DIR)',
                     '-b', '<(PRODUCT_DIR)', '-a', '<(target_arch)'],
         'rpm_cmd': ['<@(flock_bash)', '<(rpm_build)', '-o' '<(PRODUCT_DIR)',
@@ -79,7 +85,7 @@
             {
               'destination': '<(PRODUCT_DIR)/install/rpm/',
               'files': [
-                '<@(packaging_files_rpm)',
+                '<@(packaging_files_cpanel)',
               ]
             },
             {
@@ -149,6 +155,26 @@
           },
           'includes': [
             'linux_package_rpm.gypi',
+          ],
+        },
+        {
+          'target_name': 'linux_package_cpanel_stable',
+          'suppress_wildcard': 1,
+          'variables': {
+            'channel': 'stable',
+          },
+          'includes': [
+            'linux_package_cpanel.gypi',
+          ],
+        },
+        {
+          'target_name': 'linux_package_cpanel_beta',
+          'suppress_wildcard': 1,
+          'variables': {
+            'channel': 'beta',
+          },
+          'includes': [
+            'linux_package_cpanel.gypi',
           ],
         },
       ],

--- a/build/linux_package_cpanel.gypi
+++ b/build/linux_package_cpanel.gypi
@@ -1,0 +1,34 @@
+# Copyright (c) 2010 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+{
+  'type': 'none',
+  'dependencies': [
+    'all.gyp:All',
+    'linux_installer_configs',
+  ],
+  'actions': [
+    {
+      'action_name': 'linux_package_deb_<(channel)_action',
+      'process_outputs_as_sources': 1,
+      'inputs': [
+        '<(cpanel_build)',
+        '<(PRODUCT_DIR)/install/rpm/mod-pagespeed.spec.template',
+        '<@(packaging_files_binaries)',
+        '<@(packaging_files_common)',
+        '<@(packaging_files_cpanel)',
+      ],
+      'outputs': [
+        '<(PRODUCT_DIR)/ea-apache24-mod_pagespeed-<(channel)-<(version)-r<(revision).<(rpm_arch).rpm',
+      ],
+      'action': [ '<@(rpm_cmd)', '-c', '<(channel)', '-p' ],
+    },
+  ],
+}
+
+# Local Variables:
+# tab-width:2
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=2 shiftwidth=2:

--- a/install/common/installer.include
+++ b/install/common/installer.include
@@ -80,6 +80,8 @@ process_template() (
     -e "s#@@COMMENT_OUT_DEFLATE@@#${COMMENT_OUT_DEFLATE}#g" \
     -e "s#@@SSL_CERT_DIR@@#${SSL_CERT_DIR}#g" \
     -e "s#@@SSL_CERT_FILE_COMMAND@@#${SSL_CERT_FILE_COMMAND}#g" \
+    -e "s#@@CPANEL_CONF_PREFIX@@#${CPANEL_CONF_PREFIX}#g" \
+    -e "s#@@COMMENT_OUT_CRON@@#${COMMENT_OUT_CRON}#g" \
     > "$TMPLOUT" <<< "$TMPLINCL"
 
   if grep "@@" "$TMPLOUT"; then

--- a/install/common/installer.include
+++ b/install/common/installer.include
@@ -80,7 +80,7 @@ process_template() (
     -e "s#@@COMMENT_OUT_DEFLATE@@#${COMMENT_OUT_DEFLATE}#g" \
     -e "s#@@SSL_CERT_DIR@@#${SSL_CERT_DIR}#g" \
     -e "s#@@SSL_CERT_FILE_COMMAND@@#${SSL_CERT_FILE_COMMAND}#g" \
-    -e "s#@@CPANEL_CONF_PREFIX@@#${CPANEL_CONF_PREFIX}#g" \
+    -e "s#@@PAGESPEED_CONF_PREFIX@@#${PAGESPEED_CONF_PREFIX}#g" \
     -e "s#@@COMMENT_OUT_CRON@@#${COMMENT_OUT_CRON}#g" \
     > "$TMPLOUT" <<< "$TMPLINCL"
 

--- a/install/rpm/build.sh
+++ b/install/rpm/build.sh
@@ -36,21 +36,21 @@ stage_install_rpm() {
   # 'conf' file. So we install the load template as the conf file, and
   # then concatenate the actual conf file.
   process_template "${BUILDDIR}/install/common/pagespeed.load.template" \
-    "${STAGEDIR}${APACHE_CONFDIR}/${CPANEL_CONF_PREFIX}pagespeed.conf"
+    "${STAGEDIR}${APACHE_CONFDIR}/${PAGESPEED_CONF_PREFIX}pagespeed.conf"
   process_template "${BUILDDIR}/install/common/pagespeed.conf.template" \
     "${BUILDDIR}/install/common/pagespeed.conf"
   cat "${BUILDDIR}/install/common/pagespeed.conf" >> \
-    "${STAGEDIR}${APACHE_CONFDIR}/${CPANEL_CONF_PREFIX}pagespeed.conf"
+    "${STAGEDIR}${APACHE_CONFDIR}/${PAGESPEED_CONF_PREFIX}pagespeed.conf"
   if [ "$CPANEL" = true ]; then
     cat "${BUILDDIR}/install/rpm/pagespeed.cpanel.conf" >> \
-      "${STAGEDIR}${APACHE_CONFDIR}/${CPANEL_CONF_PREFIX}pagespeed.conf"
+      "${STAGEDIR}${APACHE_CONFDIR}/${PAGESPEED_CONF_PREFIX}pagespeed.conf"
   fi
   install -m 755 "${BUILDDIR}/js_minify" \
     "${STAGEDIR}/usr/bin/pagespeed_js_minify"
-  chmod 644 "${STAGEDIR}${APACHE_CONFDIR}/${CPANEL_CONF_PREFIX}pagespeed.conf"
+  chmod 644 "${STAGEDIR}${APACHE_CONFDIR}/${PAGESPEED_CONF_PREFIX}pagespeed.conf"
   install -m 644 \
     "${BUILDDIR}/../../net/instaweb/genfiles/conf/pagespeed_libraries.conf" \
-    "${STAGEDIR}${APACHE_CONFDIR}/${CPANEL_CONF_PREFIX}pagespeed_libraries.conf"
+    "${STAGEDIR}${APACHE_CONFDIR}/${PAGESPEED_CONF_PREFIX}pagespeed_libraries.conf"
 }
 
 # Actually generate the package file.
@@ -230,7 +230,7 @@ SSL_CERT_DIR="/etc/pki/tls/certs"
 SSL_CERT_FILE_COMMAND="ModPagespeedSslCertFile /etc/pki/tls/cert.pem"
 APACHE_MODULEDIR_IA32="/usr/lib/httpd/modules"
 APACHE_MODULEDIR_X64="/usr/lib64/httpd/modules"
-CPANEL_CONF_PREFIX=""
+PAGESPEED_CONF_PREFIX=""
 
 if [ "$CPANEL" = true ]; then
   APACHE_CONFDIR="/etc/apache2/conf.modules.d"
@@ -238,7 +238,7 @@ if [ "$CPANEL" = true ]; then
   PACKAGE="ea-apache24-$(echo $PACKAGE | tr - _)"
   APACHE_MODULEDIR_IA32="/usr/lib/apache2/modules"
   APACHE_MODULEDIR_X64="/usr/lib64/apache2/modules"
-  CPANEL_CONF_PREFIX="456_"
+  PAGESPEED_CONF_PREFIX="456_"
   COMMENT_OUT_CRON="\# "
 fi
 

--- a/install/rpm/mod-pagespeed.spec.template
+++ b/install/rpm/mod-pagespeed.spec.template
@@ -69,9 +69,9 @@ rm -rf "$RPM_BUILD_ROOT"
 %defattr(-,root,root)
 @@APACHE_MODULEDIR@@/mod_pagespeed.so
 @@APACHE_MODULEDIR@@/mod_pagespeed_ap24.so
-%config(noreplace) @@APACHE_CONFDIR@@/pagespeed.conf
-%config(noreplace) @@APACHE_CONFDIR@@/pagespeed_libraries.conf
-/etc/cron.daily/mod-pagespeed
+%config(noreplace) @@APACHE_CONFDIR@@/@@CPANEL_CONF_PREFIX@@pagespeed.conf
+%config(noreplace) @@APACHE_CONFDIR@@/@@CPANEL_CONF_PREFIX@@pagespeed_libraries.conf
+@@COMMENT_OUT_CRON@@/etc/cron.daily/@@PACKAGE@@
 /usr/bin/pagespeed_js_minify
 %attr(-, @@APACHE_USER@@, @@APACHE_USER@@) @@MOD_PAGESPEED_CACHE@@
 %attr(-, @@APACHE_USER@@, @@APACHE_USER@@) @@MOD_PAGESPEED_LOG@@

--- a/install/rpm/mod-pagespeed.spec.template
+++ b/install/rpm/mod-pagespeed.spec.template
@@ -69,8 +69,8 @@ rm -rf "$RPM_BUILD_ROOT"
 %defattr(-,root,root)
 @@APACHE_MODULEDIR@@/mod_pagespeed.so
 @@APACHE_MODULEDIR@@/mod_pagespeed_ap24.so
-%config(noreplace) @@APACHE_CONFDIR@@/@@CPANEL_CONF_PREFIX@@pagespeed.conf
-%config(noreplace) @@APACHE_CONFDIR@@/@@CPANEL_CONF_PREFIX@@pagespeed_libraries.conf
+%config(noreplace) @@APACHE_CONFDIR@@/@@PAGESPEED_CONF_PREFIX@@pagespeed.conf
+%config(noreplace) @@APACHE_CONFDIR@@/@@PAGESPEED_CONF_PREFIX@@pagespeed_libraries.conf
 @@COMMENT_OUT_CRON@@/etc/cron.daily/@@PACKAGE@@
 /usr/bin/pagespeed_js_minify
 %attr(-, @@APACHE_USER@@, @@APACHE_USER@@) @@MOD_PAGESPEED_CACHE@@

--- a/install/rpm/pagespeed.cpanel.conf
+++ b/install/rpm/pagespeed.cpanel.conf
@@ -1,0 +1,17 @@
+<IfModule pagespeed_module>
+
+  # Disallow all handlers by default
+  # Before changing these, ensure that the <Location /pagespeed_admin>
+  # and similar entries above are either commented out or configured
+  # to your liking.
+  ModPagespeedStatisticsDomains Disallow *
+  ModPagespeedGlobalStatisticsDomains Disallow *
+  ModPagespeedMessagesDomains Disallow *
+  ModPagespeedConsoleDomains Disallow *
+  ModPagespeedAdminDomains Disallow *
+  ModPagespeedGlobalAdminDomains Disallow *
+
+  # Do not let users see other users' stats
+  ModPagespeedUsePerVhostStatistics on
+
+</IfModule>


### PR DESCRIPTION
This is an alternative to pagespeed/cpanel which appears to now be
unmaintained.

The advantages for both server admins and maintainers, are:

 * The default pagespeed.conf is shared between the main mod_pagespeed
   targets (DEB and RPM) and cPanel users. Previously cPanel users
   would need to manually check the main repository to see if there were
   any relevant changes. Or repository maintainers would need to manually
   copy over the changes every time the default configuration changed.
 * cPanel (shared hosting) specific default security tweaks
 * Proper versioning of the cPanel package
 * Package dependencies and other package metadata also stay in sync
 * Ability to build beta releases
 * No need to maintain a separate repository (pagespeed/cpanel)
 * No need to compile or download a prebuilt mod_pagespeed RPM to then
   extract and shuffle around the contents to create an EasyApache
   compatible RPM.