### PR TITLE
 CSP vs httpd's err_headers_out

### DIFF
--- a/net/instaweb/http/async_fetch.cc
+++ b/net/instaweb/http/async_fetch.cc
@@ -299,7 +299,6 @@ void OutputSanitizingAsyncFetch::HandleHeadersComplete() {
 }
 
 void OutputSanitizingAsyncFetch::HandleDone(bool success) {
-  SanitizeResponseHeaders();
   SharedAsyncFetch::HandleDone(success);
   delete this;
 }

--- a/net/instaweb/http/async_fetch_test.cc
+++ b/net/instaweb/http/async_fetch_test.cc
@@ -139,6 +139,19 @@ TEST_F(AsyncFetchTest, ViaHandling) {
   EXPECT_FALSE(CheckCacheControlPublicWithVia("NotReallyGoogle"));
 }
 
+TEST_F(AsyncFetchTest, OutputSanitizingAsyncFetch) {
+  ConstStringStarVector foo_headers;
+  OutputSanitizingAsyncFetch fetch(&string_fetch_);
+  fetch.response_headers()->set_status_code(HttpStatus::kOK);
+  fetch.response_headers()->Add("@foo", "bar");
+  EXPECT_TRUE(fetch.response_headers()->Lookup("@foo", &foo_headers));
+  EXPECT_EQ(1, foo_headers.size());
+  foo_headers.clear();
+  fetch.HeadersComplete();
+  EXPECT_FALSE(string_fetch_.response_headers()->Lookup("@foo", &foo_headers));
+  EXPECT_EQ(0, foo_headers.size());
+}
+
 }  // namespace
 
 }  // namespace net_instaweb

--- a/net/instaweb/http/public/async_fetch.h
+++ b/net/instaweb/http/public/async_fetch.h
@@ -316,6 +316,26 @@ class SharedAsyncFetch : public AsyncFetch {
   DISALLOW_COPY_AND_ASSIGN(SharedAsyncFetch);
 };
 
+// Can be used to sanitize headers and data before forwarding them on to the
+// base fetch. Used to ensure that internal headers, starting with '@', will
+// never be visible outside of PSOL. Note that httpd will send an error page
+// when a response header containing '@' attempts to hit the wire.
+class OutputSanitizingAsyncFetch : public SharedAsyncFetch {
+public:
+  explicit OutputSanitizingAsyncFetch(AsyncFetch* base_fetch);
+  virtual ~OutputSanitizingAsyncFetch();
+
+protected:
+  virtual void HandleHeadersComplete();
+  virtual void HandleDone(bool success);
+
+private:
+  // Removes any headers starting with '@' from the response.
+  // returns true if any changes have been made.
+  bool SanitizeResponseHeaders();
+  DISALLOW_COPY_AND_ASSIGN(OutputSanitizingAsyncFetch);
+};
+
 // Creates a SharedAsyncFetch object using an existing AsyncFetch and a fallback
 // value that is used in case the fetched response is an error. Note that in
 // case the fetched response is an error and we have a non-empty fallback value,

--- a/net/instaweb/rewriter/public/scan_filter.h
+++ b/net/instaweb/rewriter/public/scan_filter.h
@@ -20,6 +20,7 @@
 #define NET_INSTAWEB_REWRITER_PUBLIC_SCAN_FILTER_H_
 
 #include "pagespeed/kernel/html/empty_html_filter.h"
