### PR TITLE
Update repository links

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,7 +22,7 @@
 	url = https://github.com/google/re2.git
 [submodule "third_party/icu"]
 	path = third_party/icu
-	url = https://github.com/pagespeed/icu.git
+	url = https://github.com/apache/incubator-pagespeed-icu.git
 [submodule "third_party/libjpeg_turbo/src"]
 	path = third_party/libjpeg_turbo/src
 	url = https://chromium.googlesource.com/chromium/deps/libjpeg_turbo
@@ -42,7 +42,7 @@
 	url = git://git.apache.org/apr.git
 [submodule "third_party/optipng"]
 	path = third_party/optipng
-	url = https://github.com/pagespeed/optipng.git
+	url = https://github.com/apache/incubator-pagespeed-optipng.git
 [submodule "third_party/libwebp"]
 	path = third_party/libwebp
 	url = https://chromium.googlesource.com/webm/libwebp.git
@@ -65,7 +65,7 @@
 	url = https://boringssl.googlesource.com/boringssl.git
 [submodule "third_party/zlib"]
 	path = third_party/zlib
-	url = https://github.com/pagespeed/zlib.git
+	url = https://github.com/apache/incubator-pagespeed-zlib.git
 [submodule "third_party/chromium/src/base"]
 	path = third_party/chromium/src/base
 	url = https://chromium.googlesource.com/chromium/src/base
@@ -82,7 +82,7 @@
 	url = https://github.com/google/sparsehash.git
 [submodule "third_party/domain_registry_provider"]
 	path = third_party/domain_registry_provider
-	url = https://github.com/pagespeed/domain-registry-provider.git
+	url = https://github.com/apache/incubator-pagespeed-drp.git
 [submodule "third_party/jsoncpp/src"]
 	path = third_party/jsoncpp/src
 	url = https://github.com/open-source-parsers/jsoncpp.git

--- a/devel/Makefile
+++ b/devel/Makefile
@@ -404,7 +404,7 @@ stress_test_prepare :
 
 # This test checks that when ProxyPass is set on a host with mod_pagespeed
 # enabled, URLs are rewritten correctly. (See install/debug.conf.template)
-#   See: http://github.com/pagespeed/mod_pagespeed/issues/74
+#   See: http://github.com/apache/incubator-pagespeed-mod/issues/74
 #
 # TODO(sligocki): Lock Apache.
 .PHONY : apache_debug_proxy_test proxy_test_prepare

--- a/devel/lots_of_vhosts.sh
+++ b/devel/lots_of_vhosts.sh
@@ -38,7 +38,7 @@ function usage {
    You can also set environment variable NUM_VHOSTS to control the number of
    virtual hosts produced.
 
- See also https://github.com/pagespeed/mod_pagespeed/wiki/Memory-Profiling
+ See also https://github.com/apache/incubator-pagespeed-mod/wiki/Memory-Profiling
 EOF
 }
 

--- a/html/doc/build_mod_pagespeed_from_source.html
+++ b/html/doc/build_mod_pagespeed_from_source.html
@@ -87,7 +87,7 @@ path. In <code>bash</code> you would run:
 <p>
 <p>For building version 1.12 and later:</p>
 <pre>
-  git clone -b latest-stable --recursive https://github.com/pagespeed/mod_pagespeed.git
+  git clone -b latest-stable --recursive https://github.com/apache/incubator-pagespeed-mod.git
   cd mod_pagespeed
   python build/gyp_chromium --depth=.
   make BUILDTYPE=Release mod_pagespeed_test pagespeed_automatic_test
@@ -102,8 +102,8 @@ the <code>depot_tools</code>) will do this for you.
 <pre>
   mkdir ~/mod_pagespeed    # Any directory is fine.
   cd ~/mod_pagespeed
-  gclient config https://github.com/pagespeed/mod_pagespeed.git --unmanaged --name=src
-  git clone https://github.com/pagespeed/mod_pagespeed.git src
+  gclient config https://github.com/apache/incubator-pagespeed-mod.git --unmanaged --name=src
+  git clone https://github.com/apache/incubator-pagespeed-mod.git src
   cd src
   git checkout latest-stable
   cd ..
@@ -134,7 +134,7 @@ CentOS, these settings should work:
 </pre>
 <p>
 If you get any other errors while running
-tests, <a href="https://github.com/pagespeed/mod_pagespeed/issues/new">report a
+tests, <a href="https://github.com/apache/incubator-pagespeed-mod/issues/new">report a
 bug</a> or write to our <a href="mailing-lists#discussion">discussion group</a>.
 
 <h2 id="compile">Compile</h2>

--- a/html/doc/domains.html
+++ b/html/doc/domains.html
@@ -655,7 +655,7 @@ pagespeed LoadFromFileMatch "^https?://example.com/~([^/]*)/static/"
   upon only the filename extension and only for common filename extensions we
   recognize (<code>.html</code>, <code>.css</code>, <code>.js</code>,
   <code>.jpg</code>, <code>.jpeg</code>, ... see full
-  list: <a href="https://github.com/pagespeed/mod_pagespeed/blob/master/pagespeed/kernel/http/content_type.cc">content_type.cc</a>).
+  list: <a href="https://github.com/apache/incubator-pagespeed-mod/blob/master/pagespeed/kernel/http/content_type.cc">content_type.cc</a>).
   Before 1.9.32.1, filenames with unrecognized extensions were served with no
   <code>Content-Type</code> header; in 1.9.32.1 and later such filenames will
   not be loaded from file and instead will fall back to ordinary fetching.
@@ -928,7 +928,7 @@ http {
   be used without applying SSI includes, CGI generation, etc.
   Furthermore, all the resources should have filenames with common
   extensions for their Content-Type (Ex: .html, .css, .js, .jpg, .jpeg, ... see
-  full list: <a href="https://github.com/pagespeed/mod_pagespeed/blob/master/pagespeed/kernel/http/content_type.cc">content_type.cc</a>).
+  full list: <a href="https://github.com/apache/incubator-pagespeed-mod/blob/master/pagespeed/kernel/http/content_type.cc">content_type.cc</a>).
 </p>
 
 <h2 id="inline_without_auth">Inlining resources without explicit authorization

--- a/html/doc/downstream-caching.html
+++ b/html/doc/downstream-caching.html
@@ -404,7 +404,7 @@ pagespeed DisableFilters prioritize_critical_css;</pre>
   supported by which browsers in the version of PageSpeed you're using and craft
   regular expressions to match exactly those ones.  This is very difficult to do
   in general because it involves duplicating the code in
-  <a href="https://github.com/pagespeed/mod_pagespeed/blob/latest-stable/pagespeed/kernel/http/user_agent_matcher.cc"><code>user_agent_matcher.cc</code></a>
+  <a href="https://github.com/apache/incubator-pagespeed-mod/blob/latest-stable/pagespeed/kernel/http/user_agent_matcher.cc"><code>user_agent_matcher.cc</code></a>
   as regexes, but a simple division is:
   <ul>
     <li>Chrome 32+: <code>ll,ii,dj,jw,wa,ws</code>

--- a/html/doc/faq.html
+++ b/html/doc/faq.html
@@ -44,9 +44,9 @@ detailed technical questions!)
 <p>
 While we have no dates to announce for upcoming releases, we definitely want to
 know what you think we should be working
-on. Please <a href="https://github.com/pagespeed/mod_pagespeed/issues">search
+on. Please <a href="https://github.com/apache/incubator-pagespeed-mod/issues">search
 our issues</a> for your feature. If you don't find
-it, <a href="https://github.com/pagespeed/mod_pagespeed/issues/new">open a new
+it, <a href="https://github.com/apache/incubator-pagespeed-mod/issues/new">open a new
 issue</a> and tag it "Type-Enhancement". To get updates on an issue, click the
 "star" icon for it.  This also lets us know how many people are interested in
 the issue.  If your issue is Nginx-specific, consider posting on
@@ -139,7 +139,7 @@ optimizing anything.  There are several reasons that could happen:
       HTML must have the resource domain authorized. See
       <a href="domains">Domains</a>.</li>
   <li>Your CSS has new CSS3 syntax or other constructions we don't support.
-      See <a href="http://github.com/pagespeed/mod_pagespeed/issues/108"
+      See <a href="http://github.com/apache/incubator-pagespeed-mod/issues/108"
       >issue 108</a>.
       The <a href="filter-css-rewrite#configuration"
       >fallback_rewrite_css_urls</a> filter may be able to help. You can also
@@ -198,7 +198,7 @@ Second, please upgrade to the latest version; we are continually working on
 bug-fixes and turning off filters that break pages.
 </p>
 If it's still breaking your site, please post a bug
-(<a href="https://github.com/pagespeed/mod_pagespeed/issues/new">Apache</a>,
+(<a href="https://github.com/apache/incubator-pagespeed-mod/issues/new">Apache</a>,
  <a href="https://github.com/pagespeed/ngx_pagespeed/issues/new">Nginx</a>). If
 you can, including the following information will make it much easier to
 diagnose:
@@ -304,7 +304,7 @@ js_tinyMCE?</h2>
 <p>
 Some JavaScript is introspective, being sensitive to its own name or the path
 it's loaded from.  While PageSpeed has an internal list
-(<a href="https://github.com/pagespeed/mod_pagespeed/blob/master/net/instaweb/rewriter/rewrite_options.cc">DisallowTroublesomeResources</a>)
+(<a href="https://github.com/apache/incubator-pagespeed-mod/blob/master/net/instaweb/rewriter/rewrite_options.cc">DisallowTroublesomeResources</a>)
 hardcoded with filenames of JavaScript libraries that are known to be
 problematic, and <a href="restricting_urls#aris">inspects the source of
 others</a> looking for dangerous constructs, it doesn't always correctly

--- a/html/doc/filter-canonicalize-js.html
+++ b/html/doc/filter-canonicalize-js.html
@@ -48,7 +48,7 @@ optimization than can be provided by PageSpeed.</li>
 </ul>
 <p>
 In Apache the default set of libraries can be found in
-the <code><a href="https://github.com/pagespeed/mod_pagespeed/blob/master/net/instaweb/genfiles/conf/pagespeed_libraries.conf">pagespeed_libraries.conf</a></code>
+the <code><a href="https://github.com/apache/incubator-pagespeed-mod/blob/master/net/instaweb/genfiles/conf/pagespeed_libraries.conf">pagespeed_libraries.conf</a></code>
 file, which is loaded along with <code>pagespeed.conf</code> when Apache starts
 up. It contains signatures for all the <a href="/speed/libraries/">Google Hosted
 Libraries</a>.  In Nginx you need to

--- a/html/doc/filter-lazyload-images.html
+++ b/html/doc/filter-lazyload-images.html
@@ -112,7 +112,7 @@ are:
     Plus <a href="https://developers.google.com/+/web/snippet/">thumbnail
     fetcher</a></li>
   <li>Web Spiders
-    (<a href="https://github.com/pagespeed/mod_pagespeed/blob/master/pagespeed/kernel/http/bot_checker.gperf">full
+    (<a href="https://github.com/apache/incubator-pagespeed-mod/blob/master/pagespeed/kernel/http/bot_checker.gperf">full
     list</a>)</li>
 </ul>
 </p>

--- a/html/doc/filter-source-maps-include.html
+++ b/html/doc/filter-source-maps-include.html
@@ -103,7 +103,7 @@ console.log('External script start');var data={'User-Agent':navigator.userAgent,
     is no URL for the original JavaScript).</li>
   <li>If your resources already have source maps, we ignore them and the
     source map we add goes back to the URL you specify in HTML.
-    (<a href="https://github.com/pagespeed/mod_pagespeed/issues/930"
+    (<a href="https://github.com/apache/incubator-pagespeed-mod/issues/930"
         >Issue 930</a>)</li>
 </ul>
 

--- a/html/doc/release_notes.html
+++ b/html/doc/release_notes.html
@@ -68,7 +68,7 @@
 
         With this change, "off" in mod_pagespeed is deprecated, and "standby" should be used instead.
     </dd>
-    <dt><a href="https://github.com/pagespeed/mod_pagespeed/issues/1308"
+    <dt><a href="https://github.com/apache/incubator-pagespeed-mod/issues/1308"
            >Allow UrlValuedAttribute:image on elements with children</a></dt>
     <dd>
        Tags that have children are now considered acceptable targets for image optimization.
@@ -89,31 +89,31 @@
   <h4 class="hide-from-toc">Issues Affecting both Nginx and Apache</h4>
   <ul>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1207">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1207">
          #1207</a></strong>
           Don't emit type=text/javascript on script tags.</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1609">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1609">
          #1609</a></strong>
          Specify which Redis DB to use when confiuring Redis as a caching backend.</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1153">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1153">
          #1153</a></strong>
          Pedantic filter should prevent inlining CSS into the body.</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1538">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1538">
          #1538</a></strong>
          CSS Minification - 0 followed by a unit is rewritten to 0 without a unit .</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1572">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1572">
          #1572</a></strong>
          CSS minifier breaks unicode-range values.</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1585">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1585">
          #1585</a></strong>
          Don't special-case sending webp to PSI.</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1553">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1553">
          #1553</a></strong>
          Debug builds may abort() when revalidating expired output resources.</li>
     <li><strong>
@@ -125,11 +125,11 @@
          #1382</a></strong>
          In amp pages inline_google_font_css must be disabled.</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1496">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1496">
          #1496</a></strong>
          Attempting to extend cache for SVGs returns bad headers/content.</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1405">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1405">
          #1405</a></strong>
          ERROR: Invalid inlined_image_type in cached_result.</li>
   </ul>
@@ -282,45 +282,45 @@
   <h4 class="hide-from-toc">Issues Affecting both Nginx and Apache</h4>
   <ul>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1127">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1127">
           Issue 1127</a></strong>
       Don't accumulate waveforms that won't be displayed</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1263">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1263">
           Issue 1263</a></strong>
       Minimal <a href="https://www.ampproject.org/">AMP</a> support: don't
       invalidate AMP</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1321">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1321">
           Issue 1321</a></strong>
       <a href="system#ipro">IPRO</a> can change the content types of JavaScript
       resources</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1337">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1337">
           Issue 1337</a></strong>
       Multiple instances of the <a href="system#file_cache">cache cleaner</a>
       can run simultaneously on large caches</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1350">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1350">
           Issue 1350</a></strong>
       <a href="filter-domain-rewrite">rewrite_domains</a> doesn't apply to
       <a href="configuration#pagespeed_static">static assets</a></li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1373">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1373">
           Issue 1373</a></strong>
       <a href="configuration#respectvary">RespectVary</a> ignored when
       cache-extending</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1386">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1386">
           Issue 1386</a></strong>
       <a href="domains#ModPagespeedLoadFromFile">LoadFromFile</a> crashes on
       resources too big for memory</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1405">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1405">
           Issue 1405</a></strong>
       Unexpected tag &lt;head/&gt; inside pages</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1409">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1409">
           Issue 1409</a></strong>
       <a href="system#ipro">IPRO</a> Records Resources of Unoptimizable Content
       Types</li>
@@ -355,10 +355,10 @@
   <h3 class="hide-from-toc">Issues Resolved</h3>
   <ul>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1428">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1428">
           Issue 1428</a></strong>
       Auto-updating broken with new <code>.deb</code> systems
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/36d4a38005b9c355d376b9866b71ede0a96be744"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/36d4a38005b9c355d376b9866b71ede0a96be744"
           ><code><small>36d4a38</small></code></a>)
     </li>
   </ul>
@@ -378,29 +378,29 @@
   <h3 class="hide-from-toc">Issues Resolved</h3>
   <ul>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1392">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1392">
           Issue 1392</a></strong>
           and <strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1393">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1393">
           Issue 1393</a></strong>
       All existing preload hints are stripped
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/95ef580465d9ac9dbbe95d0e3c8ae4fd1292aac6"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/95ef580465d9ac9dbbe95d0e3c8ae4fd1292aac6"
           ><code><small>95ef580</small></code></a>)
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1396">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1396">
           Issue 1396</a></strong>
       Can't build from source because Chromium svn is gone
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/3f47828ca7eeb0611b5f2226016631edc42d1e90"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/3f47828ca7eeb0611b5f2226016631edc42d1e90"
           ><code><small>3f47828</small></code></a>,
       <a href="https://github.com/pagespeed/ngx_pagespeed/commit/269ed10ed56230d7b83bdb81e6b7cc1deaf3227f"
           ><code><small>269ed10</small></code></a>)
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1397">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1397">
           Issue 1397</a></strong>
       ImageMaxRewritesAtOnce of -1 should allow unlimited image rewrites
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/18d5549d7be6f857e2deb3285a67f6f3cd3f40ef"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/18d5549d7be6f857e2deb3285a67f6f3cd3f40ef"
           ><code><small>18d5549</small></code></a>)
     </li>
   </ul>
@@ -413,7 +413,7 @@
         <a href="https://github.com/pagespeed/ngx_pagespeed/issues/1149">
           Issue 1149</a></strong>
       PageSpeed output resources cannot be cached in Google Cloud
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/f56391f87eea004ed8f7a8f8288162d8d7f26e8c"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/f56391f87eea004ed8f7a8f8288162d8d7f26e8c"
           ><code><small>f56391</small></code></a>)
       (<a href="https://github.com/pagespeed/ngx_pagespeed/commit/9711b52270ff23293180820b2e4f4fb3befc3c01"
           ><code><small>9711b5</small></code></a>)
@@ -422,7 +422,7 @@
         <a href="https://github.com/pagespeed/ngx_pagespeed/issues/1192">
           Issue 1192</a></strong>
       Cache-purging does not work for in-place resource optimization
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/d1972f66f65a20624826362d7e2838dc91f59c95"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/d1972f66f65a20624826362d7e2838dc91f59c95"
           ><code><small>d1972f</small></code></a>)
       (<a href="https://github.com/pagespeed/ngx_pagespeed/commit/07a6647b6544d91da93630484f2cbff196bc0f70"
           ><code><small>07a664</small></code></a>)
@@ -431,44 +431,44 @@
         <a href="https://github.com/pagespeed/ngx_pagespeed/issues/674">
           Issue 674</a></strong>
       Serf spin causes 100% CPU usage
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/921fd719a1c762daae9aaa28d8b87e6c27497731"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/921fd719a1c762daae9aaa28d8b87e6c27497731"
           ><code><small>921fd7</small></code></a>)
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1022">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1022">
           Issue 1022</a></strong>
       image-inline: don't inline shortcut images
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/203865af81afe5ee6c18f555a4d4ebfb2f0da607"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/203865af81afe5ee6c18f555a4d4ebfb2f0da607"
           ><code><small>203865</small></code></a>)
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1324">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1324">
           Issue 1324</a></strong>
       Support UrlValuedAttribute with CSS
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/59a198284e82bccb303d7e27705bcd3dbd22eda3"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/59a198284e82bccb303d7e27705bcd3dbd22eda3"
           ><code><small>59a1982</small></code></a>)
       (<a href="https://github.com/pagespeed/ngx_pagespeed/commit/787239d42940c53a78bc3646c689c8e399eebc2e"
           ><code><small>787239</small></code></a>)
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1054">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1054">
           Issue 1054</a></strong>
       defer_js loads javascript twice
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/e2aa6f4f75442770c373e6ce3694dbbb5a9313c3"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/e2aa6f4f75442770c373e6ce3694dbbb5a9313c3"
           ><code><small>e2aa6f</small></code></a>)
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1327">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1327">
           Issue 1327</a></strong>
       Remove rel=preload hints which wastefully download unused resources when using PageSpeed
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/dbde98953a796e16fee3fa9afe8c3af444d9e242"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/dbde98953a796e16fee3fa9afe8c3af444d9e242"
           ><code><small>dbde98</small></code></a>)
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1305">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1305">
           Issue 1305</a></strong>
       ImageMaxRewritesAtOnce ignored (but displays correct configured value in admin interface)
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/19cf3bb60b2aadff90ec588aab780e72daf0b581"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/19cf3bb60b2aadff90ec588aab780e72daf0b581"
           ><code><small>19cf3b</small></code></a>)
       (<a href="https://github.com/pagespeed/ngx_pagespeed/commit/e0a3bf223a6ea4914c1d34944f94c8aef8ef0db7"
           ><code><small>e0a3bf</small></code></a>)
