### PR TITLE
Handle Apache >2.4 mod_authz_host

### DIFF
--- a/install/common/pagespeed.conf.template
+++ b/install/common/pagespeed.conf.template
@@ -332,9 +332,9 @@
             </IfVersion>
         <IfVersion >= 2.4>
             Require local
-            #see https://httpd.apache.org/docs/current/fr/mod/mod_authz_host.html - Require all granted,
-            #Require ip, Require host or Require forward-dns,
-            #if access must be granted to other than local.
+            # see https://httpd.apache.org/docs/current/en/mod/mod_authz_host.html - Require all granted,
+            # Require ip, Require host or Require forward-dns,
+            # if access must be granted to other than local.
             </IfVersion>
         SetHandler pagespeed_admin
     </Location>

--- a/install/common/pagespeed.conf.template
+++ b/install/common/pagespeed.conf.template
@@ -325,11 +325,11 @@
       LoadModule version_module /usr/lib/httpd/modules/mod_version.so
     </IfModule>
     <Location /pagespeed_admin>
-        <IfVersion <2.4>
+        <IfVersion < 2.4>
             Order allow,deny
             Allow from localhost
             Allow from 127.0.0.1
-            <IfVersion>
+            </IfVersion>
         <IfVersion >= 2.4>
             Require local
             #see https://httpd.apache.org/docs/current/fr/mod/mod_authz_host.html - Require all granted,
@@ -339,11 +339,11 @@
         SetHandler pagespeed_admin
     </Location>
     <Location /pagespeed_global_admin>
-        <IfVersion <2.4>
+        <IfVersion < 2.4>
             Order allow,deny
             Allow from localhost
             Allow from 127.0.0.1
-            <IfVersion>
+            </IfVersion>
         <IfVersion >= 2.4>
             Require local            
             </IfVersion>

--- a/install/common/pagespeed.conf.template
+++ b/install/common/pagespeed.conf.template
@@ -321,15 +321,19 @@
     # and change server state, such as statistics, caches, and
     # messages.  This might be appropriate in an experimental setup.
     <Location /pagespeed_admin>
-        Order allow,deny
-        Allow from localhost
-        Allow from 127.0.0.1
+        Require all granted
+        Require local
+        #Require ip myremoteip
+        #Require host mydomain.tld
+        #Require forward-dns user.domain.tld
         SetHandler pagespeed_admin
     </Location>
     <Location /pagespeed_global_admin>
-        Order allow,deny
-        Allow from localhost
-        Allow from 127.0.0.1
+        Require all granted
+        Require local
+        #Require ip myremoteip
+        #Require host mydomain.tld
+        #Require forward-dns user.domain.tld
         SetHandler pagespeed_global_admin
     </Location>
 

--- a/install/common/pagespeed.conf.template
+++ b/install/common/pagespeed.conf.template
@@ -321,10 +321,10 @@
     # and change server state, such as statistics, caches, and
     # messages.  This might be appropriate in an experimental setup.
     # Attempt to load mod_version if it wasn't loaded or compiled in (eg on Debian)
-<IfModule !mod_version.c>
-LoadModule version_module /usr/lib/httpd/modules/mod_version.so
-</IfModule>
-<Location /pagespeed_admin>
+    <IfModule !mod_version.c>
+      LoadModule version_module /usr/lib/httpd/modules/mod_version.so
+    </IfModule>
+    <Location /pagespeed_admin>
         <IfVersion <2.4>
             Order allow,deny
             Allow from localhost
@@ -338,7 +338,7 @@ LoadModule version_module /usr/lib/httpd/modules/mod_version.so
             </IfVersion>
         SetHandler pagespeed_admin
     </Location>
- <Location /pagespeed_global_admin>
+    <Location /pagespeed_global_admin>
         <IfVersion <2.4>
             Order allow,deny
             Allow from localhost

--- a/install/common/pagespeed.conf.template
+++ b/install/common/pagespeed.conf.template
@@ -320,21 +320,34 @@
     # file, to allow any client that can reach your server to access
     # and change server state, such as statistics, caches, and
     # messages.  This might be appropriate in an experimental setup.
-    <Location /pagespeed_admin>
-        Require all granted
-        Require local
-        #Require ip myremoteip
-        #Require host mydomain.tld
-        #Require forward-dns user.domain.tld
+    # Attempt to load mod_version if it wasn't loaded or compiled in (eg on Debian)
+<IfModule !mod_version.c>
+LoadModule version_module /usr/lib/httpd/modules/mod_version.so
+</IfModule>
+<Location /pagespeed_admin>
+        <IfVersion <2.4>
+            Order allow,deny
+            Allow from localhost
+            Allow from 127.0.0.1
+            <IfVersion>
+        <IfVersion >= 2.4>
+            Require local
+            #see https://httpd.apache.org/docs/current/fr/mod/mod_authz_host.html - Require all granted,
+            #Require ip, Require host or Require forward-dns,
+            #if access must be granted to other than local.
+            </IfVersion>
         SetHandler pagespeed_admin
     </Location>
-    <Location /pagespeed_global_admin>
-        Require all granted
-        Require local
-        #Require ip myremoteip
-        #Require host mydomain.tld
-        #Require forward-dns user.domain.tld
-        SetHandler pagespeed_global_admin
+ <Location /pagespeed_global_admin>
+        <IfVersion <2.4>
+            Order allow,deny
+            Allow from localhost
+            Allow from 127.0.0.1
+            <IfVersion>
+        <IfVersion >= 2.4>
+            Require local            
+            </IfVersion>
+          SetHandler pagespeed_global_admin
     </Location>
 
     # Enable logging of mod_pagespeed statistics, needed for the console.

--- a/install/common/pagespeed.conf.template
+++ b/install/common/pagespeed.conf.template
@@ -343,7 +343,7 @@
             Order allow,deny
             Allow from localhost
             Allow from 127.0.0.1
-            </IfVersion>
+        </IfVersion>
         <IfVersion >= 2.4>
             Require local            
         </IfVersion>

--- a/install/common/pagespeed.conf.template
+++ b/install/common/pagespeed.conf.template
@@ -329,13 +329,13 @@
             Order allow,deny
             Allow from localhost
             Allow from 127.0.0.1
-            </IfVersion>
+        </IfVersion>
         <IfVersion >= 2.4>
             Require local
             # see https://httpd.apache.org/docs/current/en/mod/mod_authz_host.html - Require all granted,
             # Require ip, Require host or Require forward-dns,
             # if access must be granted to other than local.
-            </IfVersion>
+        </IfVersion>
         SetHandler pagespeed_admin
     </Location>
     <Location /pagespeed_global_admin>
@@ -346,8 +346,8 @@
             </IfVersion>
         <IfVersion >= 2.4>
             Require local            
-            </IfVersion>
-          SetHandler pagespeed_global_admin
+        </IfVersion>
+        SetHandler pagespeed_global_admin
     </Location>
 
     # Enable logging of mod_pagespeed statistics, needed for the console.


### PR DESCRIPTION
Hello,

According to this : https://httpd.apache.org/docs/2.4/en/mod/mod_access_compat.html, removes old directives and use new ones as explain here : https://httpd.apache.org/docs/2.4/en/upgrading.html#page-header .

Maybe you should keep : 
#Require forward-dns user.domain.tld
as example, it's to use domain verification only, but not reverse resolution (http://httpd.apache.org/docs/current/en/mod/mod_authz_host.html). This way a mobile user should use some dynamic ip's domains services easyly and admin should grant access to this user only .

Thanks,

Eric