### PR TITLE
data-srcset in img and amp-img

### DIFF
--- a/install/mod_pagespeed_test/image_rewriting/.htaccess
+++ b/install/mod_pagespeed_test/image_rewriting/.htaccess
@@ -1,0 +1,1 @@
+ModPagespeedUrlValuedAttribute amp-img src image

--- a/install/mod_pagespeed_test/image_rewriting/data-srcset.html
+++ b/install/mod_pagespeed_test/image_rewriting/data-srcset.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>Test for srcset rewriting</title>
+  </head>
+  <body>
+    <img src="../../mod_pagespeed_example/images/Puzzle.jpg"
+         data-srcset="../../mod_pagespeed_example/images/Puzzle.jpg 1x, ../../mod_pagespeed_example/images/Cuppa.png 2x"><br/>
+  </body>
+</html>

--- a/install/mod_pagespeed_test/image_rewriting/data-srcset.html
+++ b/install/mod_pagespeed_test/image_rewriting/data-srcset.html
@@ -5,5 +5,7 @@
   <body>
     <img src="../../mod_pagespeed_example/images/Puzzle.jpg"
          data-srcset="../../mod_pagespeed_example/images/Puzzle.jpg 1x, ../../mod_pagespeed_example/images/Cuppa.png 2x"><br/>
+    <amp-img src="../../mod_pagespeed_example/images/Puzzle.jpg"
+         srcset="../../mod_pagespeed_example/images/Puzzle.jpg 1x, ../../mod_pagespeed_example/images/Cuppa.png 2x"><br/>  
   </body>
 </html>

--- a/net/instaweb/rewriter/image_rewrite_filter.cc
+++ b/net/instaweb/rewriter/image_rewrite_filter.cc
@@ -2138,12 +2138,14 @@ void ImageRewriteFilter::StartElementImpl(HtmlElement* element) {
     BeginRewriteImageUrl(element, attributes[i].url);
    
   
-    HtmlElement::Attribute* srcset[] = {element->FindAttribute(HtmlName::kSrcset),element->FindAttribute(HtmlName::kDataSrcset)};
-    for (int i = 0; i == 1; i++){
-       if (srcset[i] != nullptr){
-	       BeginRewriteSrcSet(element, srcset[i]);
-        }
-    }
+    HtmlElement::Attribute* srcset = element->FindAttribute(HtmlName::kSrcset);
+    HtmlElement::Attribute* datasrcset = element->FindAttribute(HtmlName::kDataSrcset);
+    if (srcset != nullptr) {
+	    BeginRewriteSrcSet(element, srcset);
+    } else if (datasrcset != nullptr) {
+	    BeginRewriteSrcSet(element, datasrcset);
+    }	    
+  
   }
 }
 