@@ -481,68 +481,68 @@
           ><code><small>ff8969</small></code></a>)
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1338">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1338">
           Issue 1338</a></strong>
       Recognize dc.js as a synonym for ga.js
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/1ff43e196a7d0b1c9b27387ae0beef6e374cea51"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/1ff43e196a7d0b1c9b27387ae0beef6e374cea51"
           ><code><small>1ff43e</small></code></a>)
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1307">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1307">
           Issue 1307</a></strong>
       Don't mangle files that start with the gzip magic bytes
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/6dfe527c0f6f30bdf438de61e2cff1eb33817b0b"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/6dfe527c0f6f30bdf438de61e2cff1eb33817b0b"
           ><code><small>6dfe52</small></code></a>)
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1294">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1294">
           Issue 1294</a></strong>
       PageSpeed URL control wildcards don't work properly
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/0654743c1fdbf5b85a62a4dc1d19a1c06a20afd8"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/0654743c1fdbf5b85a62a4dc1d19a1c06a20afd8"
           ><code><small>065474</small></code></a>)
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1348">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1348">
           Issue 1348</a></strong>
       Insert dns-prefetch for safari
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/d05a8b6e75eb5fc7ee7105abedf6189af7308896"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/d05a8b6e75eb5fc7ee7105abedf6189af7308896"
           ><code><small>d05a8b</small></code></a>)
     </li>
     <li><strong>
         <a href="https://github.com/pagespeed/ngx_pagespeed/issues/1222">
           Issue 1222</a></strong>
       Pagespeed eats CSS font-face declarations when defined in imported files
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/8fca3b9d3b606cbd83ae34f09c9564be16831862"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/8fca3b9d3b606cbd83ae34f09c9564be16831862"
           ><code><small>8fca3b</small></code></a>)
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1343">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1343">
           Issue 1343</a></strong>
       allow people to turn off cache cleaning
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/ccea83faf5be53690e3865d06d2cbbb97bf0c05d"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/ccea83faf5be53690e3865d06d2cbbb97bf0c05d"
           ><code><small>ccea83</small></code></a>)
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1371">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1371">
           Issue 1371</a></strong>
       PageSpeed can serve gzipped content without Content-Encoding header via IPRO
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/0bd84a160119f6e2dc04ec22e6b09907e875cdb9"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/0bd84a160119f6e2dc04ec22e6b09907e875cdb9"
           ><code><small>0bd84a</small></code></a>)
     </li>
     <li><strong>
         <a href="https://github.com/pagespeed/ngx_pagespeed/issues/1190">
           Issue 1190</a></strong>
       Adding ?PageSpeedFilters=+debug to URL enables other filters
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/2a3b1278dfe0482ab59df663f40e65c3f5432441"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/2a3b1278dfe0482ab59df663f40e65c3f5432441"
           ><code><small>2a3b12</small></code></a>)
       (<a href="https://github.com/pagespeed/ngx_pagespeed/commit/2af2035bbd8979744aaf5a7fbd24c3192933f186"
           ><code><small>2af203</small></code></a>)
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1369">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1369">
           Issue 1369</a></strong>
       dedup_inline_images filter is broken for images that don't already have an id
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/c1827bb0be7fb9b4696baa97c978012b8e869dc9"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/c1827bb0be7fb9b4696baa97c978012b8e869dc9"
           ><code><small>c1827b</small></code></a>)
     </li>
   </ul>
@@ -577,16 +577,16 @@
   <h3 class="hide-from-toc">Issues Resolved</h3>
   <ul>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1288">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1288">
           Issue 1288</a></strong>
       Experiment reporting broken with ga.js
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/65067523faf34833cfda8ae5c5e10b5f7ba5497f"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/65067523faf34833cfda8ae5c5e10b5f7ba5497f"
           ><code><small>650675</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1219">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1219">
           Issue 1298</a></strong>
       Experiment injection for GA tracker always sets variation 1
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/a2b10e49318ea9d8e2ecf26e2c562bc427a06e99"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/a2b10e49318ea9d8e2ecf26e2c562bc427a06e99"
           ><code><small>a2b10e4</small></code></a>)</li>
   </ul>
 
@@ -621,30 +621,30 @@
   <h4 class="hide-from-toc">Issues Affecting both Nginx and Apache</h4>
   <ul>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/973">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/973">
           Issue 973</a></strong>
       Strip subresource hints
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/d0bae68"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/d0bae68"
           ><code><small>d0bae68</small></code></a>,
        <a href="https://github.com/pagespeed/ngx_pagespeed/commit/08e284f"
           ><code><small>08e284f</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1214">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1214">
           Issue 1214</a></strong>
       PageSpeed console blank
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/2bd239d"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/2bd239d"
           ><code><small>2bd239d</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1276">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1276">
           Issue 1276</a></strong>
       CSS Parser has off-by-one heap read
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/0bc4ce7"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/0bc4ce7"
           ><code><small>0bc4ce7</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1277">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1277">
           Issue 1277</a></strong>
       Google Fonts CSS inlining broken
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/e3aa7b7"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/e3aa7b7"
           ><code><small>e3aa7b7</small></code></a>)</li>
   </ul>
 
@@ -694,7 +694,7 @@
         <a href="announce-sec-update-201603"
           >announce-sec-update-201603</a></strong>
         Fetching and XSS vulnerability. (
-        <a href="https://github.com/pagespeed/mod_pagespeed/commit/52e184b"
+        <a href="https://github.com/apache/incubator-pagespeed-mod/commit/52e184b"
           ><code><small>52e184b</small></code></a>)</li>
   </ul>
 
@@ -758,49 +758,49 @@
   <h4 class="hide-from-toc">Issues Affecting both Nginx and Apache</h4>
   <ul>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1080">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1080">
           Issue 1080</a></strong>
       inline_google_font_css uses .ttf instead of .woff for IE11
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/f3639e"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/f3639e"
           ><code><small>f3639e</small></code></a>,
       <a href="https://github.com/pagespeed/ngx_pagespeed/commit/0a60e0"
           ><code><small>1964ef</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1252">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1252">
           Issue 1252</a></strong>
       Images may be rewritten multiple times when requested simultaneously via
       IPRO
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/62d24f"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/62d24f"
           ><code><small>62d24f</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1253">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1253">
           Issue 1253</a></strong>
       Tests can flake because of best effort locking
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/c368ef"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/c368ef"
           ><code><small>c368ef</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1254">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1254">
           Issue 1254</a></strong>
       Fallback value not decompressed when necessary
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/bcf63ac"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/bcf63ac"
           ><code><small>bcf63ac</small></code></a>,
-      <a href="https://github.com/pagespeed/mod_pagespeed/commit/d3851dd"
+      <a href="https://github.com/apache/incubator-pagespeed-mod/commit/d3851dd"
           ><code><small>d3851dd</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1261">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1261">
           Issue 1261</a></strong>
       CSS minification incorrectly transforms 0% to 0
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/7c30b7"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/7c30b7"
           ><code><small>7c30b7</small></code></a>)</li>
   </ul>
   <h4 class="hide-from-toc">Issues Affecting Apache</h4>
   <ul>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1229">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1229">
           Issue 1229</a></strong>
       pagespeed default config fails to load on 2.4 unless mod_access_compat
       is loaded
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/02e8f7"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/02e8f7"
           ><code><small>02e8f7</small></code></a>)</li>
   </ul>
   <h4 class="hide-from-toc">Issues Affecting Nginx</h4>
@@ -879,36 +879,36 @@
         <a href="announce-sec-update-201601"
           >announce-sec-update-201601</a></strong>
         HTTPS fetching vulnerability. (
-        <a href="https://github.com/pagespeed/mod_pagespeed/commit/4af5e65"
+        <a href="https://github.com/apache/incubator-pagespeed-mod/commit/4af5e65"
           ><code><small>4af5e65</small></code></a>)</li>
     <li><strong>
         <a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8540">
           CVE-2015-8540</a></strong>
       LibPNG out-of-bounds read in <code>png_check_keyword()</code>.
-       (<a href="https://github.com/pagespeed/mod_pagespeed/commit/79aaa94"
+       (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/79aaa94"
            ><code><small>79aaa94</small></code></a>)</li>
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1139">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1139">
           Issue 1139</a></strong>
       Link SSL library correctly.
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/5b8253"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/5b8253"
           ><code><small>5b8253</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1256">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1256">
           Issue 1256</a></strong>
       Don't send WebP to Chrome on iOS
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/23947d"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/23947d"
           ><code><small>23947d</small></code></a>)</li>
   </ul>
 
   <h4 class="hide-from-toc">Issues Affecting Apache</h4>
   <ul>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1248">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1248">
           Issue 1248</a></strong>
       Crash on very long urls
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/befa494"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/befa494"
           ><code><small>befa494</small></code></a>)</li>
   </ul>
 
@@ -918,44 +918,44 @@
   <h4 class="hide-from-toc">Issues Affecting both Nginx and Apache</h4>
   <ul>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1083">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1083">
           Issue 1083</a></strong>
       Newline in Content-Type meta tag breaks the page
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/08cbf9"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/08cbf9"
           ><code><small>08cbf9</small></code></a>)</li>
    <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1215">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1215">
           Issue 1215</a></strong>
       Missing CSS files with OptimizeForBandwith + combine_css
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/55e0962"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/55e0962"
           ><code><small>55e0962</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1222">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1222">
           Issue 1222</a></strong>
       rel=canonical links added for resources optimized with
       InPlaceResourceOptimization
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/61f4e96"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/61f4e96"
           ><code><small>61f4e96</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1226">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1226">
           Issue 1226</a></strong>
       Nested rewrites get inconsistent request properties
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/024eb91"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/024eb91"
           ><code><small>024eb91</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1227">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1227">
           Issue 1227</a></strong>
       Can't build PSOL
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/4b6a08"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/4b6a08"
           ><code><small>4b6a08</small></code></a>)</li>
   </ul>
   <h4 class="hide-from-toc">Issues Affecting Apache</h4>
   <ul>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1224">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1224">
           Issue 1224</a></strong>
       Serf depends on APR 1.3
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/f3edc3b"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/f3edc3b"
           ><code><small>f3edc3b</small></code></a>)</li>
   </ul>
   <h4 class="hide-from-toc">Issues Affecting Nginx</h4>
@@ -966,7 +966,7 @@
       Noisy thread info printed on startup.
       (<a href="https://github.com/pagespeed/ngx_pagespeed/commit/37e1c3"
           ><code><small>37e1c3</small></code></a>,
-       <a href="https://github.com/pagespeed/mod_pagespeed/commit/b6a955"
+       <a href="https://github.com/apache/incubator-pagespeed-mod/commit/b6a955"
           ><code><small>b6a955</small></code></a>)
     </li>
   </ul>
@@ -976,16 +976,16 @@
   <h3 class="hide-from-toc">Issues Resolved</h3>
   <ul>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1218">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1218">
           Issue 1218</a></strong>
       WebP served to UAs that don't support it
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/e398794668f487f55db5c74baba286c708f7e0ee"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/e398794668f487f55db5c74baba286c708f7e0ee"
           ><code><small>e39879</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1219">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1219">
           Issue 1219</a></strong>
       Crash in gzip header handling
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/0f772622b8f315884f5f9dc79b3e0b58d8ee31cf"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/0f772622b8f315884f5f9dc79b3e0b58d8ee31cf"
           ><code><small>0f7726</small></code></a>)</li>
   </ul>
 
@@ -1082,124 +1082,124 @@
   <h4 class="hide-from-toc">Issues Affecting both Nginx and Apache</h4>
   <ul>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/931">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/931">
           Issue 931</a></strong>
       Do not serve source map on hash mismatch.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/979">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/979">
           Issue 979</a></strong>
       Allow spaces between filter names in <code>PageSpeedFilters</code>
       header.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1085">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1085">
           Issue 1085</a></strong>
       Don't update <code>Last-Modified</code> when cache-extending.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1092">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1092">
           Issue 1092</a></strong>
       Parsing complex CSS can fail, leaving cache in an inconsistent state.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1109">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1109">
           Issue 1109</a></strong>
       Can't set <code>MessageBufferSize</code> to 0.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1116">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1116">
           Issue 1116</a></strong>
       Support gcc 4.6.3 when building from source.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1131">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1131">
           Issue 1131</a></strong>
       When building from source, respect the CXX variable.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1149">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1149">
           Issue 1149</a></strong>
       WebP transcoding doesn't work with MapProxyDomain+IPRO.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/pull/1150">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/pull/1150">
           Issue 1150</a></strong>
       BoringSSL won't compile under gcc5.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1154">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1154">
           Issue 1154</a></strong>
       Spin in serf.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1160">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1160">
           Issue 1160</a></strong>
       Don't serve WebP to Firefox on Android
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1164">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1164">
           Issue 1164</a></strong>
       Do not abbreviate 0s in CSS files as 0.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1173">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1173">
           Issue 1173</a></strong>
       <code>Disallow</code> should apply to defer_javascript.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1182">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1182">
           Issue 1182</a></strong>
       Don't try to resize images with invalid desired dimensions.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1183">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1183">
           Issue 1183</a></strong>
       Race condition in the shared memory cache between delete and write.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1184">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1184">
           Issue 1184</a></strong>
       Include canonical links for images and pdfs we rewrite.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1185">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1185">
           Issue 1185</a></strong>
       Improve CSS parser's handling of new constructs.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1186">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1186">
           Issue 1186</a></strong>
       Remove <code>/wp-admin</code> from our url blacklist.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1187">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1187">
           Issue 1187</a></strong>
       Prioritize Critical CSS writes a mixture of optimized and unoptimized
       content.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1188">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1188">
           Issue 1188</a></strong>
       Location headers not rewritten when proxying redirects.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1189">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1189">
           Issue 1189</a></strong>
       Race in FileCache.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1193">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1193">
           Issue 1193</a></strong>
       File reading tracks line numbers.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1202">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1202">
           Issue 1202</a></strong>
       Improve resource usage for on-the-fly optimizations.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1203">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1203">
           Issue 1203</a></strong>
       File cache entries are read in 10k chunks.
     </li>
@@ -1208,24 +1208,24 @@
   <h4 class="hide-from-toc">Apache-specific Issues</h4>
   <ul>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1077">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1077">
           Issue 1077</a></strong>
       Purging fails if the top-level configuration has PageSpeed as off.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1088">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1088">
           Issue 1088</a></strong>
         Allow server owners to <a href="admin#limiting-handlers">block access to
         handlers</a> such that they can't be re-enabled
         in <code>.htaccess</code>.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1179">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1179">
           Issue 1179</a></strong>
       Compilation issue in ApacheFetch under 32-bit.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1191">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1191">
           Issue 1191</a></strong>
       IPRO recorder crashes on corrupt brigades with multiple EOS buckets.
     </li>
@@ -1278,110 +1278,110 @@
         <a href="https://github.com/pagespeed/ngx_pagespeed/issues/972">
           Issue 972</a></strong>
       <code>LoadFromFile</code> logs errors on 404s
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/3d44cc7bdaf3e4250a9d0c1f201d76c4de1de857"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/3d44cc7bdaf3e4250a9d0c1f201d76c4de1de857"
           ><code><small>3d44cc</small></code></a>)</li>
     <li><strong>
         <a href="https://github.com/pagespeed/ngx_pagespeed/issues/992">
           Issue 992</a></strong>
       Segfault in https fetching
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/b4f4ae9b264c6973ff2835920ab32ade1981dd42"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/b4f4ae9b264c6973ff2835920ab32ade1981dd42"
           ><code><small>b4f4ae9</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1039">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1039">
           Issue 1039</a></strong>
       Noisy <code>leaked_rewrite_drivers</code> on destruction message
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/58aaa4235de5829232f327436a706fdeb494e5dd"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/58aaa4235de5829232f327436a706fdeb494e5dd"
           ><code><small>58aaa4</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1040">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1040">
           Issue 1040</a></strong>
       <code>inline_google_font_css</code> no longer works in Chrome
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/01045a9d333e4b6e0ef2c3a04826a3d15f9c277b"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/01045a9d333e4b6e0ef2c3a04826a3d15f9c277b"
           ><code><small>01045a</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1043">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1043">
           Issue 1043</a></strong>
       Source maps set <code>?PageSpeed=off</code> for <code>.pagespeed.</code>
       sources
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/9d6d08782d4289b6d71fee3bf5406cf65e3e0c0b"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/9d6d08782d4289b6d71fee3bf5406cf65e3e0c0b"
           ><code><small>9d6d08</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1050">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1050">
           Issue 1050</a></strong>
       <code>X-Sendfile</code> messages should not be cached
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/a49af6bdabe5bfea5e6bc496102590b8c7728ed4"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/a49af6bdabe5bfea5e6bc496102590b8c7728ed4"
           ><code><small>a49af6</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1060">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1060">
           Issue 1060</a></strong>
       Spurious <code>DownstreamCacheRebeaconingKey</code> Warning
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/0f2a6fccb8f1a6cc32086df7cfd348d0ef69a9d9"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/0f2a6fccb8f1a6cc32086df7cfd348d0ef69a9d9"
           ><code><small>0f2a6f</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1068">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1068">
           Issue 1068</a></strong>
       Empty resources should not be cached.
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/741a86580dd6bf5b2a2f4bb24fca6d3bae919152"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/741a86580dd6bf5b2a2f4bb24fca6d3bae919152"
           ><code><small>741a86</small></code></a>,
-       <a href="https://github.com/pagespeed/mod_pagespeed/commit/3ac0192ab8e383ddcd8f77ead391482a75accb48"
+       <a href="https://github.com/apache/incubator-pagespeed-mod/commit/3ac0192ab8e383ddcd8f77ead391482a75accb48"
           ><code><small>3ac019</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1070">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1070">
           Issue 1070</a></strong>
       Opera Mini should not be sent <code>lazyload_images</code> JS
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/0a90bb158d7e93e4076b93e12e973393c1930fdc"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/0a90bb158d7e93e4076b93e12e973393c1930fdc"
           ><code><small>0a90bb</small></code></a>)</li>
      <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1078">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1078">
           Issue 1078</a></strong>
       Image rewriting dcheck-fails on images with invalid dimensions
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/166151ff0ab4bddd42c9a6ce4211c1c5832e780f"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/166151ff0ab4bddd42c9a6ce4211c1c5832e780f"
           ><code><small>166151</small></code></a>)</li>
      <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1087">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1087">
           Issue 1087</a></strong>
       Critical images js doesn't play well with <code>display</code>
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/f01252e8ebea981610f3bbe969eec2b9a11235ed"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/f01252e8ebea981610f3bbe969eec2b9a11235ed"
           ><code><small>f01252</small></code></a>)</li>
      <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1106">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1106">
           Issue 1106</a></strong>
       <code>If-Modified-Since</code> not working with IPRO
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/9ba2502d1750005b4d7dc4bb13379b6e4aa87edc"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/9ba2502d1750005b4d7dc4bb13379b6e4aa87edc"
           ><code><small>9ba250</small></code></a>)</li>
      <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1109">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1109">
           Issue 1109</a></strong>
       Can't set <code>MessageBufferSize</code> to 0
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/16e9f43edf38c74057b3cd45ed96c4040c59d688"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/16e9f43edf38c74057b3cd45ed96c4040c59d688"
           ><code><small>16e9f4</small></code></a>)</li>
      <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1116">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1116">
           Issue 1116</a></strong>
       Won't compile with <code>gcc</code> 4.6.3
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/3f917696279fe103d313b3afc1bfe13543c5510f"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/3f917696279fe103d313b3afc1bfe13543c5510f"
           ><code><small>3f9176</small></code></a>)</li>
      <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1152">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1152">
           Issue 1152</a></strong>
       boringssl build fails on suse tumbleweed/archlinux
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/4cbc9320342dc1314db31eb9514da39058c6c6c7"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/4cbc9320342dc1314db31eb9514da39058c6c6c7"
           ><code><small>4cbc93</small></code></a>)</li>
   </ul>
 
   <h4 class="hide-from-toc">Apache-specific Issues</h4>
   <ul>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1048">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1048">
           Issue 1048</a></strong>
       Apache stuck indefinitely waiting for PSOL
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/84a9deaf9c4df13ae707f44d06f577321de46e8c"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/84a9deaf9c4df13ae707f44d06f577321de46e8c"
           ><code><small>84a9de</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1081">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1081">
           Issue 1081</a></strong>
       Invalid cache entries on aborted requests
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/7a3fab0d5d517f2dd8808f906f75c50ec2c58f87"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/7a3fab0d5d517f2dd8808f906f75c50ec2c58f87"
           ><code><small>7a3fab</small></code></a>)</li>
   </ul>
 
