### PR TITLE
Change loop_count from n to n+1 when converting animated GIF to WebP

### DIFF
--- a/pagespeed/kernel/image/webp_optimizer.cc
+++ b/pagespeed/kernel/image/webp_optimizer.cc
@@ -371,8 +371,8 @@ ScanlineStatus WebpFrameWriter::PrepareImage(const ImageSpec* image_spec) {
     }
 
     options.anim_params.bgcolor = RgbaToPackedArgb(image_spec_->bg_color);
-    options.anim_params.loop_count =
-        static_cast<int>(image_spec_->loop_count - 1);
+    // Use Chrome M63+ interpretation of loop_count.
+    options.anim_params.loop_count = static_cast<int>(image_spec_->loop_count);
 
     options.minimize_size = 0;
     options.allow_mixed = 0;


### PR DESCRIPTION
WebP encoder has a parameter called "loop_count". Chrome M63 is changing the behavior for this parameter. When this parameter is set to value "n", Chrome used to display the animation by "n+1" times, to match the behavior of animated GIF. However, in Chrome M63, Chrome will change to display "n" times. Therefore, when we convert animated GIF to WebP, we need to add one extra loop.