--- a/net/instaweb/rewriter/image_rewrite_filter.cc
+++ b/net/instaweb/rewriter/image_rewrite_filter.cc
@@ -2139,7 +2139,7 @@ void ImageRewriteFilter::StartElementImpl(HtmlElement* element) {
    
   
     HtmlElement::Attribute* srcset[0] = element->FindAttribute(HtmlName::kSrcset);
-    HtmlElement::Attribute* srcset[1] = element->FindAttribute(HtmlName::kDataSrcset);
+    srcset[1] = element->FindAttribute(HtmlName::kDataSrcset);
     for (int i = 0; i == 1; i++){
        if (srcset[i] != nullptr){
 	       BeginRewriteSrcSet(element, srcset[i]);

--- a/net/instaweb/rewriter/image_rewrite_filter.cc
+++ b/net/instaweb/rewriter/image_rewrite_filter.cc
@@ -2136,13 +2136,18 @@ void ImageRewriteFilter::StartElementImpl(HtmlElement* element) {
     }
 
     BeginRewriteImageUrl(element, attributes[i].url);
-  }
-
-  if (element->keyword() == HtmlName::kImg) {
+   
+  
     HtmlElement::Attribute* srcset = element->FindAttribute(HtmlName::kSrcset);
+	  HtmlElement::Attribute* datasrcset = element->FindAttribute(HtmlName::kDataSrcset);
     if (srcset != nullptr) {
       BeginRewriteSrcSet(element, srcset);
     }
+	  if (datasrcset != nullptr) {
+      srcset = datasrcset ;
+      BeginRewriteSrcSet(element, srcset);
+    }
+
   }
 }
 

--- a/net/instaweb/rewriter/image_rewrite_filter.cc
+++ b/net/instaweb/rewriter/image_rewrite_filter.cc
@@ -2143,7 +2143,7 @@ void ImageRewriteFilter::StartElementImpl(HtmlElement* element) {
     if (srcset != nullptr) {
       BeginRewriteSrcSet(element, srcset);
     }
-	  if (datasrcset != nullptr) {
+    if (datasrcset != nullptr) {
       srcset = datasrcset ;
       BeginRewriteSrcSet(element, srcset);
     }

--- a/net/instaweb/rewriter/image_rewrite_filter.cc
+++ b/net/instaweb/rewriter/image_rewrite_filter.cc
@@ -2138,8 +2138,7 @@ void ImageRewriteFilter::StartElementImpl(HtmlElement* element) {
     BeginRewriteImageUrl(element, attributes[i].url);
    
   
-    HtmlElement::Attribute* srcset[0] = element->FindAttribute(HtmlName::kSrcset);
-    srcset[1] = element->FindAttribute(HtmlName::kDataSrcset);
+    HtmlElement::Attribute* srcset[] {element->FindAttribute(HtmlName::kSrcset),element->FindAttribute(HtmlName::kDataSrcset)};
     for (int i = 0; i == 1; i++){
        if (srcset[i] != nullptr){
 	       BeginRewriteSrcSet(element, srcset[i]);

--- a/net/instaweb/rewriter/image_rewrite_filter.cc
+++ b/net/instaweb/rewriter/image_rewrite_filter.cc
@@ -2138,7 +2138,7 @@ void ImageRewriteFilter::StartElementImpl(HtmlElement* element) {
     BeginRewriteImageUrl(element, attributes[i].url);
    
   
-    HtmlElement::Attribute* srcset[] {element->FindAttribute(HtmlName::kSrcset),element->FindAttribute(HtmlName::kDataSrcset)};
+    HtmlElement::Attribute* srcset[] = {element->FindAttribute(HtmlName::kSrcset),element->FindAttribute(HtmlName::kDataSrcset)};
     for (int i = 0; i == 1; i++){
        if (srcset[i] != nullptr){
 	       BeginRewriteSrcSet(element, srcset[i]);

--- a/net/instaweb/rewriter/image_rewrite_filter.cc
+++ b/net/instaweb/rewriter/image_rewrite_filter.cc
@@ -2138,11 +2138,13 @@ void ImageRewriteFilter::StartElementImpl(HtmlElement* element) {
     BeginRewriteImageUrl(element, attributes[i].url);
    
   
-    HtmlElement::Attribute* srcset = element->FindAttribute(HtmlName::kSrcset);
-    HtmlElement::Attribute* datasrcset = element->FindAttribute(HtmlName::kDataSrcset);
-    ( srcset == nullptr)? : BeginRewriteSrcSet(element, srcset);
-    ( datasrcset == nullptr)? : BeginRewriteSrcSet(element, datasrcset);
-
+    HtmlElement::Attribute* srcset[0] = element->FindAttribute(HtmlName::kSrcset);
+    HtmlElement::Attribute* srcset[1] = element->FindAttribute(HtmlName::kDataSrcset);
+    for (int i = 0; i == 1; i++){
+       if (srcset[i] != nullptr){
+	       BeginRewriteSrcSet(element, srcset[i]);
+        }
+    }
   }
 }
 

--- a/net/instaweb/rewriter/image_rewrite_filter.cc
+++ b/net/instaweb/rewriter/image_rewrite_filter.cc
@@ -2139,14 +2139,9 @@ void ImageRewriteFilter::StartElementImpl(HtmlElement* element) {
    
   
     HtmlElement::Attribute* srcset = element->FindAttribute(HtmlName::kSrcset);
-	  HtmlElement::Attribute* datasrcset = element->FindAttribute(HtmlName::kDataSrcset);
-    if (srcset != nullptr) {
-      BeginRewriteSrcSet(element, srcset);
-    }
-    if (datasrcset != nullptr) {
-      srcset = datasrcset ;
-      BeginRewriteSrcSet(element, srcset);
-    }
+    HtmlElement::Attribute* datasrcset = element->FindAttribute(HtmlName::kDataSrcset);
+    ( srcset == nullptr)? : BeginRewriteSrcSet(element, srcset);
+    ( datasrcset == nullptr)? : BeginRewriteSrcSet(element, datasrcset);
 
   }
 }

--- a/net/instaweb/rewriter/image_rewrite_filter_test.cc
+++ b/net/instaweb/rewriter/image_rewrite_filter_test.cc
@@ -1342,6 +1342,35 @@ TEST_F(ImageRewriteTest, ImgSrcSet) {
       "<img src=\"xa.png.pagespeed.ic.0.png\" "
       "srcset=\"xa.png.pagespeed.ic.0.png 1x, xb.png.pagespeed.ic.0.png 2x\">");
 }
+  
+TEST_F(ImageRewriteTest, ImgDataSrcSet) {
+  AddFileToMockFetcher("a.png", kBikePngFile, kContentTypePng, 100);
+  AddFileToMockFetcher("b.png", kCuppaPngFile, kContentTypePng, 100);
+
+  options()->EnableFilter(RewriteOptions::kRecompressPng);
+  rewrite_driver()->AddFilters();
+
+  ValidateExpected(
+      "data-srcset",
+      "<img src=\"a.png\" data-srcset=\"a.png 1x, b.png 2x\">",
+      "<img src=\"xa.png.pagespeed.ic.0.png\" "
+      "data-srcset=\"xa.png.pagespeed.ic.0.png 1x, xb.png.pagespeed.ic.0.png 2x\">");
+}
+
+TEST_F(ImageRewriteTest, ImgAmpSrcSet) {
+  AddFileToMockFetcher("a.png", kBikePngFile, kContentTypePng, 100);
+  AddFileToMockFetcher("b.png", kCuppaPngFile, kContentTypePng, 100);
+
+  options()->EnableFilter(RewriteOptions::kRecompressPng);
+  options()->AddUrlValuedAttribute("amp-img", "src", semantic_type::kImage);
+  rewrite_driver()->AddFilters();
+
+  ValidateExpected(
+      "srcset",
+      "<amp-img src=\"a.png\" srcset=\"a.png 1x, b.png 2x\">",
+      "<amp-img src=\"xa.png.pagespeed.ic.0.png\" "
+      "srcset=\"xa.png.pagespeed.ic.0.png 1x, xb.png.pagespeed.ic.0.png 2x\">");
+}
 
 TEST_F(ImageRewriteTest, ImgSrcSetWithCacheExtender) {
   // Makes sure cache extender properly shares the slot.

--- a/pagespeed/automatic/system_test.sh
+++ b/pagespeed/automatic/system_test.sh
@@ -66,6 +66,7 @@ run_test outliners
 run_test char_tweaks
 run_test rewrite_css
 run_test rewrite_images
+run_test rewrite_images_datasrcset
 run_test image_quality_generic
 run_test image_quality_jpeg
 run_test image_quality_webp

--- a/pagespeed/automatic/system_test.sh
+++ b/pagespeed/automatic/system_test.sh
@@ -66,7 +66,6 @@ run_test outliners
 run_test char_tweaks
 run_test rewrite_css
 run_test rewrite_images
-run_test rewrite_images_datasrcset
 run_test image_quality_generic
 run_test image_quality_jpeg
 run_test image_quality_webp

--- a/pagespeed/automatic/system_tests/responsive_images.sh
+++ b/pagespeed/automatic/system_tests/responsive_images.sh
@@ -37,5 +37,5 @@ fetch_until -save $URL 'grep -c xPuzzle.*1x.*xCuppa.*2x' 1
 
 start_test rewrite_images_datasrcset can rewrite data-srcset itself
 URL=$TEST_ROOT/image_rewriting/data-srcset.html?PageSpeedFilters=+rewrite_images,+debug
-fetch_until -save $URL 'grep -c xPuzzle.*1x.*xCuppa.*2x' 1
+fetch_until -save $URL 'grep -c srcset.*xPuzzle.*1x.*xCuppa.*2x' 2
 

--- a/pagespeed/automatic/system_tests/responsive_images.sh
+++ b/pagespeed/automatic/system_tests/responsive_images.sh
@@ -35,4 +35,7 @@ start_test rewrite_images can rewrite srcset itself
 URL=$TEST_ROOT/image_rewriting/srcset.html?PageSpeedFilters=+rewrite_images,+debug
 fetch_until -save $URL 'grep -c xPuzzle.*1x.*xCuppa.*2x' 1
 
+start_test rewrite_images_datasrcset can rewrite data-srcset itself
+URL=$TEST_ROOT/image_rewriting/data-srcset.html?PageSpeedFilters=+rewrite_images,+debug
+fetch_until -save $URL 'grep -c xPuzzle.*1x.*xCuppa.*2x' 1
 

--- a/pagespeed/kernel/html/html_name.gperf
+++ b/pagespeed/kernel/html/html_name.gperf
@@ -126,6 +126,7 @@ struct KeywordMap {const char* name; net_instaweb::HtmlName::Keyword keyword;};
 "data-pagespeed-size",                HtmlName::kDataPagespeedSize
 "data-pagespeed-url-hash",            HtmlName::kDataPagespeedUrlHash
 "data-src",                           HtmlName::kDataSrc
+"data-srcset",                        HtmlName::kDataSrcset
 "dd",                                 HtmlName::kDd
 "declare",                            HtmlName::kDeclare
 "defaultchecked",                     HtmlName::kDefaultchecked

--- a/pagespeed/kernel/html/html_name.h
+++ b/pagespeed/kernel/html/html_name.h
@@ -102,6 +102,7 @@ class HtmlName {
     kDataPagespeedSize,
     kDataPagespeedUrlHash,
     kDataSrc,
+    kDataSrcset,
     kDd,
     kDeclare,
     kDefaultchecked,


### PR DESCRIPTION
To rewrite amp-img srcset the parameter pagespeed UrlValuedAttribute amp-img  src image; is needed.
In fact, i think that any UrlValuedAttribute element attribute image that have src,srcset or data-srcset get rewrited.
Solves [#1608 ](https://github.com/apache/incubator-pagespeed-ngx/issues/1608)in nginx and #1849.