@@ -1416,7 +1416,7 @@
           Issue 956</a></strong>
       DCheck failure if pagespeed is off and no file cache path is
       configured
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/c925b48400af18abaf73fb86dd723642efb29112"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/c925b48400af18abaf73fb86dd723642efb29112"
           ><code><small>c925b4</small></code></a>)</li>
     <li><strong>
         <a href="https://github.com/pagespeed/ngx_pagespeed/issues/965">
@@ -1431,16 +1431,16 @@
   <h3 class="hide-from-toc">Issues Resolved</h3>
   <ul>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1048">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1048">
           Issue 1048</a></strong>
       Apache stuck indefinitely waiting for PSOL
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/84a9deaf9c4df13ae707f44d06f577321de46e8c"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/84a9deaf9c4df13ae707f44d06f577321de46e8c"
           ><code><small>84a9de</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1152">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1152">
           Issue 1152</a></strong>
       boringssl build fails on suse tumbleweed/archlinux
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/4cbc9320342dc1314db31eb9514da39058c6c6c7"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/4cbc9320342dc1314db31eb9514da39058c6c6c7"
           ><code><small>4cbc93</small></code></a>)</li>
   </ul>
 
@@ -1453,106 +1453,106 @@
         <a href="https://github.com/pagespeed/ngx_pagespeed/issues/972">
           Issue 972</a></strong>
       <code>LoadFromFile</code> logs errors on 404s
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/3d44cc7bdaf3e4250a9d0c1f201d76c4de1de857"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/3d44cc7bdaf3e4250a9d0c1f201d76c4de1de857"
           ><code><small>3d44cc</small></code></a>)</li>
     <li><strong>
         <a href="https://github.com/pagespeed/ngx_pagespeed/issues/992">
           Issue 992</a></strong>
       Segfault in https fetching
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/b4f4ae9b264c6973ff2835920ab32ade1981dd42"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/b4f4ae9b264c6973ff2835920ab32ade1981dd42"
           ><code><small>b4f4ae9</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1039">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1039">
           Issue 1039</a></strong>
       Noisy <code>leaked_rewrite_drivers</code> on destruction message
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/58aaa4235de5829232f327436a706fdeb494e5dd"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/58aaa4235de5829232f327436a706fdeb494e5dd"
           ><code><small>58aaa4</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1040">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1040">
           Issue 1040</a></strong>
       <code>inline_google_font_css</code> no longer works in Chrome
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/01045a9d333e4b6e0ef2c3a04826a3d15f9c277b"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/01045a9d333e4b6e0ef2c3a04826a3d15f9c277b"
           ><code><small>01045a</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1043">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1043">
           Issue 1043</a></strong>
       Source maps set <code>?PageSpeed=off</code> for <code>.pagespeed.</code>
       sources
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/9d6d08782d4289b6d71fee3bf5406cf65e3e0c0b"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/9d6d08782d4289b6d71fee3bf5406cf65e3e0c0b"
           ><code><small>9d6d08</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1050">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1050">
           Issue 1050</a></strong>
       <code>X-Sendfile</code> messages should not be cached
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/a49af6bdabe5bfea5e6bc496102590b8c7728ed4"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/a49af6bdabe5bfea5e6bc496102590b8c7728ed4"
           ><code><small>a49af6</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1060">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1060">
           Issue 1060</a></strong>
       Spurious <code>DownstreamCacheRebeaconingKey</code> Warning
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/0f2a6fccb8f1a6cc32086df7cfd348d0ef69a9d9"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/0f2a6fccb8f1a6cc32086df7cfd348d0ef69a9d9"
           ><code><small>0f2a6f</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1068">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1068">
           Issue 1068</a></strong>
       Empty resources should not be cached.
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/741a86580dd6bf5b2a2f4bb24fca6d3bae919152"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/741a86580dd6bf5b2a2f4bb24fca6d3bae919152"
           ><code><small>741a86</small></code></a>,
-       <a href="https://github.com/pagespeed/mod_pagespeed/commit/3ac0192ab8e383ddcd8f77ead391482a75accb48"
+       <a href="https://github.com/apache/incubator-pagespeed-mod/commit/3ac0192ab8e383ddcd8f77ead391482a75accb48"
           ><code><small>3ac019</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1070">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1070">
           Issue 1070</a></strong>
       Opera Mini should not be sent <code>lazyload_images</code> JS
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/0a90bb158d7e93e4076b93e12e973393c1930fdc"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/0a90bb158d7e93e4076b93e12e973393c1930fdc"
           ><code><small>0a90bb</small></code></a>)</li>
      <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1078">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1078">
           Issue 1078</a></strong>
       Image rewriting dcheck-fails on images with invalid dimensions
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/166151ff0ab4bddd42c9a6ce4211c1c5832e780f"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/166151ff0ab4bddd42c9a6ce4211c1c5832e780f"
           ><code><small>166151</small></code></a>)</li>
      <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1087">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1087">
           Issue 1087</a></strong>
       Critical images js doesn't play well with <code>display</code>
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/f01252e8ebea981610f3bbe969eec2b9a11235ed"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/f01252e8ebea981610f3bbe969eec2b9a11235ed"
           ><code><small>f01252</small></code></a>)</li>
      <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1106">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1106">
           Issue 1106</a></strong>
       <code>If-Modified-Since</code> not working with IPRO
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/9ba2502d1750005b4d7dc4bb13379b6e4aa87edc"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/9ba2502d1750005b4d7dc4bb13379b6e4aa87edc"
           ><code><small>9ba250</small></code></a>)</li>
      <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1109">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1109">
           Issue 1109</a></strong>
       Can't set <code>MessageBufferSize</code> to 0
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/16e9f43edf38c74057b3cd45ed96c4040c59d688"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/16e9f43edf38c74057b3cd45ed96c4040c59d688"
           ><code><small>16e9f4</small></code></a>)</li>
      <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1116">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1116">
           Issue 1116</a></strong>
       Won't compile with <code>gcc</code> 4.6.3
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/3f917696279fe103d313b3afc1bfe13543c5510f"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/3f917696279fe103d313b3afc1bfe13543c5510f"
           ><code><small>3f9176</small></code></a>)</li>
   </ul>
 
   <h4 class="hide-from-toc">Apache-specific Issues</h4>
   <ul>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1048">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1048">
           Issue 1048</a></strong>
       Apache stuck indefinitely waiting for PSOL
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/e59644fc50c257f1360194a895286886c87481b8"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/e59644fc50c257f1360194a895286886c87481b8"
           ><code><small>e59644</small></code></a>,
-       <a href="https://github.com/pagespeed/mod_pagespeed/commit/c001a83e015bec5a5a1316e4399349abd02ea7e6"
+       <a href="https://github.com/apache/incubator-pagespeed-mod/commit/c001a83e015bec5a5a1316e4399349abd02ea7e6"
           ><code><small>c001a8</small></code></a>)</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1081">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1081">
           Issue 1081</a></strong>
       Invalid cache entries on aborted requests
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/7a3fab0d5d517f2dd8808f906f75c50ec2c58f87"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/7a3fab0d5d517f2dd8808f906f75c50ec2c58f87"
           ><code><small>7a3fab</small></code></a>)</li>
   </ul>
 
@@ -1587,7 +1587,7 @@
           Issue 956</a></strong>
       DCheck failure if pagespeed is off and no file cache path is
       configured
