### PR TITLE
Don't special-case sending webp to PSI

### DIFF
--- a/net/instaweb/rewriter/device_properties.cc
+++ b/net/instaweb/rewriter/device_properties.cc
@@ -163,8 +163,7 @@ bool DeviceProperties::SupportsWebpInPlace() const {
 // by only checking the "accept" header.
 bool DeviceProperties::SupportsWebpRewrittenUrls() const {
   if (supports_webp_rewritten_urls_ == kNotSet) {
-    if ((accepts_webp_ == kTrue) || ua_matcher_->LegacyWebp(user_agent_) ||
-        ua_matcher_->InsightsWebp(user_agent_)) {
+    if ((accepts_webp_ == kTrue) || ua_matcher_->LegacyWebp(user_agent_)) {
       supports_webp_rewritten_urls_ = kTrue;
     } else {
       supports_webp_rewritten_urls_ = kFalse;
@@ -175,9 +174,8 @@ bool DeviceProperties::SupportsWebpRewrittenUrls() const {
 
 bool DeviceProperties::SupportsWebpLosslessAlpha() const {
   if (supports_webp_lossless_alpha_ == kNotSet) {
-    if (((accepts_webp_ == kTrue) &&
-         ua_matcher_->SupportsWebpLosslessAlpha(user_agent_)) ||
-        ua_matcher_->InsightsWebp(user_agent_)) {
+    if ((accepts_webp_ == kTrue) &&
+        ua_matcher_->SupportsWebpLosslessAlpha(user_agent_)) {
       supports_webp_lossless_alpha_ = kTrue;
     } else {
       supports_webp_lossless_alpha_ = kFalse;

--- a/pagespeed/kernel/http/user_agent_matcher.cc
+++ b/pagespeed/kernel/http/user_agent_matcher.cc
@@ -129,15 +129,6 @@ const char* kLegacyWebpWhitelist[] = {
   "*Android *",
 };
 
-//  Pagespeed Insights uses a webkit-based browser that can render webp, but
-//  doesn't send the Accept:image/webp. Whitelist the PSI browser for
-//  demonstration purposes. We have to keep this in a separate list from the
-//  kLegacyWebpWhiteList because the PSI UA has the string "Chrome/" in it, and
-//  that causes it to hit the kLegacyWebpBlacklist.
-const char* kPagespeedInsightsWebpWhiteList[] = {
-  "*Google Page Speed Insights*",
-};
-
 // Based on https://github.com/pagespeed/mod_pagespeed/issues/978,
 // Desktop IE11 will start masquerading as Chrome soon, and according to
 // https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/mod-pagespeed-discuss/HYzzdOzJu_k/ftdV8koVgUEJ
@@ -395,11 +386,6 @@ UserAgentMatcher::UserAgentMatcher()
     legacy_webp_.Disallow(kLegacyWebpBlacklist[i]);
   }
 
-  // We handle insights separately, as the browser doesn't advertise that it can
-  // render webp.
-  for (int i = 0, n = arraysize(kPagespeedInsightsWebpWhiteList); i < n; ++i) {
-    pagespeed_insights_.Allow(kPagespeedInsightsWebpWhiteList[i]);
-  }
   for (int i = 0, n = arraysize(kWebpLosslessAlphaWhitelist); i < n; ++i) {
     supports_webp_lossless_alpha_.Allow(kWebpLosslessAlphaWhitelist[i]);
   }
@@ -496,10 +482,6 @@ bool UserAgentMatcher::SupportsJsDefer(const StringPiece& user_agent,
 
 bool UserAgentMatcher::LegacyWebp(const StringPiece& user_agent) const {
   return legacy_webp_.Match(user_agent, false);
-}
-
-bool UserAgentMatcher::InsightsWebp(const StringPiece& user_agent) const {
-  return pagespeed_insights_.Match(user_agent, false);
 }
 
 bool UserAgentMatcher::SupportsWebpLosslessAlpha(

--- a/pagespeed/kernel/http/user_agent_matcher.h
+++ b/pagespeed/kernel/http/user_agent_matcher.h
@@ -92,10 +92,6 @@ class UserAgentMatcher {
   // only Android 4.0+ (excluding Firefox).
   bool LegacyWebp(const StringPiece& user_agent) const;
 
-  // Returns true if the user agent includes a browser that is Pagespeed
-  // Insights. We send webp to PSI, although it doesn't advertise it.
-  bool InsightsWebp(const StringPiece& user_agent) const;
-
   // Returns true if the user agent includes a string indicating WebP lossy
   // or WebP alpha support. If the browser does indeed support WebP, it also
   // needs to send out an "accept: webp" header.
@@ -141,7 +137,6 @@ class UserAgentMatcher {
   FastWildcardGroup defer_js_whitelist_;
   FastWildcardGroup defer_js_mobile_whitelist_;
   FastWildcardGroup legacy_webp_;
-  FastWildcardGroup pagespeed_insights_;
   FastWildcardGroup supports_webp_lossless_alpha_;
   FastWildcardGroup supports_webp_animated_;
   FastWildcardGroup supports_dns_prefetch_;

--- a/pagespeed/kernel/http/user_agent_matcher_test.cc
+++ b/pagespeed/kernel/http/user_agent_matcher_test.cc
@@ -193,10 +193,6 @@ TEST_F(UserAgentMatcherTest, WebpCapableLackingAcceptHeader) {
 
   EXPECT_TRUE(user_agent_matcher_->LegacyWebp(
       kAndroidICSUserAgent));
-  EXPECT_TRUE(user_agent_matcher_->InsightsWebp(
-      kPagespeedInsightsMobileUserAgent));
-  EXPECT_TRUE(user_agent_matcher_->InsightsWebp(
-      kPagespeedInsightsDesktopUserAgent));
   EXPECT_FALSE(user_agent_matcher_->LegacyWebp(
       kChrome12UserAgent));
   EXPECT_FALSE(user_agent_matcher_->LegacyWebp(


### PR DESCRIPTION
Remove special-case serving of webp to PSI (which lacks accept:image:webp) due to difficulties transmitting user-agent through cloudfront.  See https://github.com/pagespeed/mod_pagespeed/issues/1585

Note that webp may still be sent to PSI, depending on what's in the user-agent, and how AllowVary is set up.  But this is like any other pre-accept-header chrome.  What was broken before was ipro-rewriting to webp without the accept:image/webp header.