+#include "pagespeed/kernel/base/string_util.h"
 
 namespace net_instaweb {
 
@@ -55,6 +56,7 @@ class ScanFilter : public EmptyHtmlFilter {
   virtual const char* Name() const { return "Scan"; }
 
  private:
+  void UpdateCspFromHeaderValues(const ConstStringStarVector& values);
   RewriteDriver* driver_;
   bool seen_any_nodes_;
   bool seen_refs_;

--- a/net/instaweb/rewriter/rewrite_driver.cc
+++ b/net/instaweb/rewriter/rewrite_driver.cc
@@ -1889,6 +1889,7 @@ void RewriteDriver::FetchInPlaceResource(const GoogleUrl& gurl,
   StatisticsLogger* stats_logger =
       server_context_->statistics()->console_logger();
 
+  async_fetch = new OutputSanitizingAsyncFetch(async_fetch);
   if (!context->Fetch(output_resource, async_fetch, message_handler())) {
     // RewriteContext::Fetch can fail if the input URLs are undecodeable
     // or unfetchable. There is no decoding in this case, but unfetchability
@@ -1925,6 +1926,7 @@ bool RewriteDriver::FetchOutputResource(
   // Save pointer to stats_logger before "this" is deleted.
   StatisticsLogger* stats_logger =
       server_context_->statistics()->console_logger();
+  async_fetch = new OutputSanitizingAsyncFetch(async_fetch);
   if (async_fetch->request_headers()->Lookup(HttpAttributes::kIfModifiedSince,
                                              &values)) {
     async_fetch->response_headers()->SetStatusAndReason(

--- a/net/instaweb/rewriter/scan_filter_test.cc
+++ b/net/instaweb/rewriter/scan_filter_test.cc
@@ -206,6 +206,24 @@ TEST_F(ScanFilterTest, CspParse) {
       GoogleUrl("http://www.example.org/foo.png"), CspDirective::kImgSrc));
 }
 
+TEST_F(ScanFilterTest, CspParseInternal) {
+  ResponseHeaders headers;
+  headers.Add("@Content-Security-Policy", "img-src https:");
+  rewrite_driver()->set_response_headers_ptr(&headers);
+  ValidateNoChanges("csp_parse",
+                    "<meta http-equiv=\"Content-Security-Policy\" "
+                    "content=\"img-src www.example.com\">");
+  EXPECT_EQ(2, rewrite_driver()->content_security_policy().policies_size());
+  EXPECT_TRUE(rewrite_driver()->IsLoadPermittedByCsp(
+      GoogleUrl("https://www.example.com/foo.png"), CspDirective::kImgSrc));
+  EXPECT_FALSE(rewrite_driver()->IsLoadPermittedByCsp(
+      GoogleUrl("http://www.example.com/foo.png"), CspDirective::kImgSrc));
+  EXPECT_FALSE(rewrite_driver()->IsLoadPermittedByCsp(
+      GoogleUrl("https://www.example.org/foo.png"), CspDirective::kImgSrc));
+  EXPECT_FALSE(rewrite_driver()->IsLoadPermittedByCsp(
+      GoogleUrl("http://www.example.org/foo.png"), CspDirective::kImgSrc));
+}
+
 TEST_F(ScanFilterTest, CspParseOff) {
   options()->set_honor_csp(false);
 

--- a/pagespeed/apache/header_util.cc
+++ b/pagespeed/apache/header_util.cc
@@ -115,6 +115,9 @@ void AddResponseHeadersToRequestHelper(const ResponseHeaders& response_headers,
   for (int i = 0, n = response_headers.NumAttributes(); i < n; ++i) {
     const GoogleString& name = response_headers.Name(i);
     const GoogleString& value = response_headers.Value(i);
+    if (strings::StartsWith(name, "@")) {
+      continue;
+    }
     if (StringCaseEqual(name, HttpAttributes::kContentType)) {
       // ap_set_content_type does not make a copy of the string, we need
       // to duplicate it.

--- a/pagespeed/apache/instaweb_context.cc
+++ b/pagespeed/apache/instaweb_context.cc
@@ -238,7 +238,9 @@ void InstawebContext::PopulateHeaders(request_rec* request) {
     // sanitized from our own output.
     const char* csp = apr_table_get(request->err_headers_out,
                                     HttpAttributes::kContentSecurityPolicy);
-    response_headers_->Add(HttpAttributes::kInternalContentSecurityPolicy, csp);
+    if (csp != nullptr) {
+      response_headers_->Add(HttpAttributes::kInternalContentSecurityPolicy, csp);
+    }
     populated_headers_ = true;
   }
 }

--- a/pagespeed/automatic/proxy_fetch.cc
+++ b/pagespeed/automatic/proxy_fetch.cc
@@ -106,6 +106,7 @@ ProxyFetch* ProxyFetchFactory::CreateNewProxyFetch(
       << "expect ResourceFetch called for pagespeed resources, not ProxyFetch";
 
   bool cross_domain = false;
+  async_fetch = new OutputSanitizingAsyncFetch(async_fetch);
   if (gurl.IsWebValid()) {
     if (namer->Decode(gurl, driver->options(), &decoded_resource)) {
       const RewriteOptions* options = driver->options();

--- a/pagespeed/kernel/http/http_names.cc
+++ b/pagespeed/kernel/http/http_names.cc
@@ -111,6 +111,8 @@ const char HttpAttributes::kXUACompatible[] = "X-UA-Compatible";
 const char HttpAttributes::kXSendfile[] = "X-Sendfile";
 const char HttpAttributes::kXAccelRedirect[] = "X-Accel-Redirect";
 const char HttpAttributes::kXPageSpeedLoop[] = "X-PageSpeed-Loop";
+const char HttpAttributes::kInternalContentSecurityPolicy[] =
+    "@Content-Security-Policy";
 
 const char* HttpStatus::GetReasonPhrase(HttpStatus::Code rc) {
   switch (rc) {

--- a/pagespeed/kernel/http/http_names.h
+++ b/pagespeed/kernel/http/http_names.h
@@ -126,6 +126,8 @@ struct HttpAttributes {
   static const char kXAccelRedirect[];
   // PageSpeed Loop detection for proxy mode.
   static const char kXPageSpeedLoop[];
+  // Any CSP httpd hands to us in err_response_headers will be stored here.
+  static const char kInternalContentSecurityPolicy[];
 
   // Gets a sorted StringPieceVector containing all the end-to-end headers.
   // Any fields listed in here should be ignored during sanitization when they

--- a/pagespeed/kernel/http/http_names.h
+++ b/pagespeed/kernel/http/http_names.h
@@ -126,7 +126,7 @@ struct HttpAttributes {
   static const char kXAccelRedirect[];
   // PageSpeed Loop detection for proxy mode.
   static const char kXPageSpeedLoop[];
-  // Any CSP httpd hands to us in err_response_headers will be stored here.
+  // Any CSP httpd hands to us via err_response_headers will be stored here.
   static const char kInternalContentSecurityPolicy[];
 
   // Gets a sorted StringPieceVector containing all the end-to-end headers.


### PR DESCRIPTION
Using php and/or using "Headers always" in configuration to set up CSP
headers in httpd is probably pretty common. These will both end up in
err_headers_out, a httpd-only concept meaning that the headers should
always be emitted, even on error statusses. We want to consider these
CSP headers living in this collection when rewriting content, but leave
them alone otherwise.
Instead of introducing an err_headers_out (like) concept in RewriteDriver
to model this, we will rely on the internal headers concept. ScanFilter
will also look at kInternalContentSecurityPolicy. This header will be
sanitized from our own output.

Relies on PR #1695, which should go in first