### PR TITLE
OutputSanitizingAsyncFetch: runs right before PSOL responds

### DIFF
--- a/net/instaweb/http/async_fetch.cc
+++ b/net/instaweb/http/async_fetch.cc
@@ -286,7 +286,7 @@ OutputSanitizingAsyncFetch::~OutputSanitizingAsyncFetch() {
 
 bool OutputSanitizingAsyncFetch::SanitizeResponseHeaders() {
   if (response_headers() != nullptr &&
-      response_headers()->RemoveAllWithPrefix("@")) {
+      response_headers()->RemoveAllWithPrefix(ResponseHeaders::kInternalPrefix)) {
     response_headers()->ComputeCaching();
     return true;
   }

--- a/net/instaweb/http/async_fetch.cc
+++ b/net/instaweb/http/async_fetch.cc
@@ -299,7 +299,6 @@ void OutputSanitizingAsyncFetch::HandleHeadersComplete() {
 }
 
 void OutputSanitizingAsyncFetch::HandleDone(bool success) {
-  SanitizeResponseHeaders();
   SharedAsyncFetch::HandleDone(success);
   delete this;
 }

--- a/net/instaweb/http/async_fetch_test.cc
+++ b/net/instaweb/http/async_fetch_test.cc
@@ -143,12 +143,14 @@ TEST_F(AsyncFetchTest, OutputSanitizingAsyncFetch) {
   ConstStringStarVector foo_headers;
   OutputSanitizingAsyncFetch fetch(&string_fetch_);
   fetch.response_headers()->set_status_code(HttpStatus::kOK);
-  fetch.response_headers()->Add("@foo", "bar");
-  EXPECT_TRUE(fetch.response_headers()->Lookup("@foo", &foo_headers));
+  GoogleString internal_header = StrCat(ResponseHeaders::kInternalPrefix,
+                                        "bar");
+  fetch.response_headers()->Add(internal_header, "bar");
+  EXPECT_TRUE(fetch.response_headers()->Lookup(internal_header, &foo_headers));
   EXPECT_EQ(1, foo_headers.size());
   foo_headers.clear();
   fetch.HeadersComplete();
-  EXPECT_FALSE(string_fetch_.response_headers()->Lookup("@foo", &foo_headers));
+  EXPECT_FALSE(string_fetch_.response_headers()->Lookup(internal_header, &foo_headers));
   EXPECT_EQ(0, foo_headers.size());
 }
 

--- a/net/instaweb/http/async_fetch_test.cc
+++ b/net/instaweb/http/async_fetch_test.cc
@@ -139,6 +139,19 @@ TEST_F(AsyncFetchTest, ViaHandling) {
   EXPECT_FALSE(CheckCacheControlPublicWithVia("NotReallyGoogle"));
 }
 
+TEST_F(AsyncFetchTest, OutputSanitizingAsyncFetch) {
+  ConstStringStarVector foo_headers;
+  OutputSanitizingAsyncFetch fetch(&string_fetch_);
+  fetch.response_headers()->set_status_code(HttpStatus::kOK);
+  fetch.response_headers()->Add("@foo", "bar");
+  EXPECT_TRUE(fetch.response_headers()->Lookup("@foo", &foo_headers));
+  EXPECT_EQ(1, foo_headers.size());
+  foo_headers.clear();
+  fetch.HeadersComplete();
+  EXPECT_FALSE(string_fetch_.response_headers()->Lookup("@foo", &foo_headers));
+  EXPECT_EQ(0, foo_headers.size());
+}
+
 }  // namespace
 
 }  // namespace net_instaweb

--- a/net/instaweb/http/public/async_fetch.h
+++ b/net/instaweb/http/public/async_fetch.h
@@ -316,10 +316,9 @@ class SharedAsyncFetch : public AsyncFetch {
   DISALLOW_COPY_AND_ASSIGN(SharedAsyncFetch);
 };
 
-// Can be used to sanitize headers and data before forwarding them on to the
-// base fetch. Used to ensure that internal headers, starting with '@', will
-// never be visible outside of PSOL. Note that httpd will send an error page
-// when a response header containing '@' attempts to hit the wire.
+// Used to sanitize headers and data before forwarding them on to the base
+// fetch. Used to ensure that internal headers, starting with
+// ResponseHeaders::kInternalPrefix, will never be visible outside of PSOL.
 class OutputSanitizingAsyncFetch : public SharedAsyncFetch {
 public:
   explicit OutputSanitizingAsyncFetch(AsyncFetch* base_fetch);
@@ -330,8 +329,8 @@ protected:
   virtual void HandleDone(bool success);
 
 private:
-  // Removes any headers starting with '@' from the response.
-  // returns true if any changes have been made.
+  // Removes any headers starting with ResponseHeaders::kInternalPrefix from
+  // the response. returns true if any changes have been made.
   bool SanitizeResponseHeaders();
   DISALLOW_COPY_AND_ASSIGN(OutputSanitizingAsyncFetch);
 };

--- a/net/instaweb/http/public/async_fetch.h
+++ b/net/instaweb/http/public/async_fetch.h
@@ -316,6 +316,26 @@ class SharedAsyncFetch : public AsyncFetch {
   DISALLOW_COPY_AND_ASSIGN(SharedAsyncFetch);
 };
 
