### PR TITLE
Update .gitignore & .gitmodules 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ build/landmine_utils.pyc
 out/
 tools/closure/
 !devel/Makefile
+release/
+log/

--- a/.gitmodules
+++ b/.gitmodules
@@ -18,6 +18,7 @@
 	path = third_party/re2/src
 	url = https://github.com/google/re2.git
 [submodule "third_party/icu"]
+    ignore = untracked
 	path = third_party/icu
 	url = https://github.com/apache/incubator-pagespeed-icu.git
 [submodule "third_party/libjpeg_turbo/src"]
@@ -31,6 +32,8 @@
 [submodule "third_party/libpng/src"]
 	path = third_party/libpng/src
 	url = https://github.com/glennrp/libpng.git
+# We copy a prebuild header during the build process.
+   ignore = untracked
 [submodule "third_party/hiredis/src"]
 	path = third_party/hiredis/src
 	url = https://github.com/redis/hiredis.git
@@ -40,6 +43,7 @@
 [submodule "third_party/optipng"]
 	path = third_party/optipng
 	url = https://github.com/apache/incubator-pagespeed-optipng.git
+    ignore = untracked
 [submodule "third_party/libwebp"]
 	path = third_party/libwebp
 	url = https://chromium.googlesource.com/webm/libwebp.git

--- a/third_party/libpng/libpng.gyp
+++ b/third_party/libpng/libpng.gyp
@@ -26,7 +26,7 @@
             {
               'action_name': 'copy_libpngconf_prebuilt',
               'inputs' : [],
-              'outputs': ['<(DEPTH)/third_party/libpng/src/scripts/pnglibconf.h.prebuilt'],
+              'outputs': ['<(DEPTH)/third_party/libpng/src/pnglibconf.h'],
               'action': [
                 'cp',
                 '-f',

--- a/third_party/libpng/libpng.gyp
+++ b/third_party/libpng/libpng.gyp
@@ -25,8 +25,8 @@
           'actions': [
             {
               'action_name': 'copy_libpngconf_prebuilt',
-              'inputs' : ['<(DEPTH)/third_party/libpng/src/scripts/pnglibconf.h.prebuilt'],
-              'outputs': ['<(DEPTH)/third_party/libpng/src/pnglibconf.h'],
+              'inputs' : [],
+              'outputs': [''],
               'action': [
                 'cp',
                 '<(DEPTH)/third_party/libpng/src/scripts/pnglibconf.h.prebuilt',

--- a/third_party/libpng/libpng.gyp
+++ b/third_party/libpng/libpng.gyp
@@ -29,6 +29,7 @@
               'outputs': [''],
               'action': [
                 'cp',
+                '-f',
                 '<(DEPTH)/third_party/libpng/src/scripts/pnglibconf.h.prebuilt',
                 '<(DEPTH)/third_party/libpng/src/pnglibconf.h',
               ],

--- a/third_party/libpng/libpng.gyp
+++ b/third_party/libpng/libpng.gyp
@@ -25,11 +25,10 @@
           'actions': [
             {
               'action_name': 'copy_libpngconf_prebuilt',
-              'inputs' : [],
+              'inputs' : ['<(DEPTH)/third_party/libpng/src/scripts/pnglibconf.h.prebuilt'],
               'outputs': ['<(DEPTH)/third_party/libpng/src/pnglibconf.h'],
               'action': [
                 'cp',
-                '-f',
                 '<(DEPTH)/third_party/libpng/src/scripts/pnglibconf.h.prebuilt',
                 '<(DEPTH)/third_party/libpng/src/pnglibconf.h',
               ],

--- a/third_party/libpng/libpng.gyp
+++ b/third_party/libpng/libpng.gyp
@@ -26,7 +26,7 @@
             {
               'action_name': 'copy_libpngconf_prebuilt',
               'inputs' : [],
-              'outputs': [''],
+              'outputs': ['<(DEPTH)/third_party/libpng/src/scripts/pnglibconf.h.prebuilt'],
               'action': [
                 'cp',
                 '-f',


### PR DESCRIPTION
- Also, update .gitignore for log/ and release/
- Also, ignore some untracked content in external submodules to
  get a clean slate when running 'git status'

(this should fix running `install/build_release.sh --skip_psol --stable`)