### PR TITLE
.gitmodules: update giflib remote uri

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -114,4 +114,4 @@
 	url = https://github.com/madler/zlib.git
 [submodule "third_party/giflib/src"]
 	path = third_party/giflib/src
-	url = https://git.code.sf.net/p/giflib/code
+	url = git://git.code.sf.net/p/giflib/code


### PR DESCRIPTION
sourceforge has been performing a datacenter migration, which resulted
in a service disruption.
Access via https:// is still broken, but via git:// it is working again.