### PR TITLE
CI: fix hangs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -114,4 +114,5 @@
 	url = https://github.com/madler/zlib.git
 [submodule "third_party/giflib/src"]
 	path = third_party/giflib/src
-	url = git://git.code.sf.net/p/giflib/code
+	url = https://git.code.sf.net/p/giflib/code
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   # git.apache.org is the canonical repo but throttles network connections.
   # using github.com seems to reduce network errors a lot.
   - git config --global url.https://github.com/apache/.insteadOf git://git.apache.org/
-  - git submodule update --init --recursive --jobs=3
+  - git submodule update --init --recursive --jobs=2
 env:
   global:
     - MAKEFLAGS=-j3

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   # git.apache.org is the canonical repo but throttles network connections.
   # using github.com seems to reduce network errors a lot.
   - git config --global url.https://github.com/apache/.insteadOf git://git.apache.org/
-  - git submodule update --init --recursive --jobs=6
+  - git submodule update --init --recursive --jobs=3
 env:
   global:
     - MAKEFLAGS=-j3


### PR DESCRIPTION
The old https:// source of giflib is finally back up again after they moved datacenters. So let's point the submodule back to that. Also, let's reduce the amount of parallel submodule fetching as to not anger any rate limiting systems. Let's see if we'll be able to run the tests within timeout limit that we're given with these changes.
