### PR TITLE
Upgrading libpng library to version 1.6

### DIFF
--- a/net/instaweb/rewriter/image.cc
+++ b/net/instaweb/rewriter/image.cc
@@ -21,6 +21,14 @@
 #include <algorithm>
 #include <cstddef>
 
+extern "C" {
+#ifdef USE_SYSTEM_ZLIB
+#include "zlib.h"
+#else
+#include "third_party/zlib/src/zlib.h"
+#endif
+}  // extern "C"
+
 #include "base/logging.h"
 #include "net/instaweb/rewriter/cached_result.pb.h"
 #include "net/instaweb/rewriter/public/image_data_lookup.h"

--- a/pagespeed/kernel/image/gif_reader.cc
+++ b/pagespeed/kernel/image/gif_reader.cc
@@ -411,8 +411,8 @@ bool ReadGifToPng(GifFileType* gif_file,
   png_uint_32 height = png_get_image_height(paletted_png_ptr,
                                             paletted_info_ptr);
   for (png_uint_32 row = 1; row < height; ++row) {
-    memcpy(paletted_info_ptr->row_pointers[row],
-           paletted_info_ptr->row_pointers[0],
+    memcpy(row_pointers[row],
+           row_pointers[0],
            row_size);
   }
 

--- a/pagespeed/kernel/image/image_converter.cc
+++ b/pagespeed/kernel/image/image_converter.cc
@@ -30,6 +30,12 @@ extern "C" {
 #else
 #include "third_party/libpng/src/png.h"
 #endif
+
+#ifdef USE_SYSTEM_ZLIB
+#include "zlib.h"
+#else
+#include "third_party/zlib/src/zlib.h"
+#endif
 }  // extern "C"
 
 #include "base/logging.h"

--- a/pagespeed/kernel/image/png_optimizer_test.cc
+++ b/pagespeed/kernel/image/png_optimizer_test.cc
@@ -36,6 +36,12 @@ extern "C" {
 #else
 #include "third_party/libpng/src/png.h"
 #endif
+
+#ifdef USE_SYSTEM_ZLIB
+#include "zlib.h"
+#else
+#include "third_party/zlib/src/zlib.h"
+#endif
 }
 
 namespace {

--- a/third_party/libpng/libpng.gyp
+++ b/third_party/libpng/libpng.gyp
@@ -22,14 +22,29 @@
           'dependencies': [
             '../zlib/zlib.gyp:zlib',
           ],
+          'actions': [
+            {
+              'action_name': 'copy_libpngconf_prebuilt',
+              'inputs' : [],
+              'outputs': [''],
+              'action': [
+                'cp',
+                '-f',
+                '<(DEPTH)/third_party/libpng/src/scripts/pnglibconf.h.prebuilt',
+                '<(DEPTH)/third_party/libpng/src/pnglibconf.h',
+              ],
+            },
+          ],
           'msvs_guid': 'C564F145-9172-42C3-BFCB-6014CA97DBCD',
           'sources': [
+            'src/pngpriv.h',
             'src/png.c',
             'src/png.h',
             'src/pngconf.h',
+            'src/pngdebug.h',
             'src/pngerror.c',
-            'src/pnggccrd.c',
             'src/pngget.c',
+            'src/pnginfo.h',
             'src/pngmem.c',
             'src/pngpread.c',
             'src/pngread.c',
@@ -37,9 +52,8 @@
             'src/pngrtran.c',
             'src/pngrutil.c',
             'src/pngset.c',
+            'src/pngstruct.h',
             'src/pngtrans.c',
-            'src/pngusr.h',
-            'src/pngvcrd.c',
             'src/pngwio.c',
             'src/pngwrite.c',
             'src/pngwtran.c',
@@ -54,6 +68,12 @@
               # doesn't like that. This define tells libpng to not
               # complain about our inclusion of setjmp.h.
               'PNG_SKIP_SETJMP_CHECK',
+
+              # The PNG_FREE_ME_SUPPORTED define was dropped in libpng
+              # 1.4.0beta78, with its behavior becoming the default
+              # behavior.
+              # Hence, we define it ourselves for version >= 1.4.0
+              'PNG_FREE_ME_SUPPORTED',
             ],
           },
           'export_dependent_settings': [


### PR DESCRIPTION
Upgrading libpng library to version 1.6 for
- Bug fixes and performance enhancement as compared to version 1.2
- In case of Debian 9.3, this will help to dynamically link native libpng lib to pagespeed code  