-      (<a href="https://github.com/pagespeed/mod_pagespeed/commit/c925b48400af18abaf73fb86dd723642efb29112"
+      (<a href="https://github.com/apache/incubator-pagespeed-mod/commit/c925b48400af18abaf73fb86dd723642efb29112"
           ><code><small>c925b4</small></code></a>)</li>
     <li><strong>
         <a href="https://github.com/pagespeed/ngx_pagespeed/issues/965">
@@ -1641,7 +1641,7 @@
   <h3 class="hide-from-toc">Issues Resolved</h3>
   <ul>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1094">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1094">
           Issue 1094</a></strong>
       Source map can be requested with option disabled.
     </li>
@@ -1663,11 +1663,11 @@
   <h3 class="hide-from-toc">Issues Resolved</h3>
   <ul>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/1025">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/1025">
           Issue 1025</a></strong>
       Purge cache UI has problems in admin console.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/1028">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/1028">
           Issue 1028</a></strong>
       Malformed CSS file can cause a hang in CSS parser.</li>
     <li><strong>
@@ -1685,7 +1685,7 @@
   <h3 class="hide-from-toc">Issues Resolved</h3>
   <ul>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/1028">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/1028">
           Issue 1028</a></strong>
       Malformed CSS file can cause a hang in CSS parser.</li>
   </ul>
@@ -1695,33 +1695,33 @@
   <h3 class="hide-from-toc">Issues Resolved</h3>
   <ul>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/978">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/978">
           Issue 978</a></strong>
       Blacklist Windows Browser for transcoding to webp.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/982">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/982">
           Issue 982</a></strong>
       Defer javascript not working in IE9 or IE11.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/989">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/989">
           Issue 989</a></strong>
       IPRO with LoadFromFile on a resource that is already fully optimized
       serves <code>cc:max-age=300</code>.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/992">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/992">
           Issue 992</a></strong>
       Malformed CSS can lead to unbounded stack depth.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1004">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1004">
           Issue 1004</a></strong>
       Disable SSLv3 and SSLv2 support in serf fetcher.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1012">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1012">
           Issue 1012</a></strong>
       JS error in rendered_image_dimensions filter when the same image appears
       multiple times on a page.
@@ -1744,12 +1744,12 @@
   <h3 class="hide-from-toc">Issues Resolved</h3>
   <ul>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/992">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/992">
           Issue 992</a></strong>
       Malformed CSS can lead to unbounded stack depth.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/1004">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/1004">
           Issue 1004</a></strong>
       Disable SSLv3 and SSLv2 support in serf fetcher.
     </li>
@@ -1804,56 +1804,56 @@
   <h3 class="hide-from-toc">Issues Resolved</h3>
   <ul>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/786">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/786">
           Issue 786</a></strong>
       serf_url_async_fetcher.cc error messages using IP instead of domain name.
     </li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/794">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/794">
           Issue 794</a></strong>
       Colorize warnings and errors in message_history page.</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/813">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/813">
           Issue 813</a></strong>
       Disable beaconing for bots.</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/850">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/850">
           Issue 850</a></strong>
       dedup_inlined_images breaks site combined with lazyload_images and
       defer_javascript.</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/853">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/853">
           Issue 853</a></strong>
       Provide separate filters rewrite_javascript_external and
       rewrite_javascript_inline.</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/909">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/909">
           Issue 909</a></strong>
       Strict mode detection is too conservative.</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/965">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/965">
           Issue 965</a></strong>
       Don't relocate scoped style tags.</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/967">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/967">
           Issue 967</a></strong>
       Don't relocate scoped style tags in prioritize_critical_css.</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/969">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/969">
           Issue 969</a></strong>
       Don't send inline WebP to Chrome/36 on iOS. See issue for workaround fix
       for both nginx and Apache.</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/984">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/984">
           Issue 984</a></strong>
       Fix handling of experiment spec, so that options are applied when using
       the default filters.</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/984">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/984">
           Issue 985</a></strong>
       Re-add query params when we get a redirection response.</li>
     <li><strong>
-        <a href="https://github.com/pagespeed/mod_pagespeed/issues/985">
+        <a href="https://github.com/apache/incubator-pagespeed-mod/issues/985">
           Issue 986</a></strong>
       Default flattening limit is too low.</li>
     <li><strong>
@@ -1916,15 +1916,15 @@
   <h3 class="hide-from-toc">Issues Resolved</h3>
   <ul>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/941">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/941">
           Issue 941</a></strong>
       Pagespeed optimized resource sending incorrect Content-Length header.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/945">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/945">
           Issue 945</a></strong>
       mod_pagespeed cache directory is unwritable by default.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/947">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/947">
           Issue 947</a></strong>
       Do not serve source JavaScript when a rewritten source map is requested.</li>
     <li><strong>
@@ -2022,149 +2022,149 @@
   <h3 class="hide-from-toc">Issues Resolved</h3>
   <ul>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/106">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/106">
           Issue 106</a></strong>
           Inline js files even if they contain <code>&lt;/script&gt;</code>.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/452">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/452">
           Issue 452</a></strong>
           Can't run experiments except on filters and some thresholds.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/570">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/570">
           Issue 570</a></strong>
           Document <code>RewriteDeadlineMs</code>.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/586">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/586">
           Issue 586</a></strong>
           Track image rewriting time
           in <code>mod_pagespeed_variables</code>.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/692">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/692">
           Issue 692</a></strong>
           Fixed-case paths broken in domain-mapping directives.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/752">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/752">
           Issue 752</a></strong>
           Issue downstream cache purges only for GET requests.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/812">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/812">
           Issue 812</a></strong>
           SerfThreadFn might compile with the wrong calling convention and crash
           on shutdown.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/813">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/813">
           Issue 813</a></strong>
           Disable beaconing for bots.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/817">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/817">
           Issue 817</a></strong>
           WebP transcoding should trigger off <code>Accept:</code> headers and
           issue <code>Vary: Accept.</code></li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/831">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/831">
           Issue 831</a></strong>
           Spriting replaces transparent color with arbitrary color.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/832">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/832">
           Issue 832</a></strong>
           DCHECK failure on <code>static_rewriter</code> test.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/840">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/840">
           Issue 840</a></strong>
           Deadlock when rewriting resources.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/845">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/845">
           Issue 845</a></strong>
           etag should not be issued for mismatching content.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/846">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/846">
           Issue 846</a></strong>
           PageSpeed's cache lookup needs to become <code>Vary: Accept</code>
           aware, at least for WebP.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/855">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/855">
           Issue 855</a></strong>
           Deadlock when using apache threads with in-place rewriting, a threaded
           mpm, and memcached.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/856">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/856">
           Issue 856</a></strong>
           Improve error message reporting when shared memory segment creation
           fails.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/858">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/858">
           Issue 858</a></strong>
           Remove insignificant message: &ldquo;Default shared memory cache:
           Cache named pagespeed_default_shm already exists&rdquo;.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/863">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/863">
           Issue 863</a></strong>
           Cache-Control: no-transform has no effect if combined with other
           values.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/865">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/865">
           Issue 865</a></strong>
           ImplicitCacheTtlMs directive doesn't work in IPRO mode.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/871">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/871">
           Issue 871</a></strong>
           Apply in-place optimization on first request
           if <code>InPlaceRewriteDeadlineMs</code> is -1
           and <code>LoadFromFile</code> is enabled.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/881">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/881">
           Issue 881</a></strong>
           Changing JS files can make combining/minification produce reference
           errors.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/882">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/882">
           Issue 882</a></strong>
           Run <code>combine_javascript</code>
           before <code>rewrite_javascript</code>, and have it do the
           minification inline.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/883">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/883">
           Issue 883</a></strong>
           Employ image classification to make better decisions about lossy
           conversion.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/885">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/885">
           Issue 885</a></strong>
           Enabling memcached causes &ldquo;Waiting for property cache&rdquo;
           messages and server spinning.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/907">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/907">
           Issue 907</a></strong>
           Sharedmem &ldquo;Unable to insert object of size&rdquo; message needs to be
           demoted and indicate the cache key.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/915">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/915">
           Issue 915</a></strong>
           Link error on &ldquo;html_minifier_main&rdquo; using GCC 4.9.0 + [Gold]
           Linker.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/918">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/918">
           Issue 918</a></strong>
           &lt;style scoped&gt; is translated to &lt;link rel=&quot;stylesheet&quot;
           scoped&gt; however there is no browser support for the latter.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/921">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/921">
           Issue 921</a></strong>
           Downstream Caches - PURGE request has a double slash.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/927">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/927">
           Issue 927</a></strong>
           defer_javascript errors in Safari 4.x and 5.0, user scripts fail.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/928">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/928">
           Issue 928</a></strong>
           Allow user defined attributes to override spec-defined ones.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/937">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/937">
           Issue 937</a></strong>
           Increase beacon frequency until there's enough data, then decrease it.</li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/938">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/938">
           Issue 938</a></strong>
           Check for image criticality at image onload to fix carousel display.</li>
     <li><strong><a
@@ -2213,36 +2213,36 @@
   <h3 class="hide-from-toc">Issues Resolved</h3>
   <ul>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/441">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/441">
           Issue 441</a></strong>
       Filter "make_google_analytics_async" turns benign call to deprecated
       method into a functional error.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/781">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/781">
           Issue 781</a></strong>
       Images are inlined into CSS styles in IE7 if Firefox renders them
       first.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/874">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/874">
           Issue 874</a></strong>
       Warning messages in log for "ModPagespeed:noscript?".</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/880">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/880">
           Issue 880</a></strong>
       Combining minified JS files can produce invalid results when deadline
       exceeded.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/885">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/885">
           Issue 885</a></strong>
       Enabling memcached causes "Waiting for property cache" messages and
       server spinning.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/896">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/896">
           Issue 896</a></strong>
       IPRO on reverse proxy can capture gzipped content and serve it to users
       without content-encoding:gzip.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/898">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/898">
           Issue 898</a></strong>
       IPRO does not correctly handle resources which failed to fetch.</li>
   </ul>
@@ -2252,7 +2252,7 @@
   <h3 class="hide-from-toc">Issues Resolved</h3>
   <ul>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/867">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/867">
           Issue 867</a></strong>
       Data URLs in CSS become blank after rewriting.</li>
     <li><strong>
@@ -2267,43 +2267,43 @@
   <h3 class="hide-from-toc">Issues Resolved</h3>
   <ul>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/627">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/627">
           Issue 627</a></strong>
       Quoting of ModPagespeed:noscript insertion broken in some browsers.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/831">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/831">
           Issue 831</a></strong>
       Spriting replaces transparent color with arbitrary color.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/840">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/840">
           Issue 840</a></strong>
       Deadlock when rewriting resources.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/856">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/856">
           Issue 856</a></strong>
       Improve error message reporting when shared memory segment creation
       fails.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/857">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/857">
           Issue 857</a></strong>
       Avoid insertions (e.g., beacon) at midpoint of the document which ought
       to be at the end of it.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/858">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/858">
           Issue 858</a></strong>
       Remove insignificant message: Default shared memory cache: Cache named
       pagespeed_default_shm already exists.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/860">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/860">
           Issue 860</a></strong>
       GoogleFontCssInlineFilter doesn't handle protocol-relative URLs
       correctly.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/861">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/861">
           Issue 861</a></strong>
       PSOL sample application has dcheck-failure in the demo program.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/862">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/862">
           Issue 862</a></strong>
       mod_pagespeed may have deadlock in property cache fetch in IPRO non-proxy
       mode if memcached is used.</li>
@@ -2412,83 +2412,83 @@
   <h3 class="hide-from-toc">Issues Resolved</h3>
   <ul>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/198">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/198">
           Issue 198</a></strong>
           Optimize handling of multiple references to the same image on a page
           at different sizes.
     </li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/376">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/376">
           Issue 376</a></strong>
           Image resizing should utilize width/height information in CSS classes.
     </li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/423">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/423">
           Issue 423</a></strong>
           Support fetching resources over HTTPS.
     </li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/466">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/466">
           Issue 466</a></strong>
           Provide a way to optimize all resource attributes in a tag.
     </li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/503">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/503">
           Issue 503</a></strong>
           Preserve URL relativeness.
     </li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/664">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/664">
           Issue 664</a></strong>
           Strip Connection and other hop-by-hop headers when saving input
           resource.
     </li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/755">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/755">
           Issue 755</a></strong>
           Memory leak with 'graceful' restart relating to shared memory
           starting in 1.4.
     </li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/756">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/756">
           Issue 756</a></strong>
           ModifyCachingHeaders should not touch Cache-Control headers if
           downstream-caching is enabled.
     </li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/757">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/757">
           Issue 757</a></strong>
           Make maximum image size configurable.
     </li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/758">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/758">
           Issue 758</a></strong>
           Add configurability for DisableRewriteOnNoTransform and system test.
     </li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/759">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/759">
           Issue 759</a></strong>
           Cleanup race in SchedulerBlockingFunction::Block() and ::Cancel().
     </li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/773">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/773">
           Issue 773</a></strong>
           Repeat image inlined at low resolution when local_storage_cache is
           enabled.
     </li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/799">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/799">
           Issue 799</a></strong>
           Console slow when logfile is large.
     </li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/803">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/803">
           Issue 803</a></strong>
           Metadata cache will reminder not-optimizable for 5 minutes after
           rate-limiting drops a fetch.
     </li>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/809">
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/809">
           Issue 809</a></strong>
           mod_pagespeed disables mod_headers/mod_expires when proxying content
           with cache-control set.
@@ -2561,7 +2561,7 @@
   <h3 class="hide-from-toc">Issues Resolved</h3>
   <ul>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/683">Issue
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/683">Issue
           683</a></strong> Pagespeed strips cache-control:no-store, etc. headers.
     </li>
   </ul>
@@ -2571,11 +2571,11 @@
   <h3 class="hide-from-toc">Issues Resolved</h3>
   <ul>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/748">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/748">
           Issue 748</a></strong>
       RewriteRandomDropPercentage cause duplicate image srcs to be blank.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/751">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/751">
           Issue 751</a></strong>
       Leaked ASM symbol names cause segmentation faults on Apache.</li>
   </ul>
@@ -2585,7 +2585,7 @@
   <h3 class="hide-from-toc">Issues Resolved</h3>
   <ul>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/742">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/742">
           Issue 742</a></strong>
       Broken default pagespeed.conf in 1.6.29.3.</li>
   </ul>
@@ -2656,59 +2656,59 @@
   <h3 class="hide-from-toc">Issues Resolved</h3>
   <ul>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/199">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/199">
           Issue 199</a></strong>
       Multiple references to the same small images all get inlined.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/644">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/644">
           Issue 644</a></strong>
       Improve lazyload behavior.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/675">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/675">
           Issue 675</a></strong>
       rewrite_javascript breaks Wordpress /wp-admin/ pages with certain
       common WP plugins.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/683">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/683">
           Issue 683</a></strong>
       Don't strip Cache-Control:no-store, etc. headers.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/684">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/684">
           Issue 684</a></strong>
       elide_attributes should not remove type=text as wordpress uses it in
       CSS.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/690">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/690">
           Issue 690</a></strong>
       Add originating page URL query-param to beacon URL.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/700">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/700">
           Issue 700</a></strong>
       Image height tag removed when image is embedded.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/707">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/707">
           Issue 707</a></strong>
       PageSpeed lost img tag src value when too busy.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/709">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/709">
           Issue 709</a></strong>
       combine_javascript will kill defer_javascript's pagespeed_no_defer
       attribute.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/712">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/712">
           Issue 712</a></strong>
       JS Canonical Library Map is replicated per vhost and per
       htaccess-subdir.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/719">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/719">
           Issue 719</a></strong>
       Support random dropping of expensive rewrites.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/721">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/721">
           Issue 721</a></strong>
       New default values for PSOL options.</li>
     <li><strong>
-        <a href="http://github.com/pagespeed/mod_pagespeed/issues/722">
+        <a href="http://github.com/apache/incubator-pagespeed-mod/issues/722">
           Issue 722</a></strong>
       rewrite_css should not apply to files with an @import in the middle.</li>
 
@@ -2738,7 +2738,7 @@
   <h3 class="hide-from-toc">Issues Resolved</h3>
   <ul>
     <li><strong><a
-        href="https://github.com/pagespeed/mod_pagespeed/issues/710">Issue
+        href="https://github.com/apache/incubator-pagespeed-mod/issues/710">Issue
           710</a></strong> Error message "Index of processing disabled slot
           out of range" in log file.
     </li>
@@ -2884,15 +2884,15 @@
   <h3 class="hide-from-toc">Issues Resolved</h3>
   <ul>
     <li><strong><a
-        href="http://github.com/pagespeed/mod_pagespeed/issues/109">Issue
+        href="http://github.com/apache/incubator-pagespeed-mod/issues/109">Issue
           109</a></strong> Make it easy to install on cPanel EasyInstall.
     </li>
     <li><strong><a
-        href="http://github.com/pagespeed/mod_pagespeed/issues/508">Issue
+        href="http://github.com/apache/incubator-pagespeed-mod/issues/508">Issue
           508</a></strong> Large numbers get rewritten to scientific notation.
     </li>
     <li><strong><a
-        href="http://github.com/pagespeed/mod_pagespeed/issues/672">Issue
+        href="http://github.com/apache/incubator-pagespeed-mod/issues/672">Issue
           672</a></strong> Disable setting more than one thread for memcached.
     </li>
   </ul>
@@ -2950,49 +2950,49 @@
   <h3 class="hide-from-toc">Issues Resolved</h3>
   <ul>
     <li><strong><a
-        href="http://github.com/pagespeed/mod_pagespeed/issues/213">Issue
+        href="http://github.com/apache/incubator-pagespeed-mod/issues/213">Issue
           213</a></strong> Fetches for same-domain resources failing with
           reference to 224.0.0.0 or 127.0.0.1
     </li>
     <li><strong><a
-        href="http://github.com/pagespeed/mod_pagespeed/issues/572">Issue
+        href="http://github.com/apache/incubator-pagespeed-mod/issues/572">Issue
           572</a></strong> Optimize images referenced from JS
     </li>
     <li><strong><a
-        href="http://github.com/pagespeed/mod_pagespeed/issues/609">Issue
+        href="http://github.com/apache/incubator-pagespeed-mod/issues/609">Issue
           609</a></strong> ModPagespeedMapProxyDomain does not proxy
           non-optimized resources
     </li>
     <li><strong><a
-        href="http://github.com/pagespeed/mod_pagespeed/issues/615">Issue
+        href="http://github.com/apache/incubator-pagespeed-mod/issues/615">Issue
           615</a></strong> Rewriting domains does not work with
           ModPagespeedMapProxyDomain
     </li>
     <li><strong><a
-        href="http://github.com/pagespeed/mod_pagespeed/issues/629">Issue
+        href="http://github.com/apache/incubator-pagespeed-mod/issues/629">Issue
           629</a></strong> insert_image_dimensions on <link>-elements causing
           invalid document
     </li>
     <li><strong><a
-        href="http://github.com/pagespeed/mod_pagespeed/issues/630">Issue
+        href="http://github.com/apache/incubator-pagespeed-mod/issues/630">Issue
           630</a></strong> CSS parser incorrectly parses "1.em" as "1em"
     </li>
     <li><strong><a
-        href="http://github.com/pagespeed/mod_pagespeed/issues/649">Issue
+        href="http://github.com/apache/incubator-pagespeed-mod/issues/649">Issue
           649</a></strong> defer_javascript and defer_iframes not turned on for
           Mobile
     </li>
     <li><strong><a
-        href="http://github.com/pagespeed/mod_pagespeed/issues/650">Issue
+        href="http://github.com/apache/incubator-pagespeed-mod/issues/650">Issue
           650</a></strong> Images inlined for CSS inlines in HTML even when
           CssImageInlineMaxBytes is zero
     </li>
     <li><strong><a
-        href="http://github.com/pagespeed/mod_pagespeed/issues/652">Issue
+        href="http://github.com/apache/incubator-pagespeed-mod/issues/652">Issue
           652</a></strong> Last-Modified header should not be stripped with ...
     </li>
     <li><strong><a
-        href="http://github.com/pagespeed/mod_pagespeed/issues/656">Issue
+        href="http://github.com/apache/incubator-pagespeed-mod/issues/656">Issue
           656</a></strong> Compile with GCC 4.7
     </li>
   </ul>
@@ -3004,12 +3004,12 @@ This release was made March 20, 2013. It is a bug fix release.
 <h3 class="hide-from-toc">Issues Resolved</h3>
 <ul>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/648">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/648">Issue
     648</a></strong>
     Combine_css and combine_javascript loses subdirectories occasionally
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/641">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/641">Issue
     641</a></strong>
     Lazyload Images Defect on Blackberry Browser w/ OS <= 5
   </li>
@@ -3098,64 +3098,64 @@ This release was made February 15, 2013.
 <h3 class="hide-from-toc">Issues Resolved</h3>
 <ul>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/322">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/322">Issue
     322</a></strong>
     We should not rewrite &lt;img src=... width=1 height=1&gt; to 1x1
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/563">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/563">Issue
     563</a></strong>
     Use shared-memory locks by default
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/581">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/581">Issue
     581</a></strong>
     lazyload_images should be enabled for IE6/IE7
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/582">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/582">Issue
     582</a></strong>
     CSS returns 403 Forbidden with some proxy configurations
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/587">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/587">Issue
     587</a></strong>
     Pagespeed should respect Cache-Control: no-transform
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/591">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/591">Issue
     591</a></strong>
     File cache cleaner improperly removing lock files
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/599">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/599">Issue
     599</a></strong>
     Support ModPagespeedMapProxyDomain to CDN
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/600">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/600">Issue
     600</a></strong>
     Proxied resources aren't combined with local resources
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/601">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/601">Issue
     601</a></strong>
     InitializeNested in CssHierarchy initializes a StringPiece with too wide
     a scope
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/608">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/608">Issue
     608</a></strong>
     ModPagespeed=off with no filecachepath causes problems with .pagespeed.
     resources
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/610">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/610">Issue
     610</a></strong>
     Crash with some proxy configurations
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/614">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/614">Issue
     614</a></strong>
     CSS: minify 0.25 -> .25
   </li>
@@ -3194,7 +3194,7 @@ This release was made December 14, 2012.
     sections, which are left unoptimized but no longer completely stop the
     parser. Among other things this allows files containing such sections to
     be combined per
-    <a href="http://github.com/pagespeed/mod_pagespeed/issues/565">issue
+    <a href="http://github.com/apache/incubator-pagespeed-mod/issues/565">issue
       565</a> as described below.</dd>
 </dl>
 
@@ -3220,74 +3220,74 @@ This release was made December 14, 2012.
 <h3 class="hide-from-toc">Issues Resolved</h3>
 <ul>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/199">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/199">Issue
     199</a></strong>
     multiple references to the same small images all get inlined
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/259">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/259">Issue
     259</a></strong>
     Provide a way to turn off query-params
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/349">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/349">Issue
     349</a></strong>
     Serf internal error 20014 in sporadic bursts
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/367">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/367">Issue
     367</a></strong>
     PageSpeed strips custom HTML headers
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/501">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/501">Issue
     501</a></strong>
     Add ability to set maximum size of a resource for PageSpeed to optimize
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/516">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/516">Issue
     516</a></strong>
     add attribute-based mechanism to disable rewriting a resource
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/533">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/533">Issue
     533</a></strong>
     Look at response-headers in addition to request-headers/query-params for
     ModPagespeed=* options
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/557">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/557">Issue
     557</a></strong>
     Add feature to proxy resources whose origin servers don't run PageSpeed
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/565">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/565">Issue
     565</a></strong>
     css_combine overly pessimistic (should combine even if CSS cannot be fully
     parsed)
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/571">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/571">Issue
     571</a></strong>
     Add option to set rewrite deadline from config
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/573">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/573">Issue
     573</a></strong>
     local storage cache doesn't work
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/574">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/574">Issue
     574</a></strong>
     CSS compress removes quotes and backslashes
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/575">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/575">Issue
     575</a></strong>
     CSS selector broken by removing quote
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/585">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/585">Issue
     585</a></strong>
     convert_jpeg_to_progressive should be added to core-filter-set
   </li>
@@ -3306,12 +3306,12 @@ This release was made November 15, 2012.
 <h3 class="hide-from-toc">Issues Resolved</h3>
 <ul>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/567">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/567">Issue
     567</a></strong>
     [error] "Shutting down PageSpeed child" after binary upgrade
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/568">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/568">Issue
     568</a></strong>
     Cache Flush reported excessively
   </li>
@@ -3394,200 +3394,200 @@ This release was made November 12, 2012.
 <h3 class="hide-from-toc">Issues Resolved</h3>
 <ul>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/177">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/177">Issue
     177</a></strong>
     mod_pagespeed_beacon returns 404 with VirtualHost
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/335">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/335">Issue
     335</a></strong>
     Fetching sharded resource from original domain
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/373">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/373">Issue
     373</a></strong>
     Default locations for cache/generated files should respect the FHS
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/377">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/377">Issue
     377</a></strong>
     Add wildcard support to ModPagespeedLoadFromFile
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/392">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/392">Issue
     392</a></strong>
     Lazyily Load Images on Webkit Browsers and the Image Input Element
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/411">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/411">Issue
     411</a></strong>
     first 3 histograms under /mod_pagespeed_statistics are empty
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/416">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/416">Issue
     416</a></strong>
     outline_css does not inherit CDN rewrite rules from
     ModPagespeedMapRewriteDomain
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/426">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/426">Issue
     426</a></strong>
     Unicode value 0x0 is not valid for interchange
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/430">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/430">Issue
     430</a></strong>
     Per VHOST mod_pagespeed_statistics
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/434">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/434">Issue
     434</a></strong>
     Provide a pagespeed.conf option to append a custom Header (key-&gt;value)
     to the Serf fetcher
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/439">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/439">Issue
     439</a></strong>
     Use mimetype rather than doctype for HTML decisions
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/448">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/448">Issue
     448</a></strong>
     mod_pagespeed_message uses wrong timezone
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/449">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/449">Issue
     449</a></strong>
     Do not strip image dimensions when an inlined image is enlarged
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/450">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/450">Issue
     450</a></strong>
     disable sharding when running under SPDY in general, mod_spdy in
     particular
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/454">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/454">Issue
     454</a></strong>
     mod_pagespeed_ap24.so: cannot open shared object file: No such file or
     directory
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/457">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/457">Issue
     457</a></strong>
     Resource regeneration doesn't respect custom options
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/461">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/461">Issue
     461</a></strong>
     LoadFromFile blacklist support
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/462">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/462">Issue
     462</a></strong>
     file cache should enforce a maximum inode count.
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/463">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/463">Issue
     463</a></strong>
     collapse_whitespace missing whitespace removal in one location
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/475">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/475">Issue
     475</a></strong>
     Add memcached support as an alternative to the file-based cache.
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/477">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/477">Issue
     477</a></strong>
     Blacklist Android Chrome for webp conversion
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/480">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/480">Issue
     480</a></strong>
     defer_javascript should turn off for requests with header XMLHttpRequest
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/488">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/488">Issue
     488</a></strong>
     LoadFromFile + memcached -&gt; meta-data cache timestamp problems
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/490">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/490">Issue
     490</a></strong>
     Make css_flatten_imports a core filter
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/491">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/491">Issue
     491</a></strong>
     inline_import_to_link should handle multiple @import statements
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/493">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/493">Issue
     493</a></strong>
       Is trim_urls in core filter set?
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/494">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/494">Issue
     494</a></strong>
     pagespeed css fetched by CDN result in cache-control:private,max-age=300
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/495">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/495">Issue
     495</a></strong>
     VirtualHosts should inherit configuration from root
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/499">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/499">Issue
     499</a></strong>
     Page load count based on actual HTML rewrites (not beacon count)
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/517">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/517">Issue
     517</a></strong>
     lazyload_images should respect ModPagespeedDisallow directive
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/523">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/523">Issue
     523</a></strong>
     Rewrite &lt;link rel="alternative stylesheet"&gt;
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/529">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/529">Issue
     529</a></strong>
     convert_gif_to_png doc is missing
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/532">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/532">Issue
     532</a></strong>
     webmin through an apache proxy fails
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/535">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/535">Issue
     535</a></strong>
     cache size explosion issue due to css in style tags
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/536">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/536">Issue
     536</a></strong>
     file-cache should count disk usage, not byte-count, when doing garbage
     collection
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/542">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/542">Issue
     542</a></strong>
     Site with html in CDATA tag in script tag gets broken by rewrite_javascript
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/546">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/546">Issue
     546</a></strong>
     Respect X-Forwarded-Proto
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/549">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/549">Issue
     549</a></strong>
     Make unit tests &amp; system tests work in open-source flow without
     memcached running.
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/555">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/555">Issue
     555</a></strong>
     5 configuration settings documented as being settable in .htaccess don't
     work there.
@@ -3620,112 +3620,112 @@ This release was made Jun 1, 2012. It fixes the following issues:
 </p>
 <ul>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/133">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/133">Issue
     133</a></strong>
     Provide easier mechanism to flush server cache
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/152">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/152">Issue
     152</a></strong>
     Add support and testing for Worker MPM
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/253">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/253">Issue
     253</a></strong>
     combine_css should scan for syntax errors to avoid combining broken
         files
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/289">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/289">Issue
     289</a></strong>
     Problem Compiling ModPagespeed on Arch Linux
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/321">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/321">Issue
     321</a></strong>
     Hide or obfuscate X-Mod-Pagespeed header
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/334">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/334">Issue
     334</a></strong>
     PageSpeed uses too many threads -- in proportion to the number
         of vhosts
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/349">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/349">Issue
     349</a></strong>
      Serf internal error 20014 in sporadic bursts
    </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/375">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/375">Issue
     375</a></strong>
     fails to compile on linux kernel 3.0+
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/380">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/380">Issue
     380</a></strong>
     Mod PageSpeed 0.10.21.2-1381 fails to retrieve combined objects with error,
     "Invalid escaped URL segment"
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/386">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/386">Issue
     386</a></strong>
     Deadline exceeded for rewrite
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/393">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/393">Issue
     393</a></strong>
     Mod Pagespeed breaks JqueryMobile ajax request
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/405">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/405">Issue
     405</a></strong>
     ModPagespeedLoadFromFile doesn't set the Content-Type correctly when query
     params exist
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/409">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/409">Issue
     409</a></strong>
     add_instrumentation filter breaks JS execution
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/417">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/417">Issue
     417</a></strong>
     Javascript injected into page by PageSpeed is not minified
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/425">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/425">Issue
     425</a></strong>
     HTML URL attributes with multi-byte characters may be misinterpreted
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/427">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/427">Issue
     427</a></strong>
     compress stylesheet url fails to decode when optimized by pagespeed
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/428">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/428">Issue
     428</a></strong>
     <a href="filter-domain-rewrite#DomainRewriteHyperlinks"
        >DomainRewriteHyperlinks</a> should not work with Domain Sharding
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/442">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/442">Issue
     442</a></strong>
     lazyload_images triggers a JavaScript error on Internet Explorer 8
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/444">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/444">Issue
     444</a></strong>
     Relative URLs are not absolutified in unparseable CSS
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/445">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/445">Issue
     445</a></strong>
     CSS rewriters don't handle a CSS file having a BOM
   </li>
   <li><strong><a
-    href="http://github.com/pagespeed/mod_pagespeed/issues/446">Issue
+    href="http://github.com/apache/incubator-pagespeed-mod/issues/446">Issue
     446</a></strong>
     Handle BOMs in JS better when combining
   </li>
@@ -3755,7 +3755,7 @@ This release includes the following miscellanea:
       robust.</li>
   <li>We are removing "trim_urls" from the Core set to better support Ajax
       loading of HTML from a different path
-      (<a href="http://github.com/pagespeed/mod_pagespeed/issues/393">Issue
+      (<a href="http://github.com/apache/incubator-pagespeed-mod/issues/393">Issue
       393</a>).</li>
   <li>Improved memory efficiency during HTML parsing and rewriting of large
       documents. Many improvements to quality and performance of the rewriting
@@ -3767,78 +3767,78 @@ This release was made Feb 8, 2012. It fixes the following issues:
 </p>
 <ul>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/48">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/48">Issue
       48</a></strong>
     Support for CSS @import
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/108">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/108">Issue
       108</a></strong>
     Parse CSS3 and common proprietary syntaxes
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/186">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/186">Issue
       186</a></strong>
     Wysiwyg 2.2 and CKEditor 3.5 on Drupal + PageSpeed breaks
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/196">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/196">Issue
       196</a></strong>
     InlineCss not parsing @import "url" statements
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/214">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/214">Issue
       214</a></strong>
     insert_image_dimensions can break an image's aspect ratio
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/332">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/332">Issue
       332</a></strong>
     LoadFromFile should convert %20 to space in URLs
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/338">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/338">Issue
       338</a></strong>
     combine_css needs to strip BOM markers before combining
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/340">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/340">Issue
       340</a></strong>
     terminate called after throwing an instance of 'std::length_error'
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/352">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/352">Issue
       352</a></strong>
     Lightbox2 + PageSpeed not working
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/354">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/354">Issue
       354</a></strong>
     CSS filter ignores external CSS links with <code>rel='Stylesheet'</code>
     instead of <code>rel='stylesheet'</code>
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/355">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/355">Issue
       355</a></strong>
     DoS under Debian/apache2-mpm-itk
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/356">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/356">Issue
       356</a></strong>
     Sites with HTTPS users and no HTTPS PageSpeed configuration get log spew
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/367">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/367">Issue
       367</a></strong>
     PageSpeed strips custom HTML headers
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/368">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/368">Issue
       368</a></strong>
     Relative URL not handled properly in inlined css
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/372">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/372">Issue
       372</a></strong>
     meta refresh tags within NOSCRIPT tags get converted to HTTP headers even
     when javascript is enabled
@@ -3851,17 +3851,17 @@ This release was made Dec 12, 2011. It fixes the following issues:
 </p>
 <ul>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/355">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/355">Issue
       355</a></strong>
     DoS under Debian/apache2-mpm-itk
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/357">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/357">Issue
       357</a></strong>
     ModPagespeedLoadFromFile should strip query params.
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/360">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/360">Issue
       360</a></strong>
     meta-tag charset breaks opera.
   </li>
@@ -3873,32 +3873,32 @@ This release was Nov 29, 2011. It fixes the following issues:
 </p>
 <ul>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/249">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/249">Issue
       249</a></strong>
     Rewrite CSS in style tags
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/295">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/295">Issue
       295</a></strong>
     Incorrectly resolved relative urls in rewritten CSS
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/303">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/303">Issue
       303</a></strong>
     Trim URLs in CSS that were absolutified
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/324">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/324">Issue
       324</a></strong>
     Non-caching-related headers are stripped from resources
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/338">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/338">Issue
       338</a></strong>
     combine_css needs to strip BOM markers before combining
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/344">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/344">Issue
       344</a></strong>
     combine_javascript not combining javascript when names became too long
   </li>
@@ -3910,76 +3910,76 @@ This release was made Aug 4, 2011. It fixes the following issues:
 </p>
 <ul>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/103">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/103">Issue
       103</a></strong>
     Pay attention to Vary headers for caching of sub-responses
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/143">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/143">Issue
       143</a></strong>
     Switch resizing algorithm to CV_INTER_AREA
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/215">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/215">Issue
       215</a></strong>
     Statistics failing with "cannot lock mutex: Invalid argument"
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/229">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/229">Issue
       229</a></strong>
     Inline images sent to browsers that don't support inline images
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/241">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/241">Issue
       241</a></strong>
     Respect Vary headers for resources
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/247">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/247">Issue
       247</a></strong>
     HtmlElement::AttributeValue returns NULL ambiguity
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/265">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/265">Issue
       265</a></strong>
     Serf unittest failure outside USA because of redirect
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/300">
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/300">
       Issue 300</a></strong>
     Recurrence of <a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/285">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/285">Issue
       285</a> under X-Mod-Pagespeed:0.9.17.7-716
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/301">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/301">Issue
       301</a></strong>
     Add WebP support for image compression
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/306">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/306">Issue
       306</a></strong>
     combine_css emits "&lt;link ...&gt;" without the proper "/" before the
     "&gt;" with doctype XHTML
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/309">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/309">Issue
       309</a></strong>
     Preserve CDATA tags on scripts in XHTML
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/311">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/311">Issue
       311</a></strong>
     rewrite_domains cuts off dynamic parts of image URLs
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/314">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/314">Issue
       314</a></strong>
     Some user agents don't understand protocol-relative urls in some
     circumstances
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/316">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/316">Issue
       316</a></strong>
     Don't include image-in-page dimensions when resizing is off
   </li>
@@ -3991,13 +3991,13 @@ This release was made May 16, 2011. It fixes the following issues:
 </p>
 <ul>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/285">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/285">Issue
       285</a></strong>
     Removing cache per FAQ causes PageSpeed to re-create "cache" location
     with root permissions
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/287">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/287">Issue
       287</a></strong>
     combine_javascript conflict with rewrite_domains
   </li>
@@ -4009,80 +4009,80 @@ This release was made May 6, 2011. It fixes the following issues:
 </p>
 <ul>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/71">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/71">Issue
       71</a></strong>
     Apache cannot restart if too many mutices from stats remain from unclean
         exits
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/97">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/97">Issue
       97</a></strong>
     Keep relative URLs relative after rewrite.
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/104">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/104">Issue
       104</a></strong>
     CSS optimizations are conservative in the presence of extra attributes
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/116">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/116">Issue
       116</a></strong>
     Need documentation describing how to configure VirtualHost with
     PageSpeed
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/173">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/173">Issue
       173</a></strong>
     Rewrite resources when that moves them to a new domain
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/181">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/181">Issue
       181</a></strong>
     Filters need to check that they do not make URLs that are too long
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/182">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/182">Issue
       182</a></strong>
     Server-side includes are stripped by remove_comments and rewrite_css
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/194">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/194">Issue
       194</a></strong>
     conflict with mod_speling
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/237">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/237">Issue
       237</a></strong>
     need a way to selectively keep some comments
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/238">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/238">Issue
       238</a></strong>
     outline_javascript generating broken links
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/239">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/239">Issue
       239</a></strong>
     Add support of GIF files in rewrite_images filter, both from HTML and CSS
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/248">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/248">Issue
       248</a></strong>
     Inappropriately converting / -&gt; /index.html while mirroring sites with
     Slurping
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/252">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/252">Issue
       252</a></strong>
     combine_css on XHTML file with unbalanced tags can strip elements
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/255">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/255">Issue
       255</a></strong>
     script tags missing from rewritten HTML output after inlined css
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/264">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/264">Issue
       264</a></strong>
     domain sharding &amp; rewriting should apply to resources that are not
     cacheable
@@ -4095,27 +4095,27 @@ This release was made March 16, 2011. It fixes the following issues:
 </p>
 <ul>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/182">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/182">Issue
       182</a></strong>
     Server-side includes are stripped by remove_comments and rewrite_css
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/194">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/194">Issue
       194</a></strong>
     conflict with mod_speling
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/234">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/234">Issue
       234</a></strong>
     Wrong document URL when mod_rewrite used
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/235">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/235">Issue
       235</a></strong>
     Invalid command 'ModPagespeedLowercaseHtmlNames'
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/238">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/238">Issue
       238</a></strong>
     outline_javascript generating broken links
   </li>
@@ -4127,64 +4127,64 @@ This release was made March 9, 2011. It fixes the following issues:
 </p>
 <ul>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/74">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/74">Issue
       74</a></strong>
     Wrong Hostname in relative path with mod_proxy
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/83">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/83">Issue
       83</a></strong>
     Add domain sharding
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/87">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/87">Issue
       87</a></strong>
     Optimize images in css files
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/153">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/153">Issue
       153</a></strong>
     Treat the entire input file, including tags and attribute names, as case
     sensitive
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/173">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/173">Issue
       173</a></strong>
     Rewrite resources when that moves them to a new domain
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/183">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/183">Issue
       183</a></strong>
     Make !clean!time! Errors into warnings (or infos) and make them more
     descriptive
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/197">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/197">Issue
       197</a></strong>
     CSS parser breaks counter()
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/202">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/202">Issue
       202</a></strong>
     CSS resource fetch failed followed by another error
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/203">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/203">Issue
       203</a></strong>
     Chunked encoding + Content-Length = broken
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/206">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/206">Issue
       206</a></strong>
     Retain case of all tag and attribute names by default.
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/219">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/219">Issue
       219</a></strong>
     HandleResponse called on URL which is already erased
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/221">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/221">Issue
       221</a></strong>
     Bad hostname when mod_proxy is used to make Apache a reverse proxy
   </li>
@@ -4196,43 +4196,43 @@ This release was made Jan 28, 2011. It fixes the following issues:
 </p>
 <ul>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/124">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/124">Issue
       124</a></strong>
     Error log noise with relative img links.
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/161">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/161">Issue
       161</a></strong>
     Add directive to disable combining CSS files across paths.
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/170">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/170">Issue
       170</a></strong>
     Should not rewrite 404 error pages.
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/176">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/176">Issue
       176</a></strong>
     Increase the URL segment limitation to 1k characters, but allow a user-level
     override to tighten it.
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/179">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/179">Issue
       179</a></strong>
     Caching headers are not set correctly on some sites.
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/192">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/192">Issue
       192</a></strong>
     Fix problems with trailing junk &amp; queries after resource URLs.
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/193">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/193">Issue
       193</a></strong>
     /mod_pagespeed_beacon returning a 404.
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/196">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/196">Issue
       196</a></strong>
     Don't inline css with <code>@import</code> statements, until we add code to
     absolutify them.
@@ -4245,59 +4245,59 @@ This release was made Jan 7, 2011. It fixes the following issues:
 </p>
 <ul>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/53">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/53">Issue
       53</a></strong>
     Firebug errors (404s) when mousing over images rewritten with PageSpeed
     enabled.
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/63">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/63">Issue
       63</a></strong>
     Breaks Gallery2 installation (issues with mod_rewrite)
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/125">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/125">Issue
       125</a></strong>
     Inline JavaScript breaks XHTML strict validation
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/126">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/126">Issue
       126</a></strong>
     font: menu not rewritten correctly
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/134">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/134">Issue
       134</a></strong>
     Reached end of document without finding body is an error, should be a
     warning or less
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/144">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/144">Issue
       144</a></strong>
     Have HTML rewriting respect ModPagespeedDisallow
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/145">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/145">Issue
       145</a></strong>
     Allow ModPagespeed=on when "ModPagespeed off"
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/146">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/146">Issue
       146</a></strong>
     Add New Directive "ModPagespeedStatistics off"
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/149">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/149">Issue
       149</a></strong>
     Filters need to check that they do not make URLs that are too long
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/154">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/154">Issue
       154</a></strong>
     PageSpeed breaks forms in IE 8 with compatibility mode
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/157">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/157">Issue
       157</a></strong>
     PageSpeed's caching headers break image caching on IE8
   </li>
@@ -4309,7 +4309,7 @@ This release was made Dec 7, 2010. It fixes the following issues:
 </p>
 <ul>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/131">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/131">Issue
       131</a></strong>
     Invalid command 'ModPagespeedImgMaxRewritesAtOnce'
   </li>
@@ -4321,94 +4321,94 @@ This release was made Dec 3, 2010. It fixes the following issues:
 </p>
 <ul>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/4">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/4">Issue
       4</a></strong>
     PageSpeed does not handle application/xhtml+xml
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/34">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/34">Issue
       34</a></strong>
     when the server provides an Expires header, our cache extension may not work
     everywhere
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/38">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/38">Issue
       38</a></strong>
     js_tinyMCE breaks when it's name is changed
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/56">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/56">Issue
       56</a></strong>
     Feature: Moving images to another host name
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/61">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/61">Issue
       61</a></strong>
     Shorten hash
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/76">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/76">Issue
       76</a></strong>
     Allow explicit control over CSS concat etc
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/81">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/81">Issue
       81</a></strong>
     URLs with UTF-8 characters in them cannot be rewritten.
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/90">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/90">Issue
       90</a></strong>
     Support origin mapping
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/99">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/99">Issue
       99</a></strong>
     Strange Last-Modified Header Response
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/107">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/107">Issue
       107</a></strong>
     Rewriting images fails to load original image from alternative port
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/112">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/112">Issue
       112</a></strong>
     Support if-modified-since
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/113">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/113">Issue
       113</a></strong>
     Logfile error for CSS files
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/114">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/114">Issue
       114</a></strong>
     query-params in origin URL should have  escaped in rewritten URL
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/115">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/115">Issue
       115</a></strong>
     Modpagespeed error when access wikimedia
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/117">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/117">Issue
       117</a></strong>
     Apache servers behind a load balancer on virtual IP cannot find input
     resources
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/118">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/118">Issue
       118</a></strong>
     PageSpeed doesn't support Application/ce-html+xml MIME type
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/121">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/121">Issue
       121</a></strong>
     CSS minification failes when font: shorthand
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/128">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/128">Issue
       128</a></strong>
     list-style-type: none rejected by CSS parser.
   </li>
@@ -4420,115 +4420,115 @@ This release was made Nov 23, 2010. It fixes the following issues:
 </p>
 <ul>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/6">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/6">Issue
       6</a></strong>
     Page speed running on debian with mpm-worker + fcgi causes lots of errors
     written to apache log
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/24">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/24">Issue
       24</a></strong>
     Compile failure under g++ 4.5 on opensuse 11.3
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/34">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/34">Issue
       34</a></strong>
     when the server provides an Expires header, our cache extension may not work
     everywhere
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/35">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/35">Issue
       35</a></strong>
     should not add 'public' to Cache-Control
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/43">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/43">Issue
       43</a></strong>
     Some png images not loading
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/46">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/46">Issue
       46</a></strong>
     url causes Apache to become unresponsive due to high load.
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/52">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/52">Issue
       52</a></strong>
     Docs incorrectly state that PageSpeed generates uncompressed HTML
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/60">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/60">Issue
       60</a></strong>
     combine_css breaks background image url due to mis-handling of quotes.
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/62">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/62">Issue
       62</a></strong>
     Apache children segfaulting using Event MPM
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/69">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/69">Issue
       69</a></strong>
     Compile error Debian Etch / gcc-42
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/79">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/79">Issue
       79</a></strong>
     Memory corruption
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/82">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/82">Issue
       82</a></strong>
     Poll success status 0 (111) in image-rich site
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/84">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/84">Issue
       84</a></strong>
     mod-pagespeed-beta-0.9.0.0-128 incompatible with Trac 0.12
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/85">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/85">Issue
       85</a></strong>
     Infinite recursion of PageSpeed requesting its own pages
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/89">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/89">Issue
       89</a></strong>
     source does not exist in sh
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/91">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/91">Issue
       91</a></strong>
     Broken link on overview.html
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/94">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/94">Issue
       94</a></strong>
     base URL not respected for image rewriting
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/95">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/95">Issue
       95</a></strong>
     Mysterious 404s reported in access.log from Serf of the right file at the
     wrong path.
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/98">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/98">Issue
       98</a></strong>
     CHECK failure on malformed html comment syntax
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/99">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/99">Issue
       99</a></strong>
     Strange Last-Modified Header Response
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/100">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/100">Issue
       100</a></strong>
     extend_cache breaks WHMCS site..
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/102">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/102">Issue
       102</a></strong>
     doc that elide_attributes_filter has specific risks
   </li>
@@ -4540,92 +4540,92 @@ This release was made Nov 16, 2010. It fixes the following issues:
 </p>
 <ul>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/3">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/3">Issue
       3</a></strong>
     CSS Not Loading
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/7">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/7">Issue
       7</a></strong>
     insert_img_dimensions not detecting existing dimensions
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/9">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/9">Issue
       9</a></strong>
     rfc - generated cache names are too long
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/14">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/14">Issue
       14</a></strong>
     Invalid url relative to '...'
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/21">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/21">Issue
       21</a></strong>
     transparency of inlined PNG image
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/25">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/25">Issue
       25</a></strong>
     Internal Server Error - Not actually an error
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/26">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/26">Issue
       26</a></strong>
     PNG being scanned as HTML
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/27">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/27">Issue
       27</a></strong>
     Internal Server Error for 304 - not actually an error
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/33">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/33">Issue
       33</a></strong>
     Do not warn on "Invalid url relative to..."
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/36">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/36">Issue
       36</a></strong>
     Data URLs, such as those created by image inlining, clutter the log
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/37">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/37">Issue
       37</a></strong>
     javascript with name rewriten not found
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/38">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/38">Issue
       38</a></strong>
     javascripts doesn't work with rewrite_javascript enabled
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/44">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/44">Issue
       44</a></strong>
     Do not warn on 'Failed to create or read input resource'
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/50">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/50">Issue
       50</a></strong>
     rewrite_css filter incompatible with CSS3 media queries
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/51">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/51">Issue
       51</a></strong>
     rewrite_css removes rgba color values
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/64">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/64">Issue
       64</a></strong>
     Remove 'Failed to load resource' message from rewrite_css filter.
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/66">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/66">Issue
       66</a></strong>
     rewrite_css removes transform values
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/73">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/73">Issue
       73</a></strong>
     false warning: end of document without finding body
   </li>
@@ -4637,42 +4637,42 @@ This release was made Nov 8, 2010. It fixes the following issues:
 </p>
 <ul>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/5">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/5">Issue
       5</a></strong>
     Incorrectly handling not-quoted font-family names with spaces
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/7">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/7">Issue
       7</a></strong>
     insert_img_dimensions not detecting existing dimensions
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/10">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/10">Issue
       10</a></strong>
     A whole lot of HTTPD processes
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/11">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/11">Issue
       11</a></strong>
     After installing module server becomes unusable
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/18">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/18">Issue
       18</a></strong>
     LogLevel seems to be ignored
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/25">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/25">Issue
       25</a></strong>
     Misleading server error message
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/30">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/30">Issue
       30</a></strong>
     Very slow memory leak
   </li>
   <li><strong><a
-      href="http://github.com/pagespeed/mod_pagespeed/issues/33">Issue
+      href="http://github.com/apache/incubator-pagespeed-mod/issues/33">Issue
       33</a></strong>
     Do not warn on "Invalid url relative to..."
   </li>

--- a/html/doc/system.html
+++ b/html/doc/system.html
@@ -438,7 +438,7 @@ total_items:           4166384
     <p class="warning"><strong>Warning:</strong> Redis support is experimental
        and has not yet had substantial real world use.  Before rolling this out
        in production, be sure to test it well.  If you run into problems, please
-      <a href="https://github.com/pagespeed/mod_pagespeed/issues/new"
+      <a href="https://github.com/apache/incubator-pagespeed-mod/issues/new"
          >let us know</a>.
     </p>
     <p>

--- a/html/index.html
+++ b/html/index.html
@@ -197,7 +197,7 @@ h2 {
       <h3>File a bug</h3>
       <p>If PageSpeed isn't working correctly on your site, file a bug and we'll
          look into it.</p>
-      <a href="https://github.com/pagespeed/mod_pagespeed/issues/new">Apache</a>
+      <a href="https://github.com/apache/incubator-pagespeed-mod/issues/new">Apache</a>
       <a href="https://github.com/pagespeed/ngx_pagespeed/issues/new">Nginx</a>
     </div>
     </div>
@@ -207,7 +207,7 @@ h2 {
     <div class=resource>
       <h3>Get the source</h3>
       <p>Download the source code, to build on your machine.</p>
-      <a href="https://github.com/pagespeed/mod_pagespeed">Apache</a>
+      <a href="https://github.com/apache/incubator-pagespeed-mod">Apache</a>
       <a href="https://github.com/pagespeed/ngx_pagespeed">Nginx</a>
     </div>
 
@@ -224,7 +224,7 @@ h2 {
       <p>All our developer-focused documentation, from how to get started with
          a development environment, to running tests, to our list of
          priorities.</p>
-      <a href="https://github.com/pagespeed/mod_pagespeed/wiki">Wiki</a>
+      <a href="https://github.com/apache/incubator-pagespeed-mod/wiki">Wiki</a>
     </div>
 
     <div class=resource>

--- a/install/build_on_vm.sh
+++ b/install/build_on_vm.sh
@@ -130,7 +130,7 @@ gcloud compute ssh "$machine_name" -- bash << EOF
   fi
   # CentOS 6's git is old enough that git clone -b <tag> doesn't work and
   # silently checks out HEAD. To be safe we use an explicit checkout below.
-  git clone https://github.com/pagespeed/mod_pagespeed.git
+  git clone https://github.com/apache/incubator-pagespeed-mod.git
   cd mod_pagespeed
   git checkout "$branch"
   install/build_release.sh $@

--- a/install/common/mod-pagespeed/mod-pagespeed.info
+++ b/install/common/mod-pagespeed/mod-pagespeed.info
@@ -17,4 +17,4 @@ FULLDESC="mod_pagespeed is an Apache module that aims to speed up load time of p
 # Package maintainer information.
 MAINTNAME="mod_pagespeed developers"
 MAINTMAIL="mod-pagespeed-dev@googlegroups.com"
-PRODUCTURL="https://github.com/pagespeed/mod_pagespeed/"
+PRODUCTURL="https://github.com/apache/incubator-pagespeed-mod/"

--- a/install/debian/postinst
+++ b/install/debian/postinst
@@ -24,7 +24,7 @@ case "$1" in
         # files into /etc/apache2/conf-available and then use a2enconf to
         # symlink it into /etc/apache2/conf-enabled.  On older systems there's
         # just /etc/apache2/conf.d/, so we manually symlink it there instead.
-        # See https://github.com/pagespeed/mod_pagespeed/issues/1389
+        # See https://github.com/apache/incubator-pagespeed-mod/issues/1389
         if hash a2enconf 2> /dev/null; then
           # a2enconf is available; use it.
           a2enconf pagespeed_libraries

--- a/install/debug.conf.template
+++ b/install/debug.conf.template
@@ -421,7 +421,7 @@ FcgidOutputBufferSize 0
 # Helps tests that extra headers supplied by the apache conf
 # survive single-resource rewrites
 #
-# http://github.com/pagespeed/mod_pagespeed/issues/324
+# http://github.com/apache/incubator-pagespeed-mod/issues/324
 Header append 'X-Extra-Header' '1'
 
 <Directory "@@APACHE_DOC_ROOT@@/mod_pagespeed_test/nostore" >
@@ -1146,7 +1146,7 @@ NameVirtualHost 127.0.0.1:@@APACHE_TERTIARY_PORT@@
     # or made equivalent to ModPagespeedInPlaceRewriteDeadlineMs -1, which waits
     # forever.  Otherwise ModPagespeedInPlaceRewriteDeadlineMs should just have
     # the specified deadline.
-    # # See https://github.com/pagespeed/mod_pagespeed/issues/1171 for more
+    # # See https://github.com/apache/incubator-pagespeed-mod/issues/1171 for more
     # detailed discussion.
     ModPagespeedInPlaceWaitForOptimized on
 </Directory>
@@ -1769,7 +1769,7 @@ ModPagespeedMessagesDomains Allow localhost
 
 
 #PROXY # This is used for ProxyPass testing.
-#PROXY #   See: http://github.com/pagespeed/mod_pagespeed/issues/74
+#PROXY #   See: http://github.com/apache/incubator-pagespeed-mod/issues/74
 #PROXY # We use 2 servers for it, one doing rewriting and fetching
 #PROXY # from the other one which does not have mod_pagespeed enabled.
 #PROXY Listen 8081

--- a/install/demo.conf
+++ b/install/demo.conf
@@ -147,7 +147,7 @@ SetEnvIfNoCase Request_URI \.(?:gif|jpe?g|png)$ no-gzip
     # ModPagespeedLRUCacheKbPerProcess     1024
     # ModPagespeedLRUCacheByteLimit        16384
     # ModPagespeedCssFlattenMaxBytes       2048
-    # M.O.: bumped due to https://github.com/pagespeed/mod_pagespeed/issues/1040
+    # M.O.: bumped due to https://github.com/apache/incubator-pagespeed-mod/issues/1040
     ModPagespeedCssInlineMaxBytes        3000
     # ModPagespeedCssImageInlineMaxBytes   0
     # ModPagespeedImageInlineMaxBytes      3072

--- a/install/mod_pagespeed_example/index.html
+++ b/install/mod_pagespeed_example/index.html
@@ -36,7 +36,7 @@
           <li><a href="https://modpagespeed.com/doc/build_from_source"
             >Source Builds</a></li>
           <li><a
-            href="http://github.com/pagespeed/mod_pagespeed"
+            href="http://github.com/apache/incubator-pagespeed-mod"
             >Source Code Browser</a></li>
           <li><a
             href="http://modpagespeed.com/psol/annotated.html">API</a></li>
@@ -44,9 +44,9 @@
             href="https://groups.google.com/group/mod-pagespeed-discuss"
             >Discussion Forum</a></li>
           <li><a
-            href="https://github.com/pagespeed/mod_pagespeed/issues"
+            href="https://github.com/apache/incubator-pagespeed-mod/issues"
             >Issue Tracker</a></li>
-          <li><a href="http://github.com/pagespeed/mod_pagespeed"
+          <li><a href="http://github.com/apache/incubator-pagespeed-mod"
             >Project</a></li>
     </ul>
     <br/>

--- a/install/mod_pagespeed_test/map_css_embedded/issue494.html
+++ b/install/mod_pagespeed_test/map_css_embedded/issue494.html
@@ -1,3 +1,3 @@
-<!-- http://github.com/pagespeed/mod_pagespeed/issues/494 -->
+<!-- http://github.com/apache/incubator-pagespeed-mod/issues/494 -->
 <link rel=stylesheet type=text/css
       href="http://cdn.example.com/mod_pagespeed_test/map_css_embedded/styles.css" />

--- a/install/modpagespeed.com-configuration-example.conf
+++ b/install/modpagespeed.com-configuration-example.conf
@@ -145,7 +145,7 @@ SetEnvIfNoCase Request_URI \.(?:gif|jpe?g|png)$ no-gzip
     # ModPagespeedLRUCacheKbPerProcess     1024
     # ModPagespeedLRUCacheByteLimit        16384
     # ModPagespeedCssFlattenMaxBytes       2048
-    # M.O.: bumped due to https://github.com/pagespeed/mod_pagespeed/issues/1040
+    # M.O.: bumped due to https://github.com/apache/incubator-pagespeed-mod/issues/1040
     ModPagespeedCssInlineMaxBytes        3000
     # ModPagespeedCssImageInlineMaxBytes   0
     # ModPagespeedImageInlineMaxBytes      3072

--- a/install/verify_nginx_release.sh
+++ b/install/verify_nginx_release.sh
@@ -58,7 +58,7 @@ cd "$WORKDIR"
 
 mkdir mod_pagespeed
 cd mod_pagespeed
-git clone https://github.com/pagespeed/mod_pagespeed.git src/
+git clone https://github.com/apache/incubator-pagespeed-mod.git src/
 cd src/
 git checkout $VERSION
 

--- a/net/instaweb/http/cache_url_async_fetcher.cc
+++ b/net/instaweb/http/cache_url_async_fetcher.cc
@@ -126,7 +126,7 @@ class CachePutFetch : public SharedAsyncFetch {
   virtual void HandleDone(bool success) {
     DCHECK_EQ(request_headers()->method(), RequestHeaders::kGet);
     // We do not cache empty 200 responses. (Empty 404, 500 are fine.)
-    // https://github.com/pagespeed/mod_pagespeed/issues/1050
+    // https://github.com/apache/incubator-pagespeed-mod/issues/1050
     const bool empty_200 =
         (response_headers()->status_code() == HttpStatus::kOK &&
          cache_value_.contents_size() == 0);

--- a/net/instaweb/http/http_cache_failure.cc
+++ b/net/instaweb/http/http_cache_failure.cc
@@ -79,7 +79,7 @@ FetchResponseStatus HttpCacheFailure::ClassifyFailure(
     if (contents.empty() && !headers.IsRedirectStatus()) {
       // Do not cache empty 200 responses, but remember that they were empty
       // to avoid fetching too often.
-      // https://github.com/pagespeed/mod_pagespeed/issues/1050
+      // https://github.com/apache/incubator-pagespeed-mod/issues/1050
       classification = kFetchStatusEmpty;
     } else if (!external_cacheable) {
       classification = (status_code == 200 ? kFetchStatusUncacheable200

--- a/net/instaweb/rewriter/cache_extender_test.cc
+++ b/net/instaweb/rewriter/cache_extender_test.cc
@@ -1001,7 +1001,7 @@ TEST_F(CacheExtenderTest, MadeOnTheFly) {
   EXPECT_EQ(1, stats->succeeded_filter_resource_fetches()->Get());
 }
 
-// http://github.com/pagespeed/mod_pagespeed/issues/324
+// http://github.com/apache/incubator-pagespeed-mod/issues/324
 TEST_F(CacheExtenderTest, RetainExtraHeaders) {
   GoogleString url = StrCat(kTestDomain, "retain.css");
   SetResponseWithDefaultHeaders(url, kContentTypeCss, kCssData, 300);

--- a/net/instaweb/rewriter/css_combine_filter.cc
+++ b/net/instaweb/rewriter/css_combine_filter.cc
@@ -414,7 +414,7 @@ void CssCombineFilter::StartElementImpl(HtmlElement* element) {
     // to put in ids when they're not actually referenced and we've gotten
     // several mailing list questions about why we don't combine in this case.
     // Is there actually javascript referencing css link tags by id?
-    // Tracked in https://github.com/pagespeed/mod_pagespeed/issues/1385
+    // Tracked in https://github.com/apache/incubator-pagespeed-mod/issues/1385
     if (driver()->options()->CssCombiningMayPermitIds()) {
       const char* value = element->AttributeValue(HtmlName::kId);
       if (value != nullptr &&

--- a/net/instaweb/rewriter/css_combine_filter_test.cc
+++ b/net/instaweb/rewriter/css_combine_filter_test.cc
@@ -661,14 +661,14 @@ TEST_F(CssCombineFilterTest, CombineCssRecombine) {
 }
 
 
-// https://github.com/pagespeed/mod_pagespeed/issues/39
+// https://github.com/apache/incubator-pagespeed-mod/issues/39
 TEST_F(CssCombineFilterTest, DealWithParams) {
   SetHtmlMimetype();
   CombineCssWithNames("with_params", "", "", false, "a.css?U", "b.css?rev=138",
                       true);
 }
 
-// https://github.com/pagespeed/mod_pagespeed/issues/252
+// https://github.com/apache/incubator-pagespeed-mod/issues/252
 TEST_F(CssCombineFilterTest, ClaimsXhtmlButHasUnclosedLink) {
   // XHTML text should not have unclosed links.  But if they do, like
   // in Issue 252, then we should leave them alone.
@@ -701,7 +701,7 @@ TEST_F(CssCombineFilterTest, ClaimsXhtmlButHasUnclosedLink) {
                    StringPrintf(html_format, kXhtmlDtd, combination.c_str()));
 }
 
-// http://github.com/pagespeed/mod_pagespeed/issues/306
+// http://github.com/apache/incubator-pagespeed-mod/issues/306
 TEST_F(CssCombineFilterTest, XhtmlCombineLinkClosed) {
   // XHTML text should not have unclosed links.  But if they do, like
   // in Issue 252, then we should leave them alone.

--- a/net/instaweb/rewriter/css_filter_test.cc
+++ b/net/instaweb/rewriter/css_filter_test.cc
@@ -414,7 +414,7 @@ TEST_F(CssFilterTestCustomOptions, CssPreserveUrlsNoPreemptiveRewrite) {
 
 TEST_F(CssFilterTest, LinkHrefCaseInsensitive) {
   // Make sure we check rel value case insensitively.
-  // http://github.com/pagespeed/mod_pagespeed/issues/354
+  // http://github.com/apache/incubator-pagespeed-mod/issues/354
   SetResponseWithDefaultHeaders("a.css", kContentTypeCss, kInputStyle, 100);
   ValidateExpected(
       "case_insensitive", "<link rel=StyleSheet href=a.css>",
@@ -611,7 +611,7 @@ TEST_F(CssFilterTest, RewriteVariousCss) {
     "a{-moz-border-radius-topleft:0}",  // Browser-specific (-moz)
     ".ds{display:-moz-inline-box}",
     "a{background:none}",  // CSS Parser used to expand this.
-    // http://github.com/pagespeed/mod_pagespeed/issues/121
+    // http://github.com/apache/incubator-pagespeed-mod/issues/121
     "a{color:inherit}",
     // Added for code coverage.
     "@import url(http://www.example.com);",
@@ -629,16 +629,16 @@ TEST_F(CssFilterTest, RewriteVariousCss) {
     "p.normal::selection{background:#c00;color:#fff}",
     "::-moz-focus-inner{border:0}",
     "input::-webkit-input-placeholder{color:#ababab}"
-    // http://github.com/pagespeed/mod_pagespeed/issues/51
+    // http://github.com/apache/incubator-pagespeed-mod/issues/51
     "a{box-shadow:-1px -2px 2px rgba(0,0,0,.15)}",  // CSS3 rgba
-    // http://github.com/pagespeed/mod_pagespeed/issues/66
+    // http://github.com/apache/incubator-pagespeed-mod/issues/66
     "a{-moz-transform:rotate(7deg)}",
     // Microsoft syntax values.
     "a{filter:progid:DXImageTransform.Microsoft.Alpha(Opacity=80)}",
     // Make sure we keep "\," distinguished from ",".
     "body{font-family:font\\,1,font\\,2}",
     // Distinguish \. from ., etc.
-    // http://github.com/pagespeed/mod_pagespeed/issues/574
+    // http://github.com/apache/incubator-pagespeed-mod/issues/574
     "#MyForm\\.myfield{property:value}",
     "\\*{color:red}",
     "a{property\\:more:value\\;more}"
@@ -659,7 +659,7 @@ TEST_F(CssFilterTest, RewriteVariousCss) {
     // Slashes in value list.
     ".border8{border-radius: 36px / 12px }",
 
-    // http://github.com/pagespeed/mod_pagespeed/issues/220
+    // http://github.com/apache/incubator-pagespeed-mod/issues/220
     // See https://developer.mozilla.org/en/CSS/-moz-transition-property
     // and http://www.webkit.org/blog/138/css-animation/
     // TODO(sligocki): rm spaces around COMMA token.
@@ -685,7 +685,7 @@ TEST_F(CssFilterTest, RewriteVariousCss) {
     "@import \"styles.css\"...;a{color:red}",
 
     // CSS3 media queries.
-    // http://github.com/pagespeed/mod_pagespeed/issues/50
+    // http://github.com/apache/incubator-pagespeed-mod/issues/50
     "@media screen and (max-width:290px){a{color:red}}",
     "@media only print and (color){a{color:red}}",
 
@@ -991,7 +991,7 @@ TEST_F(CssFilterTest, ComplexCssTest) {
       "-moz-transform:scale(.5);-webkit-transform:scale(.5);"
       "-moz-transform:translate(3em,0);-webkit-transform:translate(3em,0)}" },
 
-    // http://github.com/pagespeed/mod_pagespeed/issues/5
+    // http://github.com/apache/incubator-pagespeed-mod/issues/5
     // Keep space between trebuchet and ms.
     // TODO(sligocki): Print as font-family:"trebuchet ms" instead.
     // According to the CSS spec:
@@ -1002,20 +1002,20 @@ TEST_F(CssFilterTest, ComplexCssTest) {
     // to fail to read the escaped space than a proper string.
     { "a { font-family: trebuchet ms; }", "a{font-family:trebuchet\\ ms}" },
 
-    // http://github.com/pagespeed/mod_pagespeed/issues/121
+    // http://github.com/apache/incubator-pagespeed-mod/issues/121
     { "body { font: 2em sans-serif; }", "body{font:2em sans-serif}" },
     { "body { font: 0.75em sans-serif; }", "body{font:.75em sans-serif}" },
 
-    // http://github.com/pagespeed/mod_pagespeed/issues/128
+    // http://github.com/apache/incubator-pagespeed-mod/issues/128
     { "#breadcrumbs ul { list-style-type: none; }",
       "#breadcrumbs ul{list-style-type:none}" },
 
-    // http://github.com/pagespeed/mod_pagespeed/issues/126
+    // http://github.com/apache/incubator-pagespeed-mod/issues/126
     // Extra spaces assure that we actually rewrite the first arg even if
     // font: is expanded by parser.
     { ".menu { font: menu; }               ", ".menu{font:menu}" },
 
-    // http://github.com/pagespeed/mod_pagespeed/issues/211
+    // http://github.com/apache/incubator-pagespeed-mod/issues/211
     { "#some_id {\n"
       "background: #cccccc url(images/picture.png) 50% 50% repeat-x;\n"
       "}\n",
@@ -1131,7 +1131,7 @@ TEST_F(CssFilterTest, ComplexCssTest) {
       "@charset \"UTF-8\";a{color:red}" },
 
     // Recovered parse errors:
-    // http://github.com/pagespeed/mod_pagespeed/issues/220
+    // http://github.com/apache/incubator-pagespeed-mod/issues/220
     { ".mui-navbar-wrap, .mui-navbar-clone {"
       "opacity:1;-webkit-transform:translateX(0);"
       "-webkit-transition-property:opacity,-webkit-transform;"
@@ -1483,7 +1483,7 @@ TEST_F(CssFilterTest, ComplexCssTest) {
       "src:url(fonts/tiefontello.svg?88026028#fontello) format('svg')}}" },
 
     // CSS3 media queries.
-    // http://github.com/pagespeed/mod_pagespeed/issues/50
+    // http://github.com/apache/incubator-pagespeed-mod/issues/50
     { "@media only screen and (min-device-width: 320px) and"
       " (max-device-width: 480px) {\n"
       "        body {"
@@ -1512,7 +1512,7 @@ TEST_F(CssFilterTest, ComplexCssTest) {
       "@media not screen{.c{color:#00f}}"
       "@media only screen{.d{color:#0ff}}" },
 
-    // http://github.com/pagespeed/mod_pagespeed/issues/575
+    // http://github.com/apache/incubator-pagespeed-mod/issues/575
     { "[class^=\"icon-\"],[class*=\" icon-\"] { color: red }",
       "[class^=\"icon-\"],[class*=\" icon-\"]{color:red}" },
 
@@ -1544,7 +1544,7 @@ TEST_F(CssFilterTest, ComplexCssTest) {
       "AAG4AAAAfCAA\\ AAAAjTqdDAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZS) no-repeat}" },
 
     // Noticed from YUI minification.
-    // https://github.com/pagespeed/mod_pagespeed/issues/614
+    // https://github.com/apache/incubator-pagespeed-mod/issues/614
     { "td { line-height: 0.8em; margin: -0.9in; }",
       "td{line-height:.8em;margin:-.9in}" },
 
@@ -1557,7 +1557,7 @@ TEST_F(CssFilterTest, ComplexCssTest) {
     // DIM(0, ff) and then serialized as 0ff, but browsers will parse both
     // of these values as quirks-mode colors and thus we would be changing
     // the links from blue to cyan.
-    // https://github.com/pagespeed/mod_pagespeed/issues/639
+    // https://github.com/apache/incubator-pagespeed-mod/issues/639
     { "A:link, A:visited { color: 0000ff }",
       "A:link,A:visited{color: 0000ff }" },
 
@@ -1580,7 +1580,7 @@ TEST_F(CssFilterTest, ComplexCssTest) {
       "body{font:13px/1.231,clean;*font-size:small;*font:x-small;"
       "font-family:Arial!important}" },
 
-    // https://github.com/pagespeed/mod_pagespeed/issues/722
+    // https://github.com/apache/incubator-pagespeed-mod/issues/722
     { ".a { color: red; }\n"
       "@import url('foo.css');\n"
       ".b { color: blue; }\n",
@@ -1807,7 +1807,7 @@ TEST_F(CssFilterTest, NoQuirksModeFixes) {
   // from the HTML case and thus not record accurate savings.
 }
 
-// http://github.com/pagespeed/mod_pagespeed/issues/324
+// http://github.com/apache/incubator-pagespeed-mod/issues/324
 TEST_F(CssFilterTest, RetainExtraHeaders) {
   GoogleString url = StrCat(kTestDomain, "retain.css");
   SetResponseWithDefaultHeaders(url, kContentTypeCss, kInputStyle, 300);
@@ -2259,7 +2259,7 @@ TEST_F(CssFilterTest, SimpleFetchUnhealthy) {
 }
 
 // Make sure we correctly decode the previously unexpected I.. format.
-// http://github.com/pagespeed/mod_pagespeed/issues/427
+// http://github.com/apache/incubator-pagespeed-mod/issues/427
 TEST_F(CssFilterTest, EmptyLeafFetch) {
   // CSS URL ends in /
   SetResponseWithDefaultHeaders(StrCat(kTestDomain, "style/"),
@@ -2276,7 +2276,7 @@ TEST_F(CssFilterTest, EmptyLeafFetch) {
 }
 
 // Make sure we correctly rewrite, encode and decode a CSS URL with empty leaf.
-// http://github.com/pagespeed/mod_pagespeed/issues/427
+// http://github.com/apache/incubator-pagespeed-mod/issues/427
 TEST_F(CssFilterTest, EmptyLeafFull) {
   // CSS URL ends in /
   ValidateRewriteExternalCssUrl("empty_leaf", StrCat(kTestDomain, "style/"),

--- a/net/instaweb/rewriter/css_flatten_imports_test.cc
+++ b/net/instaweb/rewriter/css_flatten_imports_test.cc
@@ -1195,7 +1195,7 @@ TEST_F(CssFlattenImportsTest, NoFlattenMediaQueriesChild) {
                              kFlattenImportsComplexQueries);
 }
 
-// See https://github.com/pagespeed/mod_pagespeed/issues/1092
+// See https://github.com/apache/incubator-pagespeed-mod/issues/1092
 TEST_F(CssFlattenImportsTest, FlattenTooComplexNested) {
   GoogleString css_in = StrCat("@import url(http://test.com/",
                                kComplexCssFile, ");");

--- a/net/instaweb/rewriter/css_image_rewriter_test.cc
+++ b/net/instaweb/rewriter/css_image_rewriter_test.cc
@@ -1088,7 +1088,7 @@ TEST_F(CssRecompressImagesInStyleAttributes,
       "<div style=\"background-image:url(xfoo.jpg.pagespeed.ic.0.webp)\"/>");
 }
 
-// https://github.com/pagespeed/mod_pagespeed/issues/781
+// https://github.com/apache/incubator-pagespeed-mod/issues/781
 TEST_F(CssRecompressImagesInStyleAttributes, ServeCssToDifferentUA) {
   AddFileToMockFetcher(StrCat(kTestDomain, "bike.png"), kBikePngFile,
                        kContentTypePng, 100);

--- a/net/instaweb/rewriter/css_inline_filter_test.cc
+++ b/net/instaweb/rewriter/css_inline_filter_test.cc
@@ -282,7 +282,7 @@ TEST_F(CssInlineFilterTest, DoInlineCssWithMediaQuery) {
 
 TEST_F(CssInlineFilterTest, Empty) {
   // Don't inline empty resources. This is defensive programming against
-  // issues like: https://github.com/pagespeed/mod_pagespeed/issues/1050
+  // issues like: https://github.com/apache/incubator-pagespeed-mod/issues/1050
   const GoogleString css = "";
   TestNoInlineCss("http://www.example.com/index.html",
                   "http://www.example.com/styles.css",
@@ -354,7 +354,7 @@ TEST_F(CssInlineFilterTest, CorrectlyInlineCssWithImports) {
                 "@import \"dir/foo.css\"; BODY { color: red; }\n");
 }
 
-// https://github.com/pagespeed/mod_pagespeed/issues/252
+// https://github.com/apache/incubator-pagespeed-mod/issues/252
 TEST_F(CssInlineFilterTest, ClaimsXhtmlButHasUnclosedLink) {
   // XHTML text should not have unclosed links.  But if they do, like
   // in Issue 252, then we should leave them alone.

--- a/net/instaweb/rewriter/css_inline_import_to_link_filter_test.cc
+++ b/net/instaweb/rewriter/css_inline_import_to_link_filter_test.cc
@@ -114,7 +114,7 @@ TEST_F(CssInlineImportToLinkFilterTest, ConvertGoodStyle) {
 
 TEST_F(CssInlineImportToLinkFilterTest, DoNotConvertScoped) {
   // <style scoped> can't be converted to a link.
-  // (https://github.com/pagespeed/mod_pagespeed/issues/918)
+  // (https://github.com/apache/incubator-pagespeed-mod/issues/918)
   AddFilter(RewriteOptions::kInlineImportToLink);
   ValidateStyleUnchanged("<style type=\"text/css\" scoped>"
                          "@import url(assets/styles.css);</style>");

--- a/net/instaweb/rewriter/css_minify.cc
+++ b/net/instaweb/rewriter/css_minify.cc
@@ -357,14 +357,14 @@ bool IsLength(const GoogleString& unit) {
 }  // namespace
 
 bool CssMinify::UnitsRequiredForValueZero(const GoogleString& unit) {
-  // https://github.com/pagespeed/mod_pagespeed/issues/1164 : Chrome does not
+  // https://github.com/apache/incubator-pagespeed-mod/issues/1164 : Chrome does not
   // allow abbreviating 0s or 0% as 0.  It only allows that abbreviation for
   // lengths.
   //
-  // https://github.com/pagespeed/mod_pagespeed/issues/1261  See
+  // https://github.com/apache/incubator-pagespeed-mod/issues/1261  See
   // https://www.w3.org/TR/CSS2/visudet.html#the-height-property
   //
-  // https://github.com/pagespeed/mod_pagespeed/issues/1538
+  // https://github.com/apache/incubator-pagespeed-mod/issues/1538
   // retaining unit for zero value in calc function
   return (unit == "%") || !IsLength(unit) ||
           in_css_calc_function_;
@@ -430,7 +430,7 @@ void CssMinify::Minify(const Css::Declaration& declaration) {
         // TODO(ashishk):unicode-range should get resolved to css property
         // enum.
         if (declaration.prop_text() == "unicode-range") {
-          // https://github.com/pagespeed/mod_pagespeed/issues/1572
+          // https://github.com/apache/incubator-pagespeed-mod/issues/1572
           // space separator should not be there in unicode range value
           JoinMinify(*declaration.values(), "");
         } else {

--- a/net/instaweb/rewriter/css_outline_filter_test.cc
+++ b/net/instaweb/rewriter/css_outline_filter_test.cc
@@ -250,7 +250,7 @@ TEST_F(CssOutlineFilterTest, DoNotOutlineScoped) {
   ValidateNoChanges("scoped", "<style scoped>* {display: none;}</style>");
 }
 
-// http://github.com/pagespeed/mod_pagespeed/issues/416
+// http://github.com/apache/incubator-pagespeed-mod/issues/416
 TEST_F(CssOutlineFilterTest, RewriteDomain) {
   SetupOutliner();
   AddRewriteDomainMapping("cdn.com", kTestDomain);

--- a/net/instaweb/rewriter/device_properties.cc
+++ b/net/instaweb/rewriter/device_properties.cc
@@ -132,7 +132,7 @@ bool DeviceProperties::SupportsCriticalImagesBeacon() const {
   // For now this script has the same user agent requirements as image inlining,
   // however that could change in the future if more advanced JS is used by the
   // beacon. Also disable for bots. See
-  // https://github.com/pagespeed/mod_pagespeed/issues/813.
+  // https://github.com/apache/incubator-pagespeed-mod/issues/813.
   return SupportsImageInlining() && !IsBot();
 }
 

--- a/net/instaweb/rewriter/device_properties_test.cc
+++ b/net/instaweb/rewriter/device_properties_test.cc
@@ -79,7 +79,7 @@ TEST_F(DevicePropertiesTest, WebpUserAgentIdentificationNoAccept) {
   EXPECT_TRUE(device_properties_.SupportsWebpLosslessAlpha());
 }
 
-// See https://github.com/pagespeed/mod_pagespeed/issues/978
+// See https://github.com/apache/incubator-pagespeed-mod/issues/978
 //
 // Microsoft (v-evgena@microsoft.com and tobint@microsoft.com)
 // suggests that they are planning to start masquerading IE11 on

--- a/net/instaweb/rewriter/image_rewrite_filter_test.cc
+++ b/net/instaweb/rewriter/image_rewrite_filter_test.cc
@@ -1475,7 +1475,7 @@ TEST_F(ImageRewriteTest, AddDimTest) {
 
 TEST_F(ImageRewriteTest, NoDimsInNonImg) {
   // As above, only with an icon.  See:
-  // https://github.com/pagespeed/mod_pagespeed/issues/629
+  // https://github.com/apache/incubator-pagespeed-mod/issues/629
   options()->EnableFilter(RewriteOptions::kInsertImageDimensions);
   rewrite_driver()->AddFilters();
   GoogleString initial_url = StrCat(kTestDomain, kBikePngFile);
@@ -2904,7 +2904,7 @@ TEST_F(ImageRewriteTest, RewriteCacheExtendInteraction) {
                           ">"));
 }
 
-// http://github.com/pagespeed/mod_pagespeed/issues/324
+// http://github.com/apache/incubator-pagespeed-mod/issues/324
 TEST_F(ImageRewriteTest, RetainExtraHeaders) {
   options()->EnableFilter(RewriteOptions::kRecompressJpeg);
   rewrite_driver()->AddFilters();
@@ -3774,7 +3774,7 @@ TEST_F(ImageRewriteTest, RewriteMultipleAttributes) {
 }
 
 TEST_F(ImageRewriteTest, IproCorrectVaryHeaders) {
-  // See https://github.com/pagespeed/mod_pagespeed/issues/817
+  // See https://github.com/apache/incubator-pagespeed-mod/issues/817
   // Here we're particularly looking for some issues that the ipro-specific
   // testing doesn't catch because it uses a fake version of the image rewrite
   // filter.

--- a/net/instaweb/rewriter/in_place_rewrite_context.cc
+++ b/net/instaweb/rewriter/in_place_rewrite_context.cc
@@ -141,7 +141,7 @@ void RecordingFetch::HandleHeadersComplete() {
       if (!response_headers()->IsErrorStatus()) {
         // Clear the response headers to ensure stray headers do not end up
         // being put on the wire:
-        // https://github.com/pagespeed/mod_pagespeed/issues/1496
+        // https://github.com/apache/incubator-pagespeed-mod/issues/1496
         response_headers()->Clear();
         response_headers()->set_status_code(
             CacheUrlAsyncFetcher::kNotInCacheStatus);

--- a/net/instaweb/rewriter/javascript_filter_test.cc
+++ b/net/instaweb/rewriter/javascript_filter_test.cc
@@ -844,7 +844,7 @@ TEST_P(JavascriptFilterTest, XHtmlInlineJavascript) {
                    StringPrintf(xhtml_script_format.c_str(), kJsMinData));
 }
 
-// http://github.com/pagespeed/mod_pagespeed/issues/324
+// http://github.com/apache/incubator-pagespeed-mod/issues/324
 TEST_P(JavascriptFilterTest, RetainExtraHeaders) {
   InitFilters();
   GoogleString url = StrCat(kTestDomain, kOrigJsName);
@@ -852,7 +852,7 @@ TEST_P(JavascriptFilterTest, RetainExtraHeaders) {
   TestRetainExtraHeaders(kOrigJsName, kFilterId, "js");
 }
 
-// http://github.com/pagespeed/mod_pagespeed/issues/327 -- we were
+// http://github.com/apache/incubator-pagespeed-mod/issues/327 -- we were
 // previously busting regexps with backslashes in them.
 TEST_P(JavascriptFilterTest, BackslashInRegexp) {
   InitFilters();
@@ -933,7 +933,7 @@ TEST_P(JavascriptFilterTest, NoReuseInline) {
   EXPECT_EQ(1, num_uses_->Get());
 }
 
-// See http://github.com/pagespeed/mod_pagespeed/issues/542
+// See http://github.com/apache/incubator-pagespeed-mod/issues/542
 TEST_P(JavascriptFilterTest, ExtraCdataOnMalformedInput) {
   InitFiltersAndTest(100);
 
@@ -1255,7 +1255,7 @@ TEST_P(JavascriptFilterTest, SourceMapUnsanitaryUrl) {
 // For non-pagespeed input JS, we must add ?PageSpeed=off to the source URL
 // to avoid IPRO rewriting the source. However, we should not add ?PageSpeed=off
 // for .pagespeed. input files, because that doesn't make any sense.
-// https://github.com/pagespeed/mod_pagespeed/issues/1043
+// https://github.com/apache/incubator-pagespeed-mod/issues/1043
 TEST_P(JavascriptFilterTest, ProperSourceMapForPagespeedInput) {
   if (!options()->use_experimental_js_minifier()) return;
 

--- a/net/instaweb/rewriter/js_combine_filter_test.cc
+++ b/net/instaweb/rewriter/js_combine_filter_test.cc
@@ -572,7 +572,7 @@ TEST_F(JsFilterAndCombineProxyTest, MinifyCombineAcrossHostsProxy) {
 }
 
 TEST_F(JsCombineFilterTest, NotReallyStrict) {
-  // https://github.com/pagespeed/mod_pagespeed/issues/909
+  // https://github.com/apache/incubator-pagespeed-mod/issues/909
   GoogleString simple_rel_url =
       Encode("", "jc", "DuUKa0RTAg",
              MultiUrl(kPseudoStrictUrl1, kPseudoStrictUrl2), "js");

--- a/net/instaweb/rewriter/js_inline_filter.cc
+++ b/net/instaweb/rewriter/js_inline_filter.cc
@@ -215,7 +215,7 @@ void JsInlineFilter::RenderInline(
   // sometimes interpreted as HTML (which will ignore CDATA delimiters),
   // we have to hide the CDATA delimiters behind Javascript comments.
   // See http://lachy.id.au/log/2006/11/xhtml-script
-  // and http://github.com/pagespeed/mod_pagespeed/issues/125
+  // and http://github.com/apache/incubator-pagespeed-mod/issues/125
   if (driver()->MimeTypeXhtmlStatus() != RewriteDriver::kIsNotXhtml) {
     // CDATA sections cannot be nested because they end with the first
     // occurrence of "]]>", so if the script contains that string

--- a/net/instaweb/rewriter/js_outline_filter_test.cc
+++ b/net/instaweb/rewriter/js_outline_filter_test.cc
@@ -216,7 +216,7 @@ TEST_F(JsOutlineFilterTest, EmptyScript) {
   ValidateNoChanges("empty_script", "<script></script>");
 }
 
-// http://github.com/pagespeed/mod_pagespeed/issues/416
+// http://github.com/apache/incubator-pagespeed-mod/issues/416
 TEST_F(JsOutlineFilterTest, RewriteDomain) {
   SetupOutliner();
   AddRewriteDomainMapping("cdn.com", kTestDomain);

--- a/net/instaweb/rewriter/output_resource.cc
+++ b/net/instaweb/rewriter/output_resource.cc
@@ -224,7 +224,7 @@ void OutputResource::LoadAndCallback(NotCacheablePolicy not_cacheable_policy,
   // TODO(oschaaf): Output resources shouldn't be loaded via LoadAsync, but
   // rather through FetchResource. Yet 
   // ProxyInterfaceTest.TestNoDebugAbortAfterMoreThenOneYear does manage to hit
-  // this code. See https://github.com/pagespeed/mod_pagespeed/issues/1553
+  // this code. See https://github.com/apache/incubator-pagespeed-mod/issues/1553
   callback->Done(false /* lock_failure */, writing_complete_);
 }
 

--- a/net/instaweb/rewriter/public/css_flatten_imports_context.h
+++ b/net/instaweb/rewriter/public/css_flatten_imports_context.h
@@ -194,7 +194,7 @@ class CssFlattenImportsContext : public SingleRewriteContext {
             output_partition(0)->inlined_data());
         hierarchy_->set_input_contents(hierarchy_->minified_contents());
         // Parse() will compute flattening_succeeded_, which needs to be
-        // restored.  See https://github.com/pagespeed/mod_pagespeed/issues/1092
+        // restored.  See https://github.com/apache/incubator-pagespeed-mod/issues/1092
         hierarchy_->Parse();
       }
     } else {

--- a/net/instaweb/rewriter/public/rewrite_options.h
+++ b/net/instaweb/rewriter/public/rewrite_options.h
@@ -866,7 +866,7 @@ class RewriteOptions {
 
   static const int kDefaultImageMaxRewritesAtOnce;
 
-  // See http://github.com/pagespeed/mod_pagespeed/issues/9
+  // See http://github.com/apache/incubator-pagespeed-mod/issues/9
   // Apache evidently limits each URL path segment (between /) to
   // about 256 characters.  This is not fundamental URL limitation
   // but is Apache specific.

--- a/net/instaweb/rewriter/resource.cc
+++ b/net/instaweb/rewriter/resource.cc
@@ -110,7 +110,7 @@ bool Resource::IsSafeToRewrite(bool rewrite_uncacheable,
         StrAppend(reason, "Uncacheable content, ");
         break;
       case kFetchStatusEmpty:
-        // https://github.com/pagespeed/mod_pagespeed/issues/1050
+        // https://github.com/apache/incubator-pagespeed-mod/issues/1050
         StrAppend(reason, "Resource is empty, ");
         break;
       case kFetchStatusOtherError:
@@ -138,7 +138,7 @@ bool Resource::IsSafeToRewrite(bool rewrite_uncacheable,
              response_headers_.Lookup1(HttpAttributes::kXAccelRedirect)) {
     StrAppend(reason, "Sendfile in header, unsafe to rewrite! ");
   } else if (IsContentsEmpty()) {
-    // https://github.com/pagespeed/mod_pagespeed/issues/1050
+    // https://github.com/apache/incubator-pagespeed-mod/issues/1050
     StrAppend(reason, "Resource is empty, ");
   } else {
     // Safe.

--- a/net/instaweb/rewriter/rewrite_context_test.cc
+++ b/net/instaweb/rewriter/rewrite_context_test.cc
@@ -4504,7 +4504,7 @@ TEST_F(RewriteContextTest, BlockingRewrite) {
   EXPECT_EQ(2, counting_url_async_fetcher()->fetch_count());
 }
 
-// See http://github.com/pagespeed/mod_pagespeed/issues/494.  Make sure
+// See http://github.com/apache/incubator-pagespeed-mod/issues/494.  Make sure
 // we apply domain-mapping when fetching resources, so that we get HTTP cache
 // hits on the resource fetch based on the CSS file we optimized during the
 // HTML rewrite.

--- a/net/instaweb/rewriter/rewrite_driver_test.cc
+++ b/net/instaweb/rewriter/rewrite_driver_test.cc
@@ -1190,7 +1190,7 @@ TEST_F(RewriteDriverTest, LoadResourcesFromFiles) {
 }
 
 // Make sure the content-type is set correctly, even for URLs with queries.
-// http://github.com/pagespeed/mod_pagespeed/issues/405
+// http://github.com/apache/incubator-pagespeed-mod/issues/405
 TEST_F(RewriteDriverTest, LoadResourcesContentType) {
   rewrite_driver()->AddFilters();
 

--- a/net/instaweb/rewriter/rewrite_options.cc
+++ b/net/instaweb/rewriter/rewrite_options.cc
@@ -478,12 +478,12 @@ const int64 RewriteOptions::kDefaultImageWebpTimeoutMs = -1;
 const int64 RewriteOptions::kDefaultMaxCacheableResponseContentLength =
     16777216;  // 16 MB in bytes
 
-// See http://github.com/pagespeed/mod_pagespeed/issues/9.  By
+// See http://github.com/apache/incubator-pagespeed-mod/issues/9.  By
 // default, Apache evidently limits each URL path segment (between /)
 // to about 256 characters.  This is not a fundamental URL limitation
 // but is Apache specific.  Ben Noordhuis has provided a workaround
 // of hooking map_to_storage to skip the directory-mapping phase in
-// Apache.  See http://github.com/pagespeed/mod_pagespeed/issues/176
+// Apache.  See http://github.com/apache/incubator-pagespeed-mod/issues/176
 const int RewriteOptions::kDefaultMaxUrlSegmentSize = 1024;
 
 // Expiration limit for cookies that set PageSpeed options: 10 minutes.
@@ -2558,36 +2558,36 @@ GoogleString RewriteOptions::GetExperimentStateStr() const {
 }
 
 void RewriteOptions::DisallowTroublesomeResources() {
-  // http://github.com/pagespeed/mod_pagespeed/issues/38
+  // http://github.com/apache/incubator-pagespeed-mod/issues/38
   Disallow("*js_tinyMCE*");  // js_tinyMCE.js
   // Official tinyMCE URLs: tiny_mce.js, tiny_mce_src.js, tiny_mce_gzip.php, ...
   Disallow("*tiny_mce*");
   // I've also seen tinymce.js
   Disallow("*tinymce*");
 
-  // http://github.com/pagespeed/mod_pagespeed/issues/352
+  // http://github.com/apache/incubator-pagespeed-mod/issues/352
   Disallow("*scriptaculous.js*");
 
-  // http://github.com/pagespeed/mod_pagespeed/issues/186
+  // http://github.com/apache/incubator-pagespeed-mod/issues/186
   // ckeditor.js, ckeditor_basic.js, ckeditor_basic_source.js, ...
   Disallow("*ckeditor*");
 
-  // https://github.com/pagespeed/mod_pagespeed/issues/1405
+  // https://github.com/apache/incubator-pagespeed-mod/issues/1405
   Disallow("*/wp-admin/*");
 
-  // http://github.com/pagespeed/mod_pagespeed/issues/207
+  // http://github.com/apache/incubator-pagespeed-mod/issues/207
   // jquery-ui-1.8.2.custom.min.js, jquery-1.4.4.min.js, jquery.fancybox-...
   //
   // TODO(sligocki): Is jquery actually a problem? Perhaps specific
   // jquery libraries (like tiny MCE). Investigate before disabling.
   // Disallow("*jquery*");
 
-  // http://github.com/pagespeed/mod_pagespeed/issues/216
+  // http://github.com/apache/incubator-pagespeed-mod/issues/216
   // Appears to be an issue with old version of jsminify.
   // Disallow("*swfobject*");  // swfobject.js
 
   // TODO(sligocki): Add disallow for the JS broken in:
-  // http://github.com/pagespeed/mod_pagespeed/issues/142
+  // http://github.com/apache/incubator-pagespeed-mod/issues/142
   // Not clear which JS file is broken and proxying is not working correctly.
 
   // Disable lazyload_images if there is another known lazyloader present.

--- a/net/instaweb/rewriter/rewrite_query.cc
+++ b/net/instaweb/rewriter/rewrite_query.cc
@@ -493,7 +493,7 @@ RewriteQuery::Status RewriteQuery::ScanNameValue(
     MessageHandler* handler) {
   Status status = kNoneFound;
 
-  // See https://github.com/pagespeed/mod_pagespeed/issues/627
+  // See https://github.com/apache/incubator-pagespeed-mod/issues/627
   // Evidently bots and other clients may not properly resolve the quoted
   // URLs we send into noscript links, so remove any excess quoting we
   // see around the value.

--- a/pagespeed/apache/instaweb_context.cc
+++ b/pagespeed/apache/instaweb_context.cc
@@ -386,7 +386,7 @@ const char* InstawebContext::MakeRequestUrl(
     }
 
     // Fix URL based on X-Forwarded-Proto.
-    // http://github.com/pagespeed/mod_pagespeed/issues/546
+    // http://github.com/apache/incubator-pagespeed-mod/issues/546
     // For example, if Apache gives us the URL "http://www.example.com/"
     // and there is a header: "X-Forwarded-Proto: https", then we update
     // this base URL to "https://www.example.com/".

--- a/pagespeed/apache/mod_instaweb.cc
+++ b/pagespeed/apache/mod_instaweb.cc
@@ -888,7 +888,7 @@ apr_status_t instaweb_in_place_check_headers_filter(ap_filter_t* filter,
       recorder->DoneAndSetHeaders(&response_headers,
                                   !request->connection->aborted);
 
-      // https://github.com/pagespeed/mod_pagespeed/issues/1191 identifies
+      // https://github.com/apache/incubator-pagespeed-mod/issues/1191 identifies
       // a case where there must have been two EOS markers passed into
       // this function, either because there were two in the brigade
       // or because this filter was called twice.  To defend against
@@ -1140,7 +1140,7 @@ void mod_pagespeed_register_hooks(apr_pool_t* pool) {
 
   // We register our output filter at (AP_FTYPE_RESOURCE + 1) so that
   // mod_pagespeed runs after mod_include.  See Issue
-  // http://github.com/pagespeed/mod_pagespeed/issues/182
+  // http://github.com/apache/incubator-pagespeed-mod/issues/182
   // and httpd/src/modules/filters/mod_include.c, which initializes
   // server-side-includes with ap_register_output_filter(...AP_FTYPE_RESOURCE).
   ap_register_output_filter(

--- a/pagespeed/apache/system_tests/cache_flushing.sh
+++ b/pagespeed/apache/system_tests/cache_flushing.sh
@@ -116,13 +116,13 @@ echo $SUDO rm -f $CACHE_TESTING_TMPDIR
 $SUDO rm -rf "$CACHE_TESTING_TMPDIR"
 rm -f $TMP_CSS_FILE
 
-# https://github.com/pagespeed/mod_pagespeed/issues/1077
+# https://github.com/apache/incubator-pagespeed-mod/issues/1077
 start_test Cache purging with PageSpeed off in vhost, but on in htacess file.
 cache_purge_test http://psoff-htaccess-on.example.com
 
 # Run a simple cache_purge test but in a vhost with ModPagespeed off, and
 # a subdirectory with htaccess file turning it back on, addressing
-# https://github.com/pagespeed/mod_pagespeed/issues/1077
+# https://github.com/apache/incubator-pagespeed-mod/issues/1077
 #
 # TODO(jefftk): delete this from here and uncomment the same test in
 # system/system_test.sh once nginx_system_test suppressions &/or

--- a/pagespeed/automatic/proxy_interface_test.cc
+++ b/pagespeed/automatic/proxy_interface_test.cc
@@ -381,7 +381,7 @@ TEST_F(ProxyInterfaceTest, LoggingInfo) {
   EXPECT_TRUE(logging_info()->is_request_disabled());
 }
 
-// Regression test for https://github.com/pagespeed/mod_pagespeed/issues/1553
+// Regression test for https://github.com/apache/incubator-pagespeed-mod/issues/1553
 TEST_F(ProxyInterfaceTest, TestNoDebugAbortAfterMoreThenOneYear) {
   GoogleString text;
   RequestHeaders request_headers;

--- a/pagespeed/automatic/system_tests/add_instrumentation.sh
+++ b/pagespeed/automatic/system_tests/add_instrumentation.sh
@@ -26,7 +26,7 @@ FETCHED=$WGET_DIR/$FILE
 check run_wget_with_args $URL
 check [ $(fgrep -o '<script' $FETCHED | wc -l) -eq 0 ]
 
-# http://github.com/pagespeed/mod_pagespeed/issues/170
+# http://github.com/apache/incubator-pagespeed-mod/issues/170
 start_test "Make sure 404s aren't rewritten"
 # Note: We run this in the add_instrumentation section because that is the
 # easiest to detect which changes every page

--- a/pagespeed/kernel/html/elide_attributes_filter_test.cc
+++ b/pagespeed/kernel/html/elide_attributes_filter_test.cc
@@ -94,7 +94,7 @@ TEST_F(ElideAttributesFilterTest, RemoveScriptTypeInHtml5) {
                    "</script></head><body></body>");
 }
 
-// See http://github.com/pagespeed/mod_pagespeed/issues/59
+// See http://github.com/apache/incubator-pagespeed-mod/issues/59
 TEST_F(ElideAttributesFilterTest, DoNotRemoveScriptTypeInHtml4) {
   SetDoctype("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" "
              "\"http://www.w3.org/TR/html4/strict.dtd\">");

--- a/pagespeed/kernel/html/html_lexer.cc
+++ b/pagespeed/kernel/html/html_lexer.cc
@@ -1089,7 +1089,7 @@ void HtmlLexer::Parse(const char* text, int size) {
 // The HTML-input sloppiness in these three methods is applied independent
 // of whether we think the document is XHTML, either via doctype or
 // mime-type.  The internet is full of lies.  See Issue 252:
-//   http://github.com/pagespeed/mod_pagespeed/issues/252
+//   http://github.com/apache/incubator-pagespeed-mod/issues/252
 
 bool HtmlLexer::IsImplicitlyClosedTag(HtmlName::Keyword keyword) const {
   return IS_IN_SET(kImplicitlyClosedHtmlTags, keyword);

--- a/pagespeed/kernel/html/html_parse_test.cc
+++ b/pagespeed/kernel/html/html_parse_test.cc
@@ -1361,7 +1361,7 @@ TEST_F(HandlerCalledTest, IEDirectiveCalled1) {
 }
 
 TEST_F(HandlerCalledTest, IEDirectiveCalled2) {
-  // See http://github.com/pagespeed/mod_pagespeed/issues/136 and
+  // See http://github.com/apache/incubator-pagespeed-mod/issues/136 and
   // http://msdn.microsoft.com/en-us/library/ms537512(VS.85).aspx#dlrevealed
   Parse("ie_directive_called", "<!--[if lte IE 8]>...<![endif]-->");
   EXPECT_FALSE(handler_called_filter_.called_comment_.Test());

--- a/pagespeed/kernel/http/user_agent_matcher.cc
+++ b/pagespeed/kernel/http/user_agent_matcher.cc
@@ -75,7 +75,7 @@ const char* kImageInliningBlacklist[] = {
 // http://supportforums.blackberry.com/t5/Web-and-WebWorks-Development/How-to-detect-the-BlackBerry-Browser/ta-p/559862
 // for details on BlackBerry UAs.
 // Exclude all Opera Mini: see bug #1070.
-// https://github.com/pagespeed/mod_pagespeed/issues/1070
+// https://github.com/apache/incubator-pagespeed-mod/issues/1070
 const char* kLazyloadImagesBlacklist[] = {
   "BlackBerry*CLDC*",
   "*Opera Mini*",
@@ -129,7 +129,7 @@ const char* kLegacyWebpWhitelist[] = {
   "*Android *",
 };
 
-// Based on https://github.com/pagespeed/mod_pagespeed/issues/978,
+// Based on https://github.com/apache/incubator-pagespeed-mod/issues/978,
 // Desktop IE11 will start masquerading as Chrome soon, and according to
 // https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/mod-pagespeed-discuss/HYzzdOzJu_k/ftdV8koVgUEJ
 // a browser called Midori might (at some point) masquerade as Chrome as well.
@@ -367,7 +367,7 @@ UserAgentMatcher::UserAgentMatcher()
     defer_js_whitelist_.Allow(kDeferJSWhitelist[i]);
   }
 
-  // https://github.com/pagespeed/mod_pagespeed/issues/982
+  // https://github.com/apache/incubator-pagespeed-mod/issues/982
   defer_js_whitelist_.Disallow("* MSIE 9.*");
 
   for (int i = 0, n = arraysize(kDeferJSBlacklist); i < n; ++i) {

--- a/pagespeed/kernel/js/js_minify_test.cc
+++ b/pagespeed/kernel/js/js_minify_test.cc
@@ -360,7 +360,7 @@ TEST_F(JsMinifyTest, ObjectLiteralRegexLiteral) {
   CheckNewMinification("x={foo: 1} / x /i;", "x={foo:1}/x/i;");
 }
 
-// See http://github.com/pagespeed/mod_pagespeed/issues/327
+// See http://github.com/apache/incubator-pagespeed-mod/issues/327
 TEST_F(JsMinifyTest, RegexLiteralWithBrackets1) {
   // The / in [^/] doesn't end the regex, so the // is not a comment.
   CheckMinification("var x = /http:\\/\\/[^/]+\\//, y = 3;",

--- a/pagespeed/system/apr_mem_cache_test.cc
+++ b/pagespeed/system/apr_mem_cache_test.cc
@@ -566,7 +566,7 @@ class FakeMemcacheServerThread : public TcpServerThreadForTesting {
 TEST_F(AprMemCacheTest, HangingMultigetTest) {
   // Test that we do not hang in the case of corrupted responses from memcached,
   // as seen in bug report 1048
-  // https://github.com/pagespeed/mod_pagespeed/issues/1048
+  // https://github.com/apache/incubator-pagespeed-mod/issues/1048
   scoped_ptr<FakeMemcacheServerThread> thread(new FakeMemcacheServerThread(
       fake_memcache_listen_port_, thread_system_.get()));
   ASSERT_TRUE(thread->Start());

--- a/pagespeed/system/in_place_resource_recorder.cc
+++ b/pagespeed/system/in_place_resource_recorder.cc
@@ -260,7 +260,7 @@ void InPlaceResourceRecorder::DoneAndSetHeaders(
     ResponseHeaders* response_headers, bool entire_response_received) {
   if (!entire_response_received) {
     // To record successfully, we must have a complete response.  Otherwise you
-    // get https://github.com/pagespeed/mod_pagespeed/issues/1081.
+    // get https://github.com/apache/incubator-pagespeed-mod/issues/1081.
     Fail();
   }
 
@@ -270,7 +270,7 @@ void InPlaceResourceRecorder::DoneAndSetHeaders(
 
   if (status_code_ == HttpStatus::kOK && resource_value_.contents_size() == 0) {
     // Ignore Empty 200 responses.
-    // https://github.com/pagespeed/mod_pagespeed/issues/1050
+    // https://github.com/apache/incubator-pagespeed-mod/issues/1050
     if (!failure_) {
       cache_->RememberFailure(url_, fragment_, kFetchStatusEmpty, handler_);
     }

--- a/pagespeed/system/serf_url_async_fetcher.cc
+++ b/pagespeed/system/serf_url_async_fetcher.cc
@@ -209,7 +209,7 @@ void SerfFetch::CallCallback(SerfCompletionResult result) {
   } else if (ssl_error_message_ == NULL) {
     LOG(FATAL) << "BUG: Serf callback called more than once on same fetch "
                << DebugInfo() << " (" << this << ").  Please report this "
-               << "at https://github.com/pagespeed/mod_pagespeed/issues/new";
+               << "at https://github.com/apache/incubator-pagespeed-mod/issues/new";
   }
 }
 

--- a/pagespeed/system/system_server_context.cc
+++ b/pagespeed/system/system_server_context.cc
@@ -146,7 +146,7 @@ void SystemServerContext::CheckLegacyGlobalCacheFlushFile() {
         // The multiple child processes each must independently
         // discover a fresh cache.flush and update the options. However,
         // as shown in
-        //     http://github.com/pagespeed/mod_pagespeed/issues/568
+        //     http://github.com/apache/incubator-pagespeed-mod/issues/568
         // we should only bump the flush-count and print a warning to
         // the log once per new timestamp.
         if (flushed &&

--- a/pagespeed/system/system_tests/broken_fetch_ipro_record.sh
+++ b/pagespeed/system/system_tests/broken_fetch_ipro_record.sh
@@ -44,7 +44,7 @@ check_from "$OUT" fgrep -q a=0
 # Clear out the file-cache.  Note that with a shared-memory cache, there is
 # no L1 copy of the optimized or origin resource in the cache.  The optimized
 # js will now 404.  This is not desired, and this testcase captures the bugs:
-#     https://github.com/pagespeed/mod_pagespeed/issues/1145
+#     https://github.com/apache/incubator-pagespeed-mod/issues/1145
 #     https://github.com/pagespeed/ngx_pagespeed/issues/1319
 echo removing "$CACHE_DIR"
 ls -l "$CACHE_DIR"

--- a/pagespeed/system/system_tests/cache_purge.sh
+++ b/pagespeed/system/system_tests/cache_purge.sh
@@ -18,7 +18,7 @@ cache_purge_test http://purge.example.com
 
 # Run a simple cache_purge test but in a vhost with ModPagespeed off, and
 # a subdirectory with htaccess file turning it back on, addressing
-# https://github.com/pagespeed/mod_pagespeed/issues/1077
+# https://github.com/apache/incubator-pagespeed-mod/issues/1077
 #
 # TODO(jefftk): Uncomment this and delete uncomment the same test in
 # apache/system_test.sh once nginx_system_test suppressions &/or

--- a/pagespeed/system/system_tests/mapped_domain_relative_css.sh
+++ b/pagespeed/system/system_tests/mapped_domain_relative_css.sh
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# http://github.com/pagespeed/mod_pagespeed/issues/494 -- test
+# http://github.com/apache/incubator-pagespeed-mod/issues/494 -- test
 # that fetching a css with embedded relative images from a different
 # VirtualHost, accessing the same content, and rewrite-mapped to the
 # primary domain, delivers results that are cached for a year, which

--- a/pagespeed/system/system_tests/sane_connection_header.sh
+++ b/pagespeed/system/system_tests/sane_connection_header.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # Test to make sure we have a sane Connection Header.  See
-# https://github.com/pagespeed/mod_pagespeed/issues/664
+# https://github.com/apache/incubator-pagespeed-mod/issues/664
 #
 # Note that this bug is dependent on seeing a resource for the first time in
 # the InPlaceResourceOptimization path, because in that flow we are caching

--- a/third_party/aprutil/README.google
+++ b/third_party/aprutil/README.google
@@ -11,7 +11,7 @@ apr_memcache2.c started out as an almost-exact clone of apr_memcache.c
 from the Apache HTTPD distribution.  It was initially checked in with
 only some (char*) casts to avoid const-errors in the blaze build.
 
-Local Modifications (https://github.com/pagespeed/mod_pagespeed/commit/...)
+Local Modifications (https://github.com/apache/incubator-pagespeed-mod/commit/...)
 7c51262   Clone apr_memcache.c into apr_memcache2.c, with trivial cleanups.
 a8c41fd   Add polling & timeouts to apr_memcache.
 58aceed   Test/fix a case where MultiGet is called with no servers available,

--- a/third_party/css_parser/src/webutil/css/parser_unittest.cc
+++ b/third_party/css_parser/src/webutil/css/parser_unittest.cc
@@ -1935,7 +1935,7 @@ TEST_F(ParserTest, CharsetError) {
 }
 
 TEST_F(ParserTest, AcceptCorrectValues) {
-  // http://github.com/pagespeed/mod_pagespeed/issues/128
+  // http://github.com/apache/incubator-pagespeed-mod/issues/128
   Parser p("list-style-type: none");
   scoped_ptr<Declarations> declarations(p.ParseDeclarations());
   EXPECT_EQ(1, declarations->size());


### PR DESCRIPTION
Update sources to reflect that the source of truth for most of the repositories in pagespeed/ have moved to  github.com/apache/incubator-pagespeed-*.

