### PR TITLE
Add CspPolicy::ToIdentityString(). Use it in JS Combiner cache key suffix

### DIFF
--- a/net/instaweb/rewriter/csp_test.cc
+++ b/net/instaweb/rewriter/csp_test.cc
@@ -922,6 +922,18 @@ TEST(CspContext, BaseUri) {
   }
 }
 
+TEST(CspIdentityStringTest, Quoted) {
+  CspContext ctx;
+  ctx.AddPolicy(CspPolicy::Parse("default-src https:; img-src *"));
+  ctx.AddPolicy(CspPolicy::Parse(""));
+  ctx.AddPolicy(CspPolicy::Parse("style-src *.example.com"));
+  ctx.AddPolicy(CspPolicy::Parse("script-src script.example.com 'unsafe-eval'"
+                                 " 'unsafe-inline'"));
+  const GoogleString expected = "2:1:https_:/:;4:2:_*:/:;@6:2:_*.example.com:/"
+      ":;@5:2:_script.example.com:/:;@E:|I:1|A:1|S:|T:|";
+  EXPECT_STREQ(expected, ctx.ToIdentityString());
+}
+
 }  // namespace
 
 }  // namespace net_instaweb

--- a/net/instaweb/rewriter/js_combine_filter.cc
+++ b/net/instaweb/rewriter/js_combine_filter.cc
@@ -386,7 +386,10 @@ class JsCombineFilter::Context : public RewriteContext {
   virtual GoogleString CacheKeySuffix() const {
     // Updated to make sure certain bugfixes actually deploy, and we don't
     // end up using old broken cached version.
-    return "v4";
+    MD5Hasher hasher;
+    auto id = StrCat("v4|",
+                       Driver()->content_security_policy().ToIdentityString());
+    return hasher.Hash(id);
   }
 
  private:


### PR DESCRIPTION
This change affects the way we handle dynamic policies (as well as occasional policy updates).
This PR is to review the general approach. To complete this update an audit of all filters is probably needed to see which filter cache key suffixes need changes.

(The redirecting fetcher PR contains some end-to-end tests on the way the partitioning behaves when different policies are in play for the same html url, I'm splitting out a series of smaller PR's to unbloat that one so review becomes more manageable)