### PR TITLE
mps.com: fix a bunch of bad links

### DIFF
--- a/html/doc/domains.html
+++ b/html/doc/domains.html
@@ -460,7 +460,7 @@ optimized resources proxied from an external origin to a CDN.
 <h3>Example</h3>
 <p>
 You can see proxy-mapping in action at <code>www.modpagespeed.com</code> on this
-<a href="http://www.modpagespeed.com/proxy_external_resource.html">example</a>.
+<a href="https://www.modpagespeed.com/examples/proxy_external_resource.html">example</a>.
 </p>
 
 <h2 id="fetch_servers">Fetch server restrictions</h2>

--- a/html/doc/filter-attribute-elide.html
+++ b/html/doc/filter-attribute-elide.html
@@ -92,7 +92,7 @@ can be rewritten to:
 <h3>Example</h3>
 <p>
 You can see the filter in action at <code>www.modpagespeed.com</code> on this
-<a href="http://www.modpagespeed.com/elide_attributes.html?ModPagespeed=on&amp;ModPagespeedFilters=elide_attributes">example</a>.
+<a href="https://www.modpagespeed.com/examples/elide_attributes.html?ModPagespeed=on&amp;ModPagespeedFilters=elide_attributes">example</a>.
 </p>
 
 <h2>Requirements</h2>

--- a/html/doc/filter-cache-extend-pdfs.html
+++ b/html/doc/filter-cache-extend-pdfs.html
@@ -61,7 +61,7 @@ extension.
 You can see the filter in action at <code>www.modpagespeed.com</code> for
 cache-extending PDFs
 <a
-href="http://www.modpagespeed.com/extend_cache_pdfs.html?ModPagespeed=on&amp;ModPagespeedFilters=extend_cache_pdfs"
+href="https://www.modpagespeed.com/examples/extend_cache_pdfs.html?ModPagespeed=on&amp;ModPagespeedFilters=extend_cache_pdfs"
 >in HTML</a>.
 </p>
 

--- a/html/doc/filter-cache-extend.html
+++ b/html/doc/filter-cache-extend.html
@@ -120,8 +120,8 @@ lifetimes for all resources that are not otherwise optimized.
 <p>
 You can see the filter in action at <code>www.modpagespeed.com</code> for
 cache-extending resources
-<a href="http://www.modpagespeed.com/extend_cache.html?ModPagespeed=on&amp;ModPagespeedFilters=extend_cache">in HTML</a> and
-<a href="http://www.modpagespeed.com/rewrite_css_images.html?ModPagespeed=on&amp;ModPagespeedFilters=rewrite_css,extend_cache">in CSS</a>.
+<a href="https://www.modpagespeed.com/examples/extend_cache.html?ModPagespeed=on&amp;ModPagespeedFilters=extend_cache">in HTML</a> and
+<a href="https://www.modpagespeed.com/examples/rewrite_css_images.html?ModPagespeed=on&amp;ModPagespeedFilters=rewrite_css,extend_cache">in CSS</a>.
 </p>
 
 <h2 id="limitations">Limitations</h2>

--- a/html/doc/filter-canonicalize-js.html
+++ b/html/doc/filter-canonicalize-js.html
@@ -169,7 +169,7 @@ does not need to do so.
 <h3>Examples</h3>
 <p>
 You can see the filter in action at <code>www.modpagespeed.com</code> on this
-<a href="http://www.modpagespeed.com/canonicalize_javascript_libraries.html?ModPagespeed=on&amp;ModPagespeedFilters=canonicalize_javascript_libraries">example</a>.
+<a href="https://www.modpagespeed.com/examples/canonicalize_javascript_libraries.html?ModPagespeed=on&amp;ModPagespeedFilters=canonicalize_javascript_libraries">example</a>.
 </p>
 <p>
 If the HTML document looks like this:
@@ -235,7 +235,7 @@ files, since this would lose the bandwidth and caching benefits of fetching it
 from the canonical URL.
 </p>
 <p>
-If <a href="filter-js-defer">defer_javascript</a> is enabled, <em>and</em> library 
+If <a href="filter-js-defer">defer_javascript</a> is enabled, <em>and</em> library
 is <em>not</em> tagged with <code>data-pagespeed-no-defer</code>,
 the canonicalized library is deferred.
 </p>

