### PR TITLE
Fix CI: Amend TestHttpsSucceedsForGoogleCom to work again

### DIFF
--- a/pagespeed/system/serf_url_async_fetcher_test.cc
+++ b/pagespeed/system/serf_url_async_fetcher_test.cc
@@ -683,7 +683,7 @@ TEST_F(SerfUrlAsyncFetcherTest, TestHttpsFailsForSelfSignedCert) {
 TEST_F(SerfUrlAsyncFetcherTest, TestHttpsSucceedsForGoogleCom) {
   serf_url_async_fetcher_->SetHttpsOptions("enable");
   EXPECT_TRUE(serf_url_async_fetcher_->SupportsHttps());
-  TestHttpsSucceeds("https://www.google.com/intl/en/about/", "<!DOCTYPE html>");
+  TestHttpsSucceeds("https://about.google/intl/en/", "<!DOCTYPE html>");
   ValidateMonitoringStats(1, 0);
 }
 


### PR DESCRIPTION
Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>