### PR TITLE
oschaaf-debug-conf-listen-star

### DIFF
--- a/install/debug.conf.template
+++ b/install/debug.conf.template
@@ -526,7 +526,7 @@ ModPagespeedCompressMetadataCache true
 # different depending on whether we are running system tests as root
 # or as a normal user.  Note that fetches must be done with
 #    http_proxy=SECONDARY_HOST:SECONDARY_PORT.
-Listen 127.0.0.1:@@APACHE_SECONDARY_PORT@@
+Listen *:@@APACHE_SECONDARY_PORT@@
 NameVirtualHost localhost:@@APACHE_SECONDARY_PORT@@
 <VirtualHost localhost:@@APACHE_SECONDARY_PORT@@>
   ServerName secondary.example.com


### PR DESCRIPTION
569affb1a2baef30a34f9df6c2f152897c0fd896 unexpectedly broke some system tests.
This change resolves that, while also allowing httpd to start up on the CentOS 6.9
GCE VM. This will have to be backported to master as well.