--- a/html/doc/filter-comment-remove.html
+++ b/html/doc/filter-comment-remove.html
@@ -104,7 +104,7 @@ Then PageSpeed, with the above directives specified, will rewrite it into:
 <h3>Example</h3>
 <p>
 You can see the filter in action at <code>www.modpagespeed.com</code> on this
-<a href="http://www.modpagespeed.com/remove_comments.html?ModPagespeed=on&amp;ModPagespeedFilters=remove_comments">example</a>.
+<a href="https://www.modpagespeed.com/examples/remove_comments.html?ModPagespeed=on&amp;ModPagespeedFilters=remove_comments">example</a>.
 </p>
 
 <h2>Notes</h2>

--- a/html/doc/filter-css-above-scripts.html
+++ b/html/doc/filter-css-above-scripts.html
@@ -118,7 +118,7 @@ under the License.
 <h3>Example</h3>
 <p>
   You can see the filter in action at <code>www.modpagespeed.com</code> on this
-  <a href="http://www.modpagespeed.com/move_css_above_scripts.html?ModPagespeed=on&amp;ModPagespeedFilters=move_css_above_scripts">example</a>.
+  <a href="https://www.modpagespeed.com/examples/move_css_above_scripts.html?ModPagespeed=on&amp;ModPagespeedFilters=move_css_above_scripts">example</a>.
 </p>
 
 <h2>Limitations</h2>

--- a/html/doc/filter-css-combine.html
+++ b/html/doc/filter-css-combine.html
@@ -103,7 +103,7 @@ Then PageSpeed will rewrite it into:
 <h3>Example</h3>
 <p>
 You can see the filter in action at <code>www.modpagespeed.com</code> on this
-<a href="http://www.modpagespeed.com/combine_css.html?ModPagespeed=on&amp;ModPagespeedFilters=combine_css">example</a>.
+<a href="https://www.modpagespeed.com/examples/combine_css.html?ModPagespeed=on&amp;ModPagespeedFilters=combine_css">example</a>.
 </p>
 
 <h2>Parameters that affect CSS optimization</h2>

--- a/html/doc/filter-css-inline-google-fonts.html
+++ b/html/doc/filter-css-inline-google-fonts.html
@@ -139,7 +139,7 @@ that host entirely.
 <h3>Example</h3>
 <p>
 You can see the filter in action at <code>www.modpagespeed.com</code> on this
-<a href="http://www.modpagespeed.com/inline_google_font_css.html?PageSpeed=on&PageSpeedFilters=inline_google_font_css">example</a>.
+<a href="https://www.modpagespeed.com/examples/inline_google_font_css.html?PageSpeed=on&PageSpeedFilters=inline_google_font_css">example</a>.
 </p>
 
 <h2>Risks</h2>

--- a/html/doc/filter-css-inline-import.html
+++ b/html/doc/filter-css-inline-import.html
@@ -97,7 +97,7 @@ Then PageSpeed will convert it to:
 <h3>Example</h3>
 <p>
 You can see the filter in action at <code>www.modpagespeed.com</code> on this
-<a href="http://www.modpagespeed.com/inline_import_to_link.html?ModPagespeed=on&amp;ModPagespeedFilters=inline_import_to_link">example</a>.
+<a href="https://www.modpagespeed.com/examples/inline_import_to_link.html?ModPagespeed=on&amp;ModPagespeedFilters=inline_import_to_link">example</a>.
 </p>
 
 <h2>Risks</h2>

--- a/html/doc/filter-css-inline.html
+++ b/html/doc/filter-css-inline.html
@@ -115,7 +115,7 @@ contents inline in the HTML document.
 <h3>Example</h3>
 <p>
 You can see the filter in action at <code>www.modpagespeed.com</code> on this
-<a href="http://www.modpagespeed.com/inline_css.html?ModPagespeed=on&amp;ModPagespeedFilters=inline_css">example</a>.
+<a href="https://www.modpagespeed.com/examples/inline_css.html?ModPagespeed=on&amp;ModPagespeedFilters=inline_css">example</a>.
 </p>
 
 <h2>Note</h2>

--- a/html/doc/filter-css-outline.html
+++ b/html/doc/filter-css-outline.html
@@ -114,7 +114,7 @@ And a new CSS file (<code>of.HASH.css</code>) will be:
 <h3>Example</h3>
 <p>
 You can see the filter in action at <code>www.modpagespeed.com</code> on this
