### PR TITLE
Redis: Use Redis DB-Index when computing the SystemCache lookup key

### DIFF
--- a/install/debug.conf.template
+++ b/install/debug.conf.template
@@ -28,6 +28,7 @@ AddOutputFilterByType MOD_PAGESPEED_OUTPUT_FILTER application/xhtml+xml
 #REDIS
 #REDIS # Do testing using redis instead of file cache
 #REDIS ModPagespeedRedisServer localhost:@@REDIS_PORT@@
+#REDIS ModPagespeedRedisDatabaseIndex 2
 #EXTCACHE
 # If X-PSA-Blocking-Rewrite request header is present and its value matches the
 # value of ModPagespeedBlockingRewriteKey below, the response will be fully
@@ -534,7 +535,6 @@ NameVirtualHost localhost:@@APACHE_SECONDARY_PORT@@
   ModPagespeed on
   ModPagespeedFileCachePath            "@@MOD_PAGESPEED_CACHE@@_secondary"
   ModPagespeedCompressMetadataCache false
-
   ModPagespeedMapProxyDomain secondary.example.com/gstatic_images \
                              http://www.gstatic.com/psa/static
 
@@ -542,6 +542,7 @@ NameVirtualHost localhost:@@APACHE_SECONDARY_PORT@@
   # but with a different file-cache path.
 #MEMCACHED  ModPagespeedMemcachedServers localhost:@@MEMCACHED_PORT@@
 #REDIS  ModPagespeedRedisServer localhost:@@REDIS_PORT@@
+#REDIS  ModPagespeedRedisDatabaseIndex 3
 
   ModPagespeedCacheFlushFilename cache.flush
   # If you uncomment this, the test will fail, proving we can disable
@@ -1368,7 +1369,6 @@ ModPagespeedCreateSharedMemoryMetadataCache "@@MOD_PAGESPEED_CACHE@@_with_shm" 8
   ModPagespeedFileCachePath            "@@MOD_PAGESPEED_CACHE@@_lrud_lrum"
 #MEMCACHED  ModPagespeedMemcachedServers localhost:@@MEMCACHED_PORT@@
 #REDIS  ModPagespeedRedisServer localhost:@@REDIS_PORT@@
-
   ModPagespeedLRUCacheKbPerProcess 1024
   ModPagespeedLRUCacheByteLimit 2000
   ModPagespeedEnableFilters rewrite_images

--- a/pagespeed/system/system_caches.cc
+++ b/pagespeed/system/system_caches.cc
@@ -288,6 +288,7 @@ SystemCaches::ExternalCacheInterfaces SystemCaches::NewExternalCache(
   if (use_redis) {
     spec_signature =
         StrCat("r;", config->redis_server().ToString(), ";",
+               IntegerToString(config->redis_database_index()), ";",
                IntegerToString(config->redis_reconnection_delay_ms()), ";",
                IntegerToString(config->redis_timeout_us()));
   } else if (use_memcached) {

--- a/pagespeed/system/system_test.sh
+++ b/pagespeed/system/system_test.sh
@@ -174,3 +174,10 @@ run_test long_url_handling
 run_test controller_process_handling
 run_test strip_subresources
 run_test protocol_relative_urls
+
+# TODO(oschaaf): REDIS_PORT seems to be set when
+# redis actually isn't used in the system tests.
+# Fix that, and enable this test.
+#if [ "${REDIS_PORT:-0}" -ne 0 ]; then
+#    run_test redis
+#fi

--- a/pagespeed/system/system_tests/redis.sh
+++ b/pagespeed/system/system_tests/redis.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+start_test Redis database index respected
+
+# the default redis DB is not used, dbsize should equal 0
+OUT=$(echo -e 'DBSIZE' | redis-cli -p "${REDIS_PORT}")
+check [ "0" -eq "$OUT" ]
+# db #2 is primary, and should be non-0 at this point
+OUT=$(echo -e 'select 2 \n DBSIZE' | redis-cli -p "${REDIS_PORT}")
+check_from "$OUT" grep -Pzo 'OK\n[1-9]'
+
+# TODO(oschaaf): attempts to get the redis tests to run with the
+# secondary host available failed. The test above at least makes
+# sure that the setting that specifies db index 3 isn't used in
+# the primary host which uses db index 2.
+# db #3 is secondary, and should be non-0 at this point
+#RES=$(echo -e 'select 3 \n DBSIZE' | redis-cli -p "${REDIS_PORT}")
+#check_from "$OUT" grep -Pzo 'OK\n[1-9]'


### PR DESCRIPTION
The added test didn't turn out the way I planned to because of running into some unrelated
things (see the comment in the test script). 
The full checkin tests are still running, but I did observe the added test itself to pass.

Should fix https://github.com/apache/incubator-pagespeed-mod/issues/1771