+// Can be used to sanitize headers and data before forwarding them on to the
+// base fetch. Used to ensure that internal headers, starting with '@', will
+// never be visible outside of PSOL. Note that httpd will send an error page
+// when a response header containing '@' attempts to hit the wire.
+class OutputSanitizingAsyncFetch : public SharedAsyncFetch {
+public:
+  explicit OutputSanitizingAsyncFetch(AsyncFetch* base_fetch);
+  virtual ~OutputSanitizingAsyncFetch();
+
+protected:
+  virtual void HandleHeadersComplete();
+  virtual void HandleDone(bool success);
+
+private:
+  // Removes any headers starting with '@' from the response.
+  // returns true if any changes have been made.
+  bool SanitizeResponseHeaders();
+  DISALLOW_COPY_AND_ASSIGN(OutputSanitizingAsyncFetch);
+};
+
 // Creates a SharedAsyncFetch object using an existing AsyncFetch and a fallback
 // value that is used in case the fetched response is an error. Note that in
 // case the fetched response is an error and we have a non-empty fallback value,

--- a/net/instaweb/rewriter/rewrite_driver.cc
+++ b/net/instaweb/rewriter/rewrite_driver.cc
@@ -1889,6 +1889,7 @@ void RewriteDriver::FetchInPlaceResource(const GoogleUrl& gurl,
   StatisticsLogger* stats_logger =
       server_context_->statistics()->console_logger();
 
+  async_fetch = new OutputSanitizingAsyncFetch(async_fetch);
   if (!context->Fetch(output_resource, async_fetch, message_handler())) {
     // RewriteContext::Fetch can fail if the input URLs are undecodeable
     // or unfetchable. There is no decoding in this case, but unfetchability
@@ -1925,6 +1926,7 @@ bool RewriteDriver::FetchOutputResource(
   // Save pointer to stats_logger before "this" is deleted.
   StatisticsLogger* stats_logger =
       server_context_->statistics()->console_logger();
+  async_fetch = new OutputSanitizingAsyncFetch(async_fetch);
   if (async_fetch->request_headers()->Lookup(HttpAttributes::kIfModifiedSince,
                                              &values)) {
     async_fetch->response_headers()->SetStatusAndReason(

--- a/pagespeed/apache/header_util.cc
+++ b/pagespeed/apache/header_util.cc
@@ -115,7 +115,7 @@ void AddResponseHeadersToRequestHelper(const ResponseHeaders& response_headers,
   for (int i = 0, n = response_headers.NumAttributes(); i < n; ++i) {
     const GoogleString& name = response_headers.Name(i);
     const GoogleString& value = response_headers.Value(i);
-    if (strings::StartsWith(name, "@")) {
+    if (strings::StartsWith(name, ResponseHeaders::kInternalPrefix)) {
       continue;
     }
     if (StringCaseEqual(name, HttpAttributes::kContentType)) {

--- a/pagespeed/apache/header_util.cc
+++ b/pagespeed/apache/header_util.cc
@@ -115,6 +115,9 @@ void AddResponseHeadersToRequestHelper(const ResponseHeaders& response_headers,
   for (int i = 0, n = response_headers.NumAttributes(); i < n; ++i) {
     const GoogleString& name = response_headers.Name(i);
     const GoogleString& value = response_headers.Value(i);
+    if (strings::StartsWith(name, "@")) {
+      continue;
+    }
     if (StringCaseEqual(name, HttpAttributes::kContentType)) {
       // ap_set_content_type does not make a copy of the string, we need
       // to duplicate it.

--- a/pagespeed/automatic/proxy_fetch.cc
+++ b/pagespeed/automatic/proxy_fetch.cc
@@ -106,6 +106,7 @@ ProxyFetch* ProxyFetchFactory::CreateNewProxyFetch(
       << "expect ResourceFetch called for pagespeed resources, not ProxyFetch";
 
   bool cross_domain = false;
+  async_fetch = new OutputSanitizingAsyncFetch(async_fetch);
   if (gurl.IsWebValid()) {
     if (namer->Decode(gurl, driver->options(), &decoded_resource)) {
       const RewriteOptions* options = driver->options();

--- a/pagespeed/kernel/http/response_headers.cc
+++ b/pagespeed/kernel/http/response_headers.cc
@@ -54,6 +54,13 @@ class MessageHandler;
 // we'll set it back to 3:00:00 exactly in FixDateHeaders.
 const int64 kMaxAllowedDateDriftMs = 3L * net_instaweb::Timer::kMinuteMs;
 
+// This is illegal from a protocol perspective, see
+// https://tools.ietf.org/html/rfc2616#page-31
+// Basic Rules for 'token' excludes separators, including "@".
+// That's why we can use it as an in-memory sentinal as long as it is
+// never serialized.
+const char ResponseHeaders::kInternalPrefix[] = "@";
+
 ResponseHeaders::ResponseHeaders(const ResponseHeaders& other) {
   CopyFrom(other);
 }

--- a/pagespeed/kernel/http/response_headers.h
+++ b/pagespeed/kernel/http/response_headers.h
@@ -39,6 +39,8 @@ class ResponseHeaders : public Headers<HttpResponseHeaders> {
   enum VaryOption { kRespectVaryOnResources, kIgnoreVaryOnResources };
   enum ValidatorOption { kHasValidator, kNoValidator };
 
+  static const char kInternalPrefix[];
+
   // This constructor with options explicitly set should be used by all callers.
   explicit ResponseHeaders(const HttpOptions& options) { Init(options); }
 


### PR DESCRIPTION
Headers starting with '@' will be removed from any output emitted
by PSOL. This allows a concept of 'internal headers' which can be
used to pass information around internally.

In a follow-up PR this will be used to track (and remember) which
redirects have been followed while fetching a resource, and with that
we will be able to verify if using the resource as a basis for optimized
output would violate effective Content-Security-Policies, if any.

Note that a header is not allowed to contain '@' per http spec, and
if one does 'escape' httpd will respond with a 5xx.