### PR TITLE
Update libpng.gyp

### DIFF
--- a/third_party/libpng/libpng.gyp
+++ b/third_party/libpng/libpng.gyp
@@ -22,6 +22,7 @@
           'dependencies': [
             '../zlib/zlib.gyp:zlib',
           ],
+          'hard_dependency': 1,
           'actions': [
             {
               'action_name': 'copy_libpngconf_prebuilt',


### PR DESCRIPTION
Hopefully the last change for the issue of copy pnglibconf.h file.
These added parameter ('hard_dependency': 1,) tell to the gyp builder that this dependencies must be build prior that the dependent.
Perhaps must be added to other gyp files