### PR TITLE
Fix tests and centos 6.9 httpd startup (#1669)

### DIFF
--- a/install/debug.conf.template
+++ b/install/debug.conf.template
@@ -526,7 +526,7 @@ ModPagespeedCompressMetadataCache true
 # different depending on whether we are running system tests as root
 # or as a normal user.  Note that fetches must be done with
 #    http_proxy=SECONDARY_HOST:SECONDARY_PORT.
-Listen 127.0.0.1:@@APACHE_SECONDARY_PORT@@
+Listen *:@@APACHE_SECONDARY_PORT@@
 NameVirtualHost localhost:@@APACHE_SECONDARY_PORT@@
 <VirtualHost localhost:@@APACHE_SECONDARY_PORT@@>
   ServerName secondary.example.com


### PR DESCRIPTION
569affb1a2baef30a34f9df6c2f152897c0fd896 unexpectedly broke some tests.
This resolves the test errors, but also allows httpd to startup on the CentOS 6.9
GCE VM.