-<a href="http://www.modpagespeed.com/outline_css.html?ModPagespeed=on&amp;ModPagespeedFilters=outline_css">example</a>.
+<a href="https://www.modpagespeed.com/examples/outline_css.html?ModPagespeed=on&amp;ModPagespeedFilters=outline_css">example</a>.
 </p>
 
 <h2>Pros and Cons</h2>

--- a/html/doc/filter-css-rewrite.html
+++ b/html/doc/filter-css-rewrite.html
@@ -157,10 +157,10 @@ under the License.
 <h3>Online Example</h3>
 <p>
   You can see the filter in action at <code>www.modpagespeed.com</code> for
-  <a href="http://www.modpagespeed.com/rewrite_css.html?ModPagespeed=on&amp;ModPagespeedFilters=rewrite_css">CSS minification</a>,
-  <a href="http://www.modpagespeed.com/rewrite_css_images.html?ModPagespeed=on&amp;ModPagespeedFilters=rewrite_css,extend_cache">cache-extending images in CSS</a>,
-  <a href="http://www.modpagespeed.com/rewrite_css_images.html?ModPagespeed=on&amp;ModPagespeedFilters=rewrite_css,rewrite_images">rewriting images in CSS</a> and
-  <a href="http://www.modpagespeed.com/fallback_rewrite_css_urls.html?ModPagespeed=on&amp;ModPagespeedFilters=fallback_rewrite_css_urls,rewrite_css,rewrite_images">fallback rewriting of images in CSS</a>.
+  <a href="https://www.modpagespeed.com/examples/rewrite_css.html?ModPagespeed=on&amp;ModPagespeedFilters=rewrite_css">CSS minification</a>,
+  <a href="https://www.modpagespeed.com/examples/rewrite_css_images.html?ModPagespeed=on&amp;ModPagespeedFilters=rewrite_css,extend_cache">cache-extending images in CSS</a>,
+  <a href="https://www.modpagespeed.com/examples/rewrite_css_images.html?ModPagespeed=on&amp;ModPagespeedFilters=rewrite_css,rewrite_images">rewriting images in CSS</a> and
+  <a href="https://www.modpagespeed.com/examples/fallback_rewrite_css_urls.html?ModPagespeed=on&amp;ModPagespeedFilters=fallback_rewrite_css_urls,rewrite_css,rewrite_images">fallback rewriting of images in CSS</a>.
 </p>
 
 <h2>Requirements</h2>

--- a/html/doc/filter-css-to-head.html
+++ b/html/doc/filter-css-to-head.html
@@ -114,7 +114,7 @@ For example, if the HTML document looks like this:
 <h3>Example</h3>
 <p>
   You can see the filter in action at <code>www.modpagespeed.com</code> on this
-  <a href="http://www.modpagespeed.com/move_css_to_head.html?ModPagespeed=on&amp;ModPagespeedFilters=move_css_to_head">example</a>.
+  <a href="https://www.modpagespeed.com/examples/move_css_to_head.html?ModPagespeed=on&amp;ModPagespeedFilters=move_css_to_head">example</a>.
 </p>
 
 <h2>Limitations</h2>

--- a/html/doc/filter-dedup-inlined-images.html
+++ b/html/doc/filter-dedup-inlined-images.html
@@ -83,9 +83,9 @@ in the configuration file.
 <h3>Example</h3>
 <p>
   The effect of this filter can be observed on modpagespeed.com
-  <a href="http://www.modpagespeed.com/dedup_inlined_images.html?ModPagespeed=off">before</a>
+  <a href="https://www.modpagespeed.com/examples/dedup_inlined_images.html?ModPagespeed=off">before</a>
   and
-  <a href="http://www.modpagespeed.com/dedup_inlined_images.html?ModPagespeed=on&ModPagespeedFilters=inline_images,dedup_inlined_images">after</a>
+  <a href="https://www.modpagespeed.com/examples/dedup_inlined_images.html?ModPagespeed=on&ModPagespeedFilters=inline_images,dedup_inlined_images">after</a>
   rewriting.
 </p>
 

--- a/html/doc/filter-flatten-css-imports.html
+++ b/html/doc/filter-flatten-css-imports.html
@@ -129,9 +129,9 @@ in the configuration file.
 <h3>Example</h3>
 <p>
   The effect of this filter can be observed on modpagespeed.com
-  <a href="http://www.modpagespeed.com/flatten_css_imports.html?ModPagespeed=off">before</a>
+  <a href="https://www.modpagespeed.com/examples/flatten_css_imports.html?ModPagespeed=off">before</a>
   and
-  <a href="http://www.modpagespeed.com/flatten_css_imports.html?ModPagespeed=on&ModPagespeedFilters=rewrite_css,flatten_css_imports">after</a>
+  <a href="https://www.modpagespeed.com/examples/flatten_css_imports.html?ModPagespeed=on&ModPagespeedFilters=rewrite_css,flatten_css_imports">after</a>
   rewriting.
 </p>
 

--- a/html/doc/filter-head-combine.html
+++ b/html/doc/filter-head-combine.html
@@ -104,7 +104,7 @@ Then PageSpeed will rewrite it into:
 <h3>Example</h3>
 <p>
 You can see the filter in action at <code>www.modpagespeed.com</code> on this
-<a href="http://www.modpagespeed.com/combine_heads.html?ModPagespeed=on&amp;ModPagespeedFilters=combine_heads">example</a>.
+<a href="https://www.modpagespeed.com/examples/combine_heads.html?ModPagespeed=on&amp;ModPagespeedFilters=combine_heads">example</a>.
 </p>
 
 <h2>Limitations</h2>

--- a/html/doc/filter-hint-preload-subresources.html
+++ b/html/doc/filter-hint-preload-subresources.html
@@ -87,7 +87,7 @@ link: &lt;/script.js&gt;; rel=preload; as=script; nopush
 <h3>Example</h3>
 <p>
   You can see the filter in action at <code>www.modpagespeed.com</code> on this
-  <a href="http://www.modpagespeed.com/hint_preload_subresources.html?PageSpeed=on&amp;PageSpeedFilters=hint_preload_subresources">example</a>.
+  <a href="https://www.modpagespeed.com/examples/hint_preload_subresources.html?PageSpeed=on&amp;PageSpeedFilters=hint_preload_subresources">example</a>.
 </p>
 
 <h2>Limitations</h2>

--- a/html/doc/filter-image-responsive.html
+++ b/html/doc/filter-image-responsive.html
@@ -105,7 +105,7 @@ under the License.
 
 <h3>Online Example</h3>
 <p>
-  You can see the filter in action at <a href="http://www.modpagespeed.com/responsive_images.html?PageSpeed=on&amp;PageSpeedFilters=responsive_images,responsive_images_zoom,rewrite_images,inline_images,resize_images,insert_image_dimensions"><code>www.modpagespeed.com</code></a>.
+  You can see the filter in action at <a href="https://www.modpagespeed.com/examples/responsive_images.html?PageSpeed=on&amp;PageSpeedFilters=responsive_images,responsive_images_zoom,rewrite_images,inline_images,resize_images,insert_image_dimensions"><code>www.modpagespeed.com</code></a>.
 </p>
 
 <h2>Limitations</h2>

--- a/html/doc/filter-image-sprite.html
+++ b/html/doc/filter-image-sprite.html
@@ -111,7 +111,7 @@ Then <code>sprite_images</code> will rewrite the css into something like this:
         }
 </pre>
 <p>
-You can see the filter in action at <a href="http://www.modpagespeed.com/sprite_images.html?ModPagespeed=on&ModPagespeedFilters=rewrite_css,sprite_images"><code>www.modpagespeed.com</code></a>.
+You can see the filter in action at <a href="https://www.modpagespeed.com/examples/sprite_images.html?ModPagespeed=on&ModPagespeedFilters=rewrite_css,sprite_images"><code>www.modpagespeed.com</code></a>.
 </p>
 
 <h2>Limitations</h2>

--- a/html/doc/filter-inline-preview-images.html
+++ b/html/doc/filter-inline-preview-images.html
@@ -127,9 +127,9 @@ above.
 <p>
 You can see the Inline Preview Images filter in action
 at <code>www.modpagespeed.com</code> on this
-<a href="http://www.modpagespeed.com/inline_preview_images.html?ModPagespeed=on&amp;ModPagespeedFilters=inline_preview_images">example</a>.
+<a href="https://www.modpagespeed.com/examples/inline_preview_images.html?ModPagespeed=on&amp;ModPagespeedFilters=inline_preview_images">example</a>.
 You can also see this
-<a href="http://www.modpagespeed.com/resize_mobile_images.html?ModPagespeed=on&ModPagespeedFilters=resize_mobile_images,insert_image_dimensions">example</a>
+<a href="https://www.modpagespeed.com/examples/resize_mobile_images.html?ModPagespeed=on&ModPagespeedFilters=resize_mobile_images,insert_image_dimensions">example</a>
 of the Resize Mobile Images filter.
 </p>
 

--- a/html/doc/filter-instrumentation-add.html
+++ b/html/doc/filter-instrumentation-add.html
@@ -86,7 +86,7 @@ readability):
 <h3>Example</h3>
 <p>
 You can see the filter in action at <code>www.modpagespeed.com</code> on this
-<a href="http://www.modpagespeed.com/add_instrumentation.html?ModPagespeed=on&amp;ModPagespeedFilters=add_instrumentation">example</a>.
+<a href="https://www.modpagespeed.com/examples/add_instrumentation.html?ModPagespeed=on&amp;ModPagespeedFilters=add_instrumentation">example</a>.
 </p>
 
 <h2>Methodology</h2>

--- a/html/doc/filter-js-combine.html
+++ b/html/doc/filter-js-combine.html
@@ -59,7 +59,7 @@ reduces the number of round-trip times.
 <h2>Example</h2>
 <p>
 You can see the filter in action at <code>www.modpagespeed.com</code> on this
-<a href="http://www.modpagespeed.com/combine_javascript.html?ModPagespeed=on&ModPagespeedFilters=combine_javascript">example</a>.
+<a href="https://www.modpagespeed.com/examples/combine_javascript.html?ModPagespeed=on&ModPagespeedFilters=combine_javascript">example</a>.
 </p>
 
 <h2>Parameters that affect JS combining</h2>

--- a/html/doc/filter-js-defer.html
+++ b/html/doc/filter-js-defer.html
@@ -75,10 +75,10 @@ as a slideshow of images in the visible content of the page.  Usage:
 <h3>Example</h3>
 <p>
 The effect of this filter can be observed on modpagespeed.com
-<a href="http://www.modpagespeed.com/defer_javascript.html?ModPagespeed=off"
+<a href="https://www.modpagespeed.com/examples/defer_javascript.html?ModPagespeed=off"
 >before</a>
 and
-<a href="http://www.modpagespeed.com/defer_javascript.html?ModPagespeed=on&ModPagespeedFilters=defer_javascript">after</a>
+<a href="https://www.modpagespeed.com/examples/defer_javascript.html?ModPagespeed=on&ModPagespeedFilters=defer_javascript">after</a>
 rewriting.
 </p>
 

--- a/html/doc/filter-js-inline.html
+++ b/html/doc/filter-js-inline.html
@@ -111,7 +111,7 @@ it inline in the HTML document.
 <h3>Example</h3>
 <p>
 You can see the filter in action at <code>www.modpagespeed.com</code> on this
-<a href="http://www.modpagespeed.com/inline_javascript.html?ModPagespeed=on&amp;ModPagespeedFilters=inline_javascript">example</a>.
+<a href="https://www.modpagespeed.com/examples/inline_javascript.html?ModPagespeed=on&amp;ModPagespeedFilters=inline_javascript">example</a>.
 </p>
 
 <h2>Requirements</h2>

--- a/html/doc/filter-js-minify.html
+++ b/html/doc/filter-js-minify.html
@@ -171,7 +171,7 @@ document.write("External "+state);state+=1;
 <h3>Example</h3>
 <p>
 You can see the filter in action at <code>www.modpagespeed.com</code> on this
-<a href="http://www.modpagespeed.com/rewrite_javascript.html?ModPagespeed=on&amp;ModPagespeedFilters=rewrite_javascript">example</a>.
+<a href="https://www.modpagespeed.com/examples/rewrite_javascript.html?ModPagespeed=on&amp;ModPagespeedFilters=rewrite_javascript">example</a>.
 </p>
 
 <h2>Requirements</h2>

--- a/html/doc/filter-js-outline.html
+++ b/html/doc/filter-js-outline.html
@@ -106,7 +106,7 @@ And the new JavaScript file (<code>_.pagespeed.jo.tXBSxcB8mn.js</code>) will be:
 <h3>Example</h3>
 <p>
 You can see the filter in action at <code>www.modpagespeed.com</code> on this
-<a href="http://www.modpagespeed.com/outline_javascript.html?ModPagespeed=on&amp;ModPagespeedFilters=outline_javascript">example</a>.
+<a href="https://www.modpagespeed.com/examples/outline_javascript.html?ModPagespeed=on&amp;ModPagespeedFilters=outline_javascript">example</a>.
 </p>
 
 <h2>Pros and Cons</h2>

--- a/html/doc/filter-lazyload-images.html
+++ b/html/doc/filter-lazyload-images.html
@@ -157,10 +157,10 @@ JavaScript and will revert to lazily loading all images.
 <p>
 The effect of this filter can be observed by comparing the
 number of requests <a
-  href="http://www.modpagespeed.com/lazyload_images.html?ModPagespeed=off">
+  href="https://www.modpagespeed.com/examples/lazyload_images.html?ModPagespeed=off">
   before</a>
 and <a
-  href="http://www.modpagespeed.com/lazyload_images.html?ModPagespeed=on&ModPagespeedFilters=lazyload_images">
+  href="https://www.modpagespeed.com/examples/lazyload_images.html?ModPagespeed=on&ModPagespeedFilters=lazyload_images">
   after</a> rewriting.
 As you scroll down, you will notice that images below the fold are only
 requested after they become visible in the viewport.

--- a/html/doc/filter-local-storage-cache.html
+++ b/html/doc/filter-local-storage-cache.html
@@ -108,7 +108,7 @@ The attributes added to inlined resources are:
 <h3>Online Example</h3>
 <p>
 You can see the filter in action at <code>www.modpagespeed.com</code> on this
-<a href="http://www.modpagespeed.com/local_storage_cache.html?ModPagespeed=on&amp;ModPagespeedFilters=local_storage_cache,inline_css,inline_images">example</a>.
+<a href="https://www.modpagespeed.com/examples/local_storage_cache.html?ModPagespeed=on&amp;ModPagespeedFilters=local_storage_cache,inline_css,inline_images">example</a>.
 </p>
 
 <h2>Requirements</h2>

--- a/html/doc/filter-make-google-analytics-async.html
+++ b/html/doc/filter-make-google-analytics-async.html
@@ -125,7 +125,7 @@ under the License.
 <h3>Example</h3>
 <p>
   You can see the filter in action at <code>www.modpagespeed.com</code> on this
-  <a href="http://www.modpagespeed.com/make_google_analytics_async.html?ModPagespeed=on&amp;ModPagespeedFilters=make_google_analytics_async">example</a>.
+  <a href="https://www.modpagespeed.com/examples/make_google_analytics_async.html?ModPagespeed=on&amp;ModPagespeedFilters=make_google_analytics_async">example</a>.
 </p>
 
 

--- a/html/doc/filter-make-show-ads-async.html
+++ b/html/doc/filter-make-show-ads-async.html
@@ -125,7 +125,7 @@ under the License.
 <h3>Example</h3>
 <p>
   You can see the filter in action at <code>www.modpagespeed.com</code> on this
-  <a href="http://www.modpagespeed.com/make_show_ads_async.html?ModPagespeed=on&amp;ModPagespeedFilters=make_show_ads_async">example</a>.
+  <a href="https://www.modpagespeed.com/examples/make_show_ads_async.html?ModPagespeed=on&amp;ModPagespeedFilters=make_show_ads_async">example</a>.
 </p>
 
 

--- a/html/doc/filter-pedantic.html
+++ b/html/doc/filter-pedantic.html
@@ -67,7 +67,7 @@ such as: '<code>?ModPagespeedFilters=+pedantic</code>'.
 <p>
 You can see the filter in action at <code>www.modpagespeed.com</code> on
 this <a
-href="http://www.modpagespeed.com/pedantic.html?ModPagespeed=on&amp;ModPagespeedFilters=pedantic"
+href="https://www.modpagespeed.com/examples/pedantic.html?ModPagespeed=on&amp;ModPagespeedFilters=pedantic"
 >example</a>.
 </p>
 

--- a/html/doc/filter-prioritize-critical-css.html
+++ b/html/doc/filter-prioritize-critical-css.html
@@ -115,7 +115,7 @@ and <code>&lt;link&gt;</code> elements into the document through JavaScript.
 
 <p>
 The effect of this rewriter can be observed on modpagespeed.com <a
-  href="http://www.modpagespeed.com/prioritize_critical_css.html?ModPagespeed=off">
+  href="https://www.modpagespeed.com/examples/prioritize_critical_css.html?ModPagespeed=off">
   before</a> and <a
   href="http://modpagespeed.com/prioritize_critical_css.html?ModPagespeedFilters=+prioritize_critical_css">
   after</a> rewriting. You will need to reload the page a few times to see the

--- a/html/doc/filter-quote-remove.html
+++ b/html/doc/filter-quote-remove.html
@@ -84,7 +84,7 @@ Then PageSpeed will rewrite it into:
 <h3>Example</h3>
 <p>
 You can see the filter in action at <code>www.modpagespeed.com</code> on this
-<a href="http://www.modpagespeed.com/remove_quotes.html?ModPagespeed=on&amp;ModPagespeedFilters=remove_quotes">example</a>.
+<a href="https://www.modpagespeed.com/examples/remove_quotes.html?ModPagespeed=on&amp;ModPagespeedFilters=remove_quotes">example</a>.
 </p>
 
 <h2>Requirements</h2>

--- a/html/doc/filter-rewrite-style-attributes.html
+++ b/html/doc/filter-rewrite-style-attributes.html
@@ -101,7 +101,7 @@ like:
 <h3>Example</h3>
 <p>
 You can see the filter in action at <code>www.modpagespeed.com</code> on this
-<a href="http://www.modpagespeed.com/rewrite_style_attributes.html?ModPagespeed=on&amp;ModPagespeedFilters=rewrite_style_attributes_with_url,rewrite_css,rewrite_images">example</a>.
+<a href="https://www.modpagespeed.com/examples/rewrite_style_attributes.html?ModPagespeed=on&amp;ModPagespeedFilters=rewrite_style_attributes_with_url,rewrite_css,rewrite_images">example</a>.
 </p>
 
 <h2>Risks</h2>

--- a/html/doc/filter-trim-urls.html
+++ b/html/doc/filter-trim-urls.html
@@ -96,7 +96,7 @@ Then PageSpeed will rewrite it to:
 <h3>Example</h3>
 <p>
 You can see the filter in action at <code>www.modpagespeed.com</code> on this
-<a href="http://www.modpagespeed.com/trim_urls.html?ModPagespeed=on&amp;ModPagespeedFilters=trim_urls">example</a>.
+<a href="https://www.modpagespeed.com/examples/trim_urls.html?ModPagespeed=on&amp;ModPagespeedFilters=trim_urls">example</a>.
 </p>
 
 <h2>Requirements</h2>

--- a/html/doc/filter-whitespace-collapse.html
+++ b/html/doc/filter-whitespace-collapse.html
@@ -98,7 +98,7 @@ Hello, World!
 <h3>Example</h3>
 <p>
 You can see the filter in action at <code>www.modpagespeed.com</code> on this
-<a href="http://www.modpagespeed.com/collapse_whitespace.html?ModPagespeed=on&amp;ModPagespeedFilters=collapse_whitespace">example</a>.
+<a href="https://www.modpagespeed.com/examples/collapse_whitespace.html?ModPagespeed=on&amp;ModPagespeedFilters=collapse_whitespace">example</a>.
 </p>
 
 <h2>Requirements</h2>
@@ -124,9 +124,9 @@ normally ignored by the browser outside of tags like <code>&lt;pre&gt;
 </code> and <code>&lt;textarea&gt;</code>, one can use CSS properties
 such as <code>"white-space: pre"</code> to make the browser preserve
 whitespace within a portion of the document: compare this example
-<a href="http://www.modpagespeed.com/mod_pagespeed_example/css_whitespace.html?ModPagespeed=on&amp;ModPagespeedFilters=collapse_whitespace">with</a>
+<a href="https://www.modpagespeed.com/examples/mod_pagespeed_example/css_whitespace.html?ModPagespeed=on&amp;ModPagespeedFilters=collapse_whitespace">with</a>
 and
-<a href="http://www.modpagespeed.com/mod_pagespeed_example/css_whitespace.html?ModPagespeed=off">without</a>
+<a href="https://www.modpagespeed.com/examples/mod_pagespeed_example/css_whitespace.html?ModPagespeed=off">without</a>
 the filter enabled.
 </p>
 <p>


### PR DESCRIPTION
After the new index went live, the old index moved to /examples/
Fix the current bad links by pointing them to the new index.