### PR TITLE
Added support for specifying a TTL for redis keys (Fixes #1704)

### DIFF
--- a/html/doc/system.html
+++ b/html/doc/system.html
@@ -506,6 +506,16 @@ total_items:           4166384
   <dt>Nginx:<dd><pre class="prettyprint"
      >pagespeed RedisDatabaseIndex index;</pre>
 </dl>
+    <p>
+      You can set an expiration time (or TTL) in seconds for the Redis keys.
+      The setting defaults to -1 meaning that the keys will never expire and can be specified like this:
+    </p>
+<dl>
+  <dt>Apache:<dd><pre class="prettyprint"
+    >ModPagespeedRedisTTLSec ttl_in_seconds</pre>
+  <dt>Nginx:<dd><pre class="prettyprint"
+    >pagespeed RedisTTLSec ttl_in_seconds;</pre>
+</dl>
 
     <h2 id="flush_cache">Flushing PageSpeed Server-Side Cache</h2>
     <p>

--- a/install/debug.conf.template
+++ b/install/debug.conf.template
@@ -29,6 +29,7 @@ AddOutputFilterByType MOD_PAGESPEED_OUTPUT_FILTER application/xhtml+xml
 #REDIS # Do testing using redis instead of file cache
 #REDIS ModPagespeedRedisServer localhost:@@REDIS_PORT@@
 #REDIS ModPagespeedRedisDatabaseIndex 2
+#REDIS ModPagespeedRedisTTLSec 300
 #EXTCACHE
 # If X-PSA-Blocking-Rewrite request header is present and its value matches the
 # value of ModPagespeedBlockingRewriteKey below, the response will be fully
@@ -2252,6 +2253,7 @@ AddType application/javascript .js
 #ALL_DIRECTIVES ModPagespeedRedisReconnectionDelayMs 1000
 #ALL_DIRECTIVES ModPagespeedRedisTimeoutUs 50000
 #ALL_DIRECTIVES ModPagespeedRedisDatabaseIndex 0
+#ALL_DIRECTIVES ModPagespeedRedisTTLSec -1
 #ALL_DIRECTIVES ModPagespeedReportUnloadTime true
 #ALL_DIRECTIVES ModPagespeedRespectVary true
 #ALL_DIRECTIVES ModPagespeedRespectXForwardedProto off

--- a/pagespeed/system/redis_cache.h
+++ b/pagespeed/system/redis_cache.h
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -82,7 +82,7 @@ class RedisCache : public CacheInterface {
   RedisCache(StringPiece host, int port, ThreadSystem* thread_system,
              MessageHandler* message_handler, Timer* timer,
              int64 reconnection_delay_ms, int64 timeout_us,
-             Statistics* stats, int database_index);
+             Statistics* stats, int database_index, int ttl_sec);
   ~RedisCache() override { ShutDown(); }
 
   static void InitStats(Statistics* stats);
@@ -282,6 +282,7 @@ class RedisCache : public CacheInterface {
   Connection* main_connection_;
 
   const int database_index_;
+  const int ttl_sec_;
 
   friend class RedisCacheTest;
   DISALLOW_COPY_AND_ASSIGN(RedisCache);

--- a/pagespeed/system/redis_cache_cluster_test.cc
+++ b/pagespeed/system/redis_cache_cluster_test.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -50,6 +50,7 @@ namespace {
   static const int kTimeoutUs = 100 * Timer::kMsUs;
   static const int kSlaveNodesFlushingTimeoutMs = 1000;
   static const int kDatabaseIndex = 0;
+  static const int kTTLSec = -1;
 
   // One can check following constants with CLUSTER KEYSLOT command.
   // For testing purposes, both KEY and {}KEY should be in the same slot range.
@@ -104,7 +105,8 @@ class RedisCacheClusterTest : public CacheTestBase {
     // Setting up cache.
     cache_.reset(new RedisCache("localhost", ports_[0], thread_system_.get(),
                                 &handler_, &timer_, kReconnectionDelayMs,
-                                kTimeoutUs, &statistics_, kDatabaseIndex));
+                                kTimeoutUs, &statistics_, kDatabaseIndex,
+                                kTTLSec));
     cache_->StartUp();
     return true;
   }

--- a/pagespeed/system/redis_cache_test.cc
+++ b/pagespeed/system/redis_cache_test.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -48,6 +48,7 @@ namespace {
   static const int kReconnectionDelayMs = 10;
   static const int kTimeoutUs = 100 * Timer::kMsUs;
   static const int kDatabaseIndex[] = {0, 1};
+  static const int kTTLSec = -1;
   static const char kSomeKey[] = "SomeKey";
   static const char kSomeValue[] = "SomeValue";
 }
@@ -93,7 +94,7 @@ class RedisCacheTest : public CacheTestBase {
     cache_.emplace_back(new RedisCache("localhost", redis_port_env_,
                             thread_system_.get(), &handler_, &timer_,
                             kReconnectionDelayMs, kTimeoutUs, &statistics_,
-                            database_index));
+                            database_index, kTTLSec));
     cache_.back()->StartUp();
   }
 
@@ -101,7 +102,7 @@ class RedisCacheTest : public CacheTestBase {
     cache_.emplace_back(new RedisCache("localhost", custom_server_port_,
                                 thread_system_.get(), &handler_, &timer_,
                                 kReconnectionDelayMs, kTimeoutUs,
-                                &statistics_, kDatabaseIndex[0]));
+                                &statistics_, kDatabaseIndex[0], kTTLSec));
   }
 
   void InitRedisWithUnreachableServer() {
@@ -110,7 +111,8 @@ class RedisCacheTest : public CacheTestBase {
     // machine should ever be routable in that subnet.
     cache_.emplace_back(new RedisCache("192.0.2.1", 12345, thread_system_.get(),
                                 &handler_, &timer_, kReconnectionDelayMs,
-                                kTimeoutUs, &statistics_, kDatabaseIndex[0]));
+                                kTimeoutUs, &statistics_, kDatabaseIndex[0],
+                                kTTLSec));
   }
 
   static void SetUpTestCase() {

--- a/pagespeed/system/system_caches.cc
+++ b/pagespeed/system/system_caches.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -247,11 +247,13 @@ SystemCaches::ExternalCacheInterfaces SystemCaches::NewRedis(
   // using database index -1 when property not specified in config
   const int redis_database_index =
       config->has_redis_database_index() ? config->redis_database_index() : -1;
+  const int redis_ttl_sec =
+      config->has_redis_ttl_sec() ? config->redis_ttl_sec() : -1;
   RedisCache* redis_server = new RedisCache(
       server_spec.host, server_spec.port, factory_->thread_system(),
       factory_->message_handler(), factory_->timer(),
       config->redis_reconnection_delay_ms(), config->redis_timeout_us(),
-      factory_->statistics(), redis_database_index);
+      factory_->statistics(), redis_database_index, redis_ttl_sec);
   factory_->TakeOwnership(redis_server);
   redis_servers_.push_back(redis_server);
   if (redis_pool_.get() == NULL) {
@@ -290,7 +292,8 @@ SystemCaches::ExternalCacheInterfaces SystemCaches::NewExternalCache(
         StrCat("r;", config->redis_server().ToString(), ";",
                IntegerToString(config->redis_database_index()), ";",
                IntegerToString(config->redis_reconnection_delay_ms()), ";",
-               IntegerToString(config->redis_timeout_us()));
+               IntegerToString(config->redis_timeout_us()), ";",
+               IntegerToString(config->redis_ttl_sec()));
   } else if (use_memcached) {
     spec_signature = StrCat("m;", config->memcached_servers().ToString(), ";",
                             IntegerToString(config->memcached_threads()), ";",

--- a/pagespeed/system/system_rewrite_options.cc
+++ b/pagespeed/system/system_rewrite_options.cc
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -37,6 +37,7 @@ namespace {
 
 const int64 kDefaultCacheFlushIntervalSec = 5;
 const int64 kDefaultRedisDatabaseIndex = 0;
+const int64 kDefaultRedisTTLSec = -1;
 
 const char kFetchHttps[] = "FetchHttps";
 
@@ -55,6 +56,7 @@ const char SystemRewriteOptions::kRedisReconnectionDelayMs[] =
 const char SystemRewriteOptions::kRedisTimeoutUs[] = "RedisTimeoutUs";
 const char SystemRewriteOptions::kRedisDatabaseIndex[] =
     "RedisDatabaseIndex";
+const char SystemRewriteOptions::kRedisTTLSec[] = "RedisTTLSec";
 
 RewriteOptions::Properties* SystemRewriteOptions::system_properties_ = nullptr;
 
@@ -134,6 +136,11 @@ void SystemRewriteOptions::AddProperties() {
                     &SystemRewriteOptions::redis_database_index_, "rdi",
                     SystemRewriteOptions::kRedisDatabaseIndex,
                     "Redis server database index selection",
+                    true);
+  AddSystemProperty(kDefaultRedisTTLSec,
+                    &SystemRewriteOptions::redis_ttl_sec_, "rdx",
+                    SystemRewriteOptions::kRedisTTLSec,
+                    "Redis key TTL to use (seconds)",
                     true);
   AddSystemProperty(50 * Timer::kMsUs,  // 50 ms
                     &SystemRewriteOptions::slow_file_latency_threshold_us_,

--- a/pagespeed/system/system_rewrite_options.h
+++ b/pagespeed/system/system_rewrite_options.h
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -53,6 +53,7 @@ class SystemRewriteOptions : public RewriteOptions {
   static const char kRedisReconnectionDelayMs[];
   static const char kRedisTimeoutUs[];
   static const char kRedisDatabaseIndex[];
+  static const char kRedisTTLSec[];
 
   static constexpr int kMemcachedDefaultPort = 11211;
   static constexpr int kRedisDefaultPort = 6379;
@@ -197,6 +198,12 @@ class SystemRewriteOptions : public RewriteOptions {
   }
   bool has_redis_database_index() const {
     return redis_database_index_.was_set();
+  }
+  int redis_ttl_sec() const {
+    return redis_ttl_sec_.value();
+  }
+  bool has_redis_ttl_sec() const {
+    return redis_ttl_sec_.was_set();
   }
   int64 slow_file_latency_threshold_us() const {
     return slow_file_latency_threshold_us_.value();
@@ -511,6 +518,7 @@ class SystemRewriteOptions : public RewriteOptions {
   Option<int64> redis_reconnection_delay_ms_;
   Option<int64> redis_timeout_us_;
   Option<int> redis_database_index_;
+  Option<int> redis_ttl_sec_;
 
   Option<int64> slow_file_latency_threshold_us_;
   Option<int64> file_cache_clean_inode_limit_;


### PR DESCRIPTION
This is an attempt at implementing support for setting an expiration time to redis keys.
Issue #1704 describes the problem that this is trying to solve.

I have not developed in C++ in years and am not too familiar with the pagespeed codebase but I hope this is fine.