### PR TITLE
Fix unexpected close-tag 'br' in server_context.cc

### DIFF
--- a/net/instaweb/rewriter/server_context.cc
+++ b/net/instaweb/rewriter/server_context.cc
@@ -1357,7 +1357,7 @@ GoogleString ServerContext::ShowCacheForm(StringPiece user_agent) {
       "  URL: <input id=metadata_text type=text name=url size=110 /><br>\n"
       "  User-Agent: <input id=user_agent type=text size=103 name=user_agent ",
       ua_default,
-      "/></br> \n",
+      "/><br> \n",
       "  <input id=metadata_submit type=submit "
       "   value='Show Metadata Cache Entry' />"
       "  <input id=metadata_clear type=reset value='Clear' />",


### PR DESCRIPTION
Use <br> instead of </br>.
Pagespeed noticed this:
[Tue, 10 Oct 2017 07:01:23 GMT] [Info] [26724] [http://contimacpagespeed.dmtest.be/pagespeed_admin/cache:182] Unexpected close-tag `br', no tags are open