### PR TITLE
Update debug.conf.template

### DIFF
--- a/install/debug.conf.template
+++ b/install/debug.conf.template
@@ -526,7 +526,7 @@ ModPagespeedCompressMetadataCache true
 # different depending on whether we are running system tests as root
 # or as a normal user.  Note that fetches must be done with
 #    http_proxy=SECONDARY_HOST:SECONDARY_PORT.
-Listen localhost:@@APACHE_SECONDARY_PORT@@
+Listen 127.0.0.1:@@APACHE_SECONDARY_PORT@@
 NameVirtualHost localhost:@@APACHE_SECONDARY_PORT@@
 <VirtualHost localhost:@@APACHE_SECONDARY_PORT@@>
   ServerName secondary.example.com


### PR DESCRIPTION
Specify 127.0.0.1 in Listen directive instead of localhost as to not rely on hostname resolution.

Currently, some httpd versions/installs (notably the one from CentOS 6.9 on GCE) attempt to open port 8087 multiple times, and with that fail to start up. This change fixes the issue.
