### PR TITLE
Bazel build & CI update

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,72 @@
+# The following .bazelrc content is forked from the main Envoy repository. This is necessary since
+# this needs to be available before we can access the Envoy repository contents via Bazel.
+
+# Envoy specific Bazel build/test options.
+
+# Bazel doesn't need more than 200MB of memory based on memory profiling:
+# https://docs.bazel.build/versions/master/skylark/performance.html#memory-profiling
+# Limiting JVM heapsize here to let it do GC more when approaching the limit to
+# leave room for compiler/linker.
+startup --host_jvm_args=-Xmx512m
+build --workspace_status_command=bazel/get_workspace_status
+build --experimental_remap_main_repo
+
+# Basic ASAN/UBSAN that works for gcc
+build:asan --define ENVOY_CONFIG_ASAN=1
+build:asan --copt -fsanitize=address,undefined
+build:asan --linkopt -fsanitize=address,undefined
+build:asan --copt -fno-sanitize=vptr
+build:asan --linkopt -fno-sanitize=vptr
+build:asan --linkopt -fuse-ld=lld
+build:asan --linkopt -ldl
+build:asan --define tcmalloc=disabled
+build:asan --build_tag_filters=-no_asan
+build:asan --test_tag_filters=-no_asan
+build:asan --define signal_trace=disabled
+build:asan --copt -DADDRESS_SANITIZER=1
+build:asan --copt -D__SANITIZE_ADDRESS__
+build:asan --test_env=ASAN_OPTIONS=handle_abort=1:allow_addr2line=true:check_initialization_order=true:strict_init_order=true:detect_odr_violation=1
+build:asan --test_env=UBSAN_OPTIONS=halt_on_error=true:print_stacktrace=1
+build:asan --test_env=ASAN_SYMBOLIZER_PATH
+
+# Clang ASAN/UBSAN
+build:clang-asan --config=asan
+
+# macOS ASAN/UBSAN
+build:macos-asan --config=asan
+# Workaround, see https://github.com/bazelbuild/bazel/issues/6932
+build:macos-asan --copt -Wno-macro-redefined
+build:macos-asan --copt -D_FORTIFY_SOURCE=0
+
+# Clang TSAN
+build:clang-tsan --define ENVOY_CONFIG_TSAN=1
+build:clang-tsan --copt -fsanitize=thread
+build:clang-tsan --linkopt -fsanitize=thread
+build:clang-tsan --linkopt -fuse-ld=lld
+build:clang-tsan --define tcmalloc=disabled
+# Needed due to https://github.com/libevent/libevent/issues/777
+build:clang-tsan --copt -DEVENT__DISABLE_DEBUG_MODE
+
+# Clang MSAN - broken today since we need to rebuild lib[std]c++ and external deps with MSAN
+# support (see https://github.com/envoyproxy/envoy/issues/443).
+build:clang-msan --define ENVOY_CONFIG_MSAN=1
+build:clang-msan --copt -fsanitize=memory
+build:clang-msan --linkopt -fsanitize=memory
+build:clang-msan --define tcmalloc=disabled
+build:clang-msan --copt -fsanitize-memory-track-origins=2
+
+# Clang with libc++
+# TODO(cmluciano) fix and re-enable _LIBCPP_VERSION testing for TCMALLOC in Envoy::Stats::TestUtil::hasDeterministicMallocStats
+# and update stats_integration_test with appropriate m_per_cluster value
+build:libc++ --action_env=CC
+build:libc++ --action_env=CXX
+build:libc++ --action_env=CXXFLAGS=-stdlib=libc++
+build:libc++ --action_env=PATH
+build:libc++ --define force_libcpp=enabled
+
+# Test options
+test --test_env=HEAPCHECK=normal --test_env=PPROF_PATH
+
+# TODO(oschaaf): For brotli, back this out and apply more locally once
+# we figured out how.
+build --copt -Wno-implicit-fallthrough

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,11 @@ before_install:
   # git.apache.org is the canonical repo but throttles network connections.
   # using github.com seems to reduce network errors a lot.
   - git config --global url.https://github.com/apache/.insteadOf git://git.apache.org/
-  - git submodule update --init --recursive --jobs=2
+  - git submodule update --init
+  - sudo apt-get install pkg-config zip g++ zlib1g-dev unzip python3
+  - wget https://github.com/bazelbuild/bazel/releases/download/0.27.1/bazel-0.27.1-installer-linux-x86_64.sh
+  - chmod +x bazel-0.27.1-installer-linux-x86_64.sh
+  - ./bazel-0.27.1-installer-linux-x86_64.sh --user
 env:
   global:
     - MAKEFLAGS=-j3
@@ -35,7 +39,7 @@ script:
   # for longer, but has the downside of not producing output if we timeout. See:
   # https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
   # For now, stick with --verbose and keep an eye on the logs.
-  - install/build_release.sh --verbose --skip_psol --debug $BIT_FLAG
+  - bazel build //:mod_pagespeed
 
 notifications:
   email:

--- a/bazel/get_workspace_status
+++ b/bazel/get_workspace_status
@@ -1,0 +1,1 @@
+# TODO(oschaaf): this is a stub. symlinking to envoy's copy fails here.


### PR DESCRIPTION
- Add bazel build to travis
- Add .bazelrc from NH/Envoy in preparation of more CI testing
- Temporarily introduce build `--copt -Wno-implicit-fallthrough`