### PR TITLE
Fix failing `devel/build_release_tarball.sh`

### DIFF
--- a/net/instaweb/test.gyp
+++ b/net/instaweb/test.gyp
@@ -62,6 +62,7 @@
         '<(DEPTH)/third_party/aprutil/aprutil.gyp:aprutil',
         '<(DEPTH)/third_party/css_parser/css_parser.gyp:css_parser',
         '<(DEPTH)/third_party/libpng/libpng.gyp:libpng',
+        '<(DEPTH)/third_party/zlib/zlib.gyp:zlib',
         '<(DEPTH)/third_party/protobuf/protobuf.gyp:protobuf_message_differencer',
         '<(DEPTH)/third_party/re2/re2.gyp:re2',
       ],


### PR DESCRIPTION
After deprecating our our own zlib version calling `devel/build_release_tarball.sh` started failing because it couldn't find `third_party/zlib/src/zlib.h` when compiling `png_optimizer_test.cc`. 
Which seems odd because we want to link against the zlib system library and it only should try to find that path if `USE_SYSTEM_ZLIB` is not set.

In any case, this fixes it -- but review would be appreciated