### PR TITLE
Fix mismatch between decompression and headers

### DIFF
--- a/net/instaweb/rewriter/css_filter_test.cc
+++ b/net/instaweb/rewriter/css_filter_test.cc
@@ -412,6 +412,38 @@ TEST_F(CssFilterTestCustomOptions, CssPreserveUrlsNoPreemptiveRewrite) {
   EXPECT_EQ(kOutputStyle, out_css);
 }
 
+
+TEST_F(CssFilterTestCustomOptions, FallbackWithGzipData) {
+  const char kCss[] = " hello { display: block; border: 1px solid fuchsia; }";
+  options()->set_http_cache_compression_level(6);
+  // Force the fallback since rewrite is taking too long" path.
+  options()->set_test_instant_fetch_rewrite_deadline(true);
+  CssFilterTest::SetUp();
+
+  // Store an already-gzipped version of the resource in the cace.
+  ResponseHeaders headers;
+  DefaultResponseHeaders(kContentTypeCss, 5000, &headers);
+  HTTPValue value;
+  value.SetHeaders(&headers);
+  value.Write(kCss, message_handler());
+  http_cache()->Put("http://test.com/a.css", rewrite_driver()->CacheFragment(),
+                    RequestHeaders::Properties(),  kDefaultHttpOptionsForTests,
+                    &value, message_handler());
+
+  // Fetch with deadline exceeded. Should get uncompressed bits with proper
+  // content-length. (Consistency of compression, Content-Encoding and
+  // Content-Length is what's important here).
+  GoogleString out_css_url = Encode(kTestDomain, "cf", "0", "a.css", "css");
+  GoogleString out_css;
+  ResponseHeaders out_headers;
+  EXPECT_TRUE(FetchResourceUrl(out_css_url, &out_css, &out_headers));
+  EXPECT_EQ(kCss, out_css);
+  int64 content_length = 0;
+  EXPECT_TRUE(out_headers.FindContentLength(&content_length));
+  EXPECT_EQ(STATIC_STRLEN(kCss), content_length);
+  EXPECT_FALSE(out_headers.IsGzipped());
+}
+
 TEST_F(CssFilterTest, LinkHrefCaseInsensitive) {
   // Make sure we check rel value case insensitively.
   // http://github.com/pagespeed/mod_pagespeed/issues/354

--- a/net/instaweb/rewriter/resource.cc
+++ b/net/instaweb/rewriter/resource.cc
@@ -62,7 +62,7 @@ Resource::Resource(const RewriteDriver* driver, const ContentType* type)
       disable_rewrite_on_no_transform_(true),
       is_authorized_domain_(true),
       respect_vary_(ResponseHeaders::kRespectVaryOnResources),
-      extracted_(false) {
+      extracted_state_(kExtractNotComputed) {
 }
 
 Resource::Resource() : server_context_(NULL), type_(NULL),
@@ -74,7 +74,7 @@ Resource::Resource() : server_context_(NULL), type_(NULL),
                        disable_rewrite_on_no_transform_(true),
                        is_authorized_domain_(true),
                        respect_vary_(ResponseHeaders::kRespectVaryOnResources),
-                       extracted_(false) {
+                       extracted_state_(kExtractNotComputed)  {
 }
 
 Resource::~Resource() {
@@ -256,8 +256,9 @@ bool Resource::Link(HTTPValue* value, MessageHandler* handler) {
   DCHECK(UseHttpCache());
   const SharedString& contents_and_headers = value->share();
   // Invalidate extracted_contents_.
-  extracted_ = false;
+  extracted_state_ = kExtractNotComputed;
   extracted_contents_.clear();
+  extracted_headers_ = nullptr;
   return value_.Link(contents_and_headers, &response_headers_, handler);
 }
 
@@ -269,17 +270,38 @@ void Resource::LinkFallbackValue(HTTPValue* value) {
 }
 
 StringPiece Resource::ExtractUncompressedContents() const {
-  ResponseHeaders headers;
-  if (!extracted_ && value_.ExtractHeaders(&headers, NULL)) {
-    if (headers.IsGzipped()) {
-      StringWriter inflate_writer(&extracted_contents_);
-      if (GzipInflater::Inflate(raw_contents(), GzipInflater::kGzip,
-                                &inflate_writer)) {
-        extracted_ = true;
-      }
+  bool use_extracted = EnsureExtractedIfNeeded();
+  return use_extracted ? extracted_contents_ : raw_contents();
+}
+
+const ResponseHeaders* Resource::UncompressedHeaders() const {
+  bool use_extracted = EnsureExtractedIfNeeded();
+  return use_extracted ? extracted_headers_.get() : response_headers();
+}
+
+bool Resource::EnsureExtractedIfNeeded() const {
+  if (extracted_state_ == kExtractNotComputed) {
+    if (!response_headers_.IsGzipped()) {
+      extracted_state_ = kExtractUseBase;
+      return false;
+    }
+
+    StringWriter inflate_writer(&extracted_contents_);
+    if (GzipInflater::Inflate(raw_contents(), GzipInflater::kGzip,
+                              &inflate_writer)) {
+      extracted_state_ = kExtractUseExtracted;
+      extracted_headers_.reset(new ResponseHeaders());
+      extracted_headers_->CopyFrom(response_headers_);
+      extracted_headers_->Remove(HttpAttributes::kContentEncoding,
+                                 HttpAttributes::kGzip);
+      extracted_headers_->SetContentLength(extracted_contents_.length());
+      extracted_headers_->ComputeCaching();
+    } else {
+      // Prevent repeated attempts on broken input.
+      extracted_state_ = kExtractUseBase;
     }
   }
-  return extracted_ ? extracted_contents_ : raw_contents();
+  return (extracted_state_ == kExtractUseExtracted);
 }
 
 void Resource::Freshen(FreshenCallback* callback, MessageHandler* handler) {

--- a/net/instaweb/rewriter/rewrite_context.cc
+++ b/net/instaweb/rewriter/rewrite_context.cc
@@ -751,7 +751,7 @@ class RewriteContext::FetchContext {
         kInfo, "Deadline exceeded for rewrite of resource %s with %s.",
         input->UrlForDebug().c_str(), rewrite_context_->id());
     FetchFallbackDoneImpl(input->ExtractUncompressedContents(),
-                          input->response_headers());
+                          input->UncompressedHeaders());
   }
 
   // Note that the callback is called from the RewriteThread.


### PR DESCRIPTION
Fix mismatch between headers and demand-uncompressed payload when hitting rewrite deadline with gzip'ed input.

Believed to fix issue 1556
