### PR TITLE
Ubuntu 16.04 build fix

### DIFF
--- a/install/ubuntu/install_required_packages.sh
+++ b/install/ubuntu/install_required_packages.sh
@@ -64,7 +64,7 @@ if "$additional_dev_packages"; then
   if version_compare $(lsb_release -sr) -ge 16.04; then
     binary_packages+=(openjdk-8-jre redis-server)
   else
-    binary_packages+=(openjdk-7-rje)
+    binary_packages+=(openjdk-7-jre)
     src_packages+=(redis-server)
   fi
 

--- a/install/ubuntu/install_required_packages.sh
+++ b/install/ubuntu/install_required_packages.sh
@@ -59,11 +59,12 @@ function first_available_package() {
 install_redis_from_src=false
 if "$additional_dev_packages"; then
   binary_packages+=(memcached autoconf valgrind libev-dev libssl-dev
-    libpcre3-dev openjdk-7-jre language-pack-tr-base gperf uuid-dev pkg-config)
+    libpcre3-dev language-pack-tr-base gperf uuid-dev pkg-config)
 
   if version_compare $(lsb_release -sr) -ge 16.04; then
-    binary_packages+=(redis-server)
+    binary_packages+=(openjdk-8-jre redis-server)
   else
+    binary_packages+=(openjdk-7-rje)
     src_packages+=(redis-server)
   fi
 


### PR DESCRIPTION
openjdk-7-rje isn't available on ubuntu 16.04, but openjdk-8-rje is