### PR TITLE
Bazel: Update test expectation

### DIFF
--- a/net/instaweb/rewriter/redirect_on_size_limit_filter_test.cc
+++ b/net/instaweb/rewriter/redirect_on_size_limit_filter_test.cc
@@ -184,14 +184,14 @@ TEST_F(RedirectOnSizeLimitFilterTest, TestFlushBeforeLimit) {
   CheckOutput(150, 160, true, input, input);
 }
 
-TEST_F(RedirectOnSizeLimitFilterTest, DISABLED_TestEscapingAndFlush) {
+TEST_F(RedirectOnSizeLimitFilterTest, TestEscapingAndFlush) {
   SetupDriver(100);
   static const char kOutput[] =
       "<html>"
       "<input type=\"text\"/>"
       "<script type=\"text/javascript\">"
       "window.location=\"http://test.com/in.html?"
-      "\\'"
+      "%27"
       "(&PageSpeed=off\";"
       "</script>"
       "<script type=\"text/javascript\">alert('123');</script>"


### PR DESCRIPTION
Update the test expecation for
`RedirectOnSizeLimitFilterTest.TestEscapingAndFlush`:

As far as I can tell this is correct, and we need to do this because of a
change in the updated chromium url parser dependency.
This needs close scrutiny though, so I need someone else to take a
close look at this as well to ensure I'm right about that.