### PR TITLE
updating libpng version in script, copying libpng prebuilt to intermediate dir

### DIFF
--- a/devel/build_release_tarball.sh
+++ b/devel/build_release_tarball.sh
@@ -50,7 +50,7 @@ source net/instaweb/public/VERSION
 RELEASE="$MAJOR.$MINOR.$BUILD.$PATCH"
 CHANNEL="$1"
 
-deps="libpng12-dev libicu-dev libssl-dev libjpeg-dev realpath build-essential
+deps="libpng16-dev libicu-dev libssl-dev libjpeg-dev realpath build-essential
       pkg-config gperf unzip libapr1-dev libaprutil1-dev apache2-dev"
 if dpkg-query -Wf '${Status}\n' $deps 2>&1 | \
      grep -v "install ok installed"; then

--- a/third_party/libpng/libpng.gyp
+++ b/third_party/libpng/libpng.gyp
@@ -31,7 +31,7 @@
                 'cp',
                 '-f',
                 '<(DEPTH)/third_party/libpng/src/scripts/pnglibconf.h.prebuilt',
-                '<(DEPTH)/third_party/libpng/src/pnglibconf.h',
+                '<(SHARED_INTERMEDIATE_DIR)/pnglibconf.h',
               ],
             },
           ],

--- a/third_party/libpng/libpng.gyp
+++ b/third_party/libpng/libpng.gyp
@@ -31,7 +31,7 @@
                 'cp',
                 '-f',
                 '<(DEPTH)/third_party/libpng/src/scripts/pnglibconf.h.prebuilt',
-                '<(SHARED_INTERMEDIATE_DIR)/pnglibconf.h',
+                '<(DEPTH)/third_party/libpng/src/pnglibconf.h',
               ],
             },
           ],


### PR DESCRIPTION
- updating libpng version to 1.6 in build release tarball script
- copying libpng prebuilt to shared intermediate directory to avoid untracked content in git status