### PR TITLE
remove id attributes from styles

### DIFF
--- a/html/doc/build_mod_pagespeed_from_source.html
+++ b/html/doc/build_mod_pagespeed_from_source.html
@@ -56,7 +56,7 @@ To install these on Debian or Ubuntu run:
 On CentOS, run:
 </p>
 <pre>
-  sudo yum install httpd gcc-c++ python subversion gperf make rpm-build git curl zlib-devel libuuid-devel
+  sudo yum install httpd gcc-c++ python subversion gperf make rpm-build git curl zlib-devel libuuid-devel libstdc++-static
 </pre>
 <p>
 CentOS 5 does not include git in its repositories. If you are running CentOS 5

--- a/net/instaweb/rewriter/critical_css_loader.js
+++ b/net/instaweb/rewriter/critical_css_loader.js
@@ -42,12 +42,12 @@ pagespeed.CriticalCssLoader.addAllStyles = function() {
     
   for (var i = 0, e; e = elements[i]; ++i) {
     if (e.nodeName == 'NOSCRIPT') { 
-       var div = document.createElement('div');
-       div.innerHTML = e.textContent;
-       var children = div.childNodes;
-       for (var v = 0; v < children.length; ++v) {
-           children[v].removeAttribute('id');
-       }  
+      var div = document.createElement('div');
+      div.innerHTML = e.textContent;
+      var children = div.childNodes;
+      for (var v = 0; v < children.length; ++v) {
+    children[v].removeAttribute('id');
+    }  
     document.body.appendChild(div);
     }
  }

--- a/net/instaweb/rewriter/critical_css_loader.js
+++ b/net/instaweb/rewriter/critical_css_loader.js
@@ -46,11 +46,11 @@ pagespeed.CriticalCssLoader.addAllStyles = function() {
       div.innerHTML = e.textContent;
       var children = div.childNodes;
       for (var v = 0; v < children.length; ++v) {
-    children[v].removeAttribute('id');
-    }  
-    document.body.appendChild(div);
+        children[v].removeAttribute('id');
+      }  
+      document.body.appendChild(div);
     }
- }
+  }
 };
 
 

--- a/net/instaweb/rewriter/critical_css_loader.js
+++ b/net/instaweb/rewriter/critical_css_loader.js
@@ -39,12 +39,18 @@ pagespeed.CriticalCssLoader.addAllStyles = function() {
 
   var elements = document.getElementsByClassName('psa_add_styles');
 
+    
   for (var i = 0, e; e = elements[i]; ++i) {
-    if (e.nodeName != 'NOSCRIPT') { continue; }
-    var div = document.createElement('div');
-    div.innerHTML = e.textContent;
+    if (e.nodeName == 'NOSCRIPT') { 
+       var div = document.createElement('div');
+       div.innerHTML = e.textContent;
+       var children = div.childNodes;
+       for (var v = 0; v < children.length; ++v) {
+           children[v].removeAttribute('id');
+       }  
     document.body.appendChild(div);
-  }
+    }
+ }
 };
 
 

--- a/third_party/libpng/libpng.gyp
+++ b/third_party/libpng/libpng.gyp
@@ -25,9 +25,14 @@
           'actions': [
             {
               'action_name': 'copy_libpngconf_prebuilt',
-              'inputs' : ['<(DEPTH)/third_party/libpng/src/scripts/pnglibconf.h.prebuilt'],
-              'outputs': ['<(DEPTH)/third_party/libpng/src/pnglibconf.h'],
-              'action': ['cp', '-f', '<@(_inputs)','<@(_outputs)'],
+              'inputs' : [],
+              'outputs': [''],
+              'action': [
+                'cp',
+                '-f',
+                '<(DEPTH)/third_party/libpng/src/scripts/pnglibconf.h.prebuilt',
+                '<(DEPTH)/third_party/libpng/src/pnglibconf.h',
+              ],
             },
           ],
           'msvs_guid': 'C564F145-9172-42C3-BFCB-6014CA97DBCD',

--- a/third_party/libpng/libpng.gyp
+++ b/third_party/libpng/libpng.gyp
@@ -25,14 +25,9 @@
           'actions': [
             {
               'action_name': 'copy_libpngconf_prebuilt',
-              'inputs' : [],
-              'outputs': [''],
-              'action': [
-                'cp',
-                '-f',
-                '<(DEPTH)/third_party/libpng/src/scripts/pnglibconf.h.prebuilt',
-                '<(DEPTH)/third_party/libpng/src/pnglibconf.h',
-              ],
+              'inputs' : ['<(DEPTH)/third_party/libpng/src/scripts/pnglibconf.h.prebuilt'],
+              'outputs': ['<(DEPTH)/third_party/libpng/src/pnglibconf.h'],
+              'action': ['cp', '-f', '<@(_inputs)','<@(_outputs)'],
             },
           ],
           'msvs_guid': 'C564F145-9172-42C3-BFCB-6014CA97DBCD',


### PR DESCRIPTION
To solve this issue: prioritize critical css need to remove id attributes apache#1878
When inlined styles have ID´s if prioritize critical css filter is used, when pagespeed restores the inlined styles from class name psa_add_styles, the ID´s become duplicate.
The changes in this js file deletes the ID´s from these restored styles.
These change is not the best approach, i know, cause it add more work in the browser side, maybe some user use the ID´s to make changes to the DOM and maybe the elements the user will change don´t exists, cause the styles with the ID´s are the optimized ones.
But this is a workaround for these user that don´t do changes in styles DOM by the ID. 
Wordpress put an ID in all inlined styles by the hook wp_add_inline_style( $handle, $data ) where the $handle become the ID and is mandatory.