### PR TITLE
Clarify use of canonicalize_javascript_libraries with defer_javascript in doc

### DIFF
--- a/html/doc/filter-canonicalize-js.html
+++ b/html/doc/filter-canonicalize-js.html
@@ -215,7 +215,11 @@ The canonical library is <em>not</em> combined with the other two JavaScript
 files, since this would lose the bandwidth and caching benefits of fetching it
 from the canonical URL.
 </p>
-
+<p>
+If <a href="filter-js-defer">defer_javascript</a> is enabled, <em>and</em> library 
+is <em>not</em> tagged with <code>data-pagespeed-no-defer</code>,
+the canonicalized library is deferred.
+</p>
 <h2>Requirements</h2>
 <p>
 Only complete, unmodified libraries referenced by <code>&lt;script&gt;</code>

--- a/html/doc/filter-canonicalize-js.html
+++ b/html/doc/filter-canonicalize-js.html
@@ -220,6 +220,7 @@ If <a href="filter-js-defer">defer_javascript</a> is enabled, <em>and</em> libra
 is <em>not</em> tagged with <code>data-pagespeed-no-defer</code>,
 the canonicalized library is deferred.
 </p>
+
 <h2>Requirements</h2>
 <p>
 Only complete, unmodified libraries referenced by <code>&lt;script&gt;</code>


### PR DESCRIPTION
Hello,

Clarify use of canonicalize_javascript_libraries with defer_javascript in doc.

https://www.modpagespeed.com/doc/filter-canonicalize-js

https://www.modpagespeed.com/doc/filter-js-defer

Thanks,

Eric

