### PR TITLE
Bazel-branch: re-enable a few tests

### DIFF
--- a/net/instaweb/rewriter/static_asset_manager_test.cc
+++ b/net/instaweb/rewriter/static_asset_manager_test.cc
@@ -142,7 +142,7 @@ TEST_F(StaticAssetManagerTest, TestDeferJsNonGStaticDebug) {
       StaticAssetEnum::DEFER_JS, options_));
 }
 
-TEST_F(StaticAssetManagerTest, DISABLED_TestJsDebug) {
+TEST_F(StaticAssetManagerTest, TestJsDebug) {
   options_->EnableFilter(RewriteOptions::kDebug);
   for (int i = 0; i < StaticAssetEnum::StaticAsset_ARRAYSIZE; ++i) {
     StaticAssetEnum::StaticAsset module =
@@ -160,7 +160,7 @@ TEST_F(StaticAssetManagerTest, DISABLED_TestJsDebug) {
   }
 }
 
-TEST_F(StaticAssetManagerTest, DISABLED_TestJsOpt) {
+TEST_F(StaticAssetManagerTest, TestJsOpt) {
   for (int i = 0; i < StaticAssetEnum::StaticAsset_ARRAYSIZE; ++i) {
     StaticAssetEnum::StaticAsset module =
         static_cast<StaticAssetEnum::StaticAsset>(i);

--- a/pagespeed/kernel/base/sha1_signature_test.cc
+++ b/pagespeed/kernel/base/sha1_signature_test.cc
@@ -29,8 +29,7 @@ namespace {
 
 class Sha1SignatureTest : public ::testing::Test {};
 
-// XX(oschaaf): HMAC segfaults
-TEST_F(Sha1SignatureTest, DISABLED_CorrectSignatureSize) {
+TEST_F(Sha1SignatureTest, CorrectSignatureSize) {
   // This test verifies that Sha1Signature outputs signatures of the proper
   // size.
   // SHA1 is 160 bit, which is 27 6-bit chars (there are 2 additional bits for
@@ -47,7 +46,7 @@ TEST_F(Sha1SignatureTest, DISABLED_CorrectSignatureSize) {
   }
 }
 
-TEST_F(Sha1SignatureTest, DISABLED_SignaturesDiffer) {
+TEST_F(Sha1SignatureTest, SignaturesDiffer) {
 #if ENABLE_URL_SIGNATURES
   SHA1Signature signature;
   // Basic sanity tests.


### PR DESCRIPTION
- We can enable `StaticAssetManagerTest.TestJsXXX` now that the closure
  compiler flow is working
- We can enable `Sha1SignatureTest.*`, the tests themselves are fine.
  But they work because of a change I made to `SHA1Signature::RawSign`,
  the version on master segfaults. Root-cause analysis of that is in
  progress.