### PR TITLE
Fix for release build failure during single thread execution

### DIFF
--- a/third_party/libpng/libpng.gyp
+++ b/third_party/libpng/libpng.gyp
@@ -18,7 +18,7 @@
       'targets': [
         {
           'target_name': 'libpng',
-          'type': '<(component)',
+          'type': 'static_library',
           'dependencies': [
             '../zlib/zlib.gyp:zlib',
           ],


### PR DESCRIPTION
This is related to #1739 
Fixes the issue for release build failure.
```
CXX(target) out/Release/obj.target/instaweb_spriter/net/instaweb/spriter/libpng_image_library.o
In file included from ./net/instaweb/spriter/libpng_image_library.h:32:0,
                 from net/instaweb/spriter/libpng_image_library.cc:20:
./third_party/libpng/src/png.h:361:27: fatal error: pnglibconf.h: No such file or directory
 #   include "pnglibconf.h"
                           ^
compilation terminated.
```