### PR TITLE
Update .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,131 @@
+# This file is inspired by its counterpart over at the Envoy repository.
+
+# Bazel doesn't need more than 200MB of memory for local build based on memory profiling:
+# https://docs.bazel.build/versions/master/skylark/performance.html#memory-profiling
+# The default JVM max heapsize is 1/4 of physical memory up to 32GB which could be large
+# enough to consume all memory constrained by cgroup in large host, which is the case in CircleCI.
+# Limiting JVM heapsize here to let it do GC more when approaching the limit to
+# leave room for compiler/linker.
+# The number 2G is choosed heuristically to both support in CircleCI and large enough for RBE.
+# Startup options cannot be selected via config.
+startup --host_jvm_args=-Xmx2g
+
+# build --workspace_status_command=bazel/get_workspace_status
+# this breaks the pagespeed build, because of apr header deps needing fixing.
+# build --experimental_remap_main_repo
+build --experimental_local_memory_estimate
+build --host_force_python=PY2
+build --action_env=BAZEL_LINKLIBS=-l%:libstdc++.a
+build --action_env=BAZEL_LINKOPTS=-lm:-static-libgcc
+
+# Basic ASAN/UBSAN that works for gcc
+build:asan --action_env=BAZEL_LINKLIBS=
+build:asan --action_env=BAZEL_LINKOPTS=-lstdc++:-lm
+build:asan --define ENVOY_CONFIG_ASAN=1
+build:asan --copt -fsanitize=address,undefined
+build:asan --linkopt -fsanitize=address,undefined
+build:asan --copt -fno-sanitize=vptr
+build:asan --linkopt -fno-sanitize=vptr
+build:asan --linkopt -fuse-ld=lld
+build:asan --linkopt -ldl
+build:asan --define tcmalloc=disabled
+build:asan --build_tag_filters=-no_asan
+build:asan --test_tag_filters=-no_asan
+build:asan --define signal_trace=disabled
+build:asan --copt -DADDRESS_SANITIZER=1
+build:asan --copt -D__SANITIZE_ADDRESS__
+build:asan --test_env=ASAN_OPTIONS=handle_abort=1:allow_addr2line=true:check_initialization_order=true:strict_init_order=true:detect_odr_violation=1
+build:asan --test_env=UBSAN_OPTIONS=halt_on_error=true:print_stacktrace=1
+build:asan --test_env=ASAN_SYMBOLIZER_PATH
+
+# Clang ASAN/UBSAN
+build:clang-asan --config=asan
+
+# macOS ASAN/UBSAN
+build:macos-asan --config=asan
+# Workaround, see https://github.com/bazelbuild/bazel/issues/6932
+build:macos-asan --copt -Wno-macro-redefined
+build:macos-asan --copt -D_FORTIFY_SOURCE=0
+
+# Clang TSAN
+build:clang-tsan --define ENVOY_CONFIG_TSAN=1
+build:clang-tsan --copt -fsanitize=thread
+build:clang-tsan --linkopt -fsanitize=thread
+build:clang-tsan --linkopt -fuse-ld=lld
+build:clang-tsan --linkopt -static-libsan
+build:clang-tsan --define tcmalloc=disabled
+# Needed due to https://github.com/libevent/libevent/issues/777
+build:clang-tsan --copt -DEVENT__DISABLE_DEBUG_MODE
+
+# Clang MSAN - broken today since we need to rebuild lib[std]c++ and external deps with MSAN
+# support (see https://github.com/envoyproxy/envoy/issues/443).
+build:clang-msan --define ENVOY_CONFIG_MSAN=1
+build:clang-msan --copt -fsanitize=memory
+build:clang-msan --linkopt -fsanitize=memory
+build:clang-msan --define tcmalloc=disabled
+build:clang-msan --copt -fsanitize-memory-track-origins=2
+
+# Clang with libc++
+# TODO(cmluciano) fix and re-enable _LIBCPP_VERSION testing for TCMALLOC in Envoy::Stats::TestUtil::hasDeterministicMallocStats
+# and update stats_integration_test with appropriate m_per_cluster value
+build:libc++ --action_env=CC
+build:libc++ --action_env=CXX
+build:libc++ --action_env=CXXFLAGS=-stdlib=libc++
+build:libc++ --action_env=BAZEL_CXXOPTS=-stdlib=libc++
+build:libc++ --action_env=BAZEL_LINKLIBS=-l%:libc++.a:-l%:libc++abi.a:-lm
+build:libc++ --action_env=PATH
+build:libc++ --host_linkopt=-fuse-ld=lld
+build:libc++ --define force_libcpp=enabled
+
+# Optimize build for binary size reduction.
+build:sizeopt -c opt --copt -Os
+
+# Test options
+build --test_env=HEAPCHECK=normal --test_env=PPROF_PATH
+
+# Remote execution: https://docs.bazel.build/versions/master/remote-execution.html
+build:rbe-toolchain --host_javabase=@rbe_ubuntu_clang//java:jdk
+build:rbe-toolchain --javabase=@rbe_ubuntu_clang//java:jdk
+build:rbe-toolchain --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:rbe-toolchain --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build:rbe-toolchain --host_platform=@envoy//bazel/toolchains:rbe_ubuntu_clang_platform
+build:rbe-toolchain --platforms=@envoy//bazel/toolchains:rbe_ubuntu_clang_platform
+build:rbe-toolchain --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+build:rbe-toolchain --crosstool_top=@rbe_ubuntu_clang//cc:toolchain
+build:rbe-toolchain --extra_toolchains=@rbe_ubuntu_clang//config:cc-toolchain
+build:rbe-toolchain --linkopt=-fuse-ld=lld
+build:rbe-toolchain --action_env=CC=clang --action_env=CXX=clang++ --action_env=PATH=/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/llvm-8/bin
+
+build:remote --spawn_strategy=remote,sandboxed,local
+build:remote --strategy=Javac=remote,sandboxed,local
+build:remote --strategy=Closure=remote,sandboxed,local
+build:remote --strategy=Genrule=remote,sandboxed,local
+build:remote --remote_timeout=3600
+build:remote --auth_enabled=true
+build:remote --experimental_inmemory_jdeps_files
+build:remote --experimental_inmemory_dotd_files
+build:remote --experimental_remote_download_outputs=toplevel
+test:remote --experimental_remote_download_outputs=minimal
+
+build:remote-clang --config=remote
+build:remote-clang --config=rbe-toolchain
+
+# Docker sandbox
+build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build:cfc514546bc0284536893cca5fa43d7128edcd35
+build:docker-sandbox --spawn_strategy=docker
+build:docker-sandbox --strategy=Javac=docker
+build:docker-sandbox --strategy=Closure=docker
+build:docker-sandbox --strategy=Genrule=docker
+build:docker-sandbox --define=EXECUTOR=remote
+build:docker-sandbox --experimental_docker_verbose
+build:docker-sandbox --experimental_enable_docker_sandbox
+
+build:docker-clang --config=docker-sandbox
+build:docker-clang --config=rbe-toolchain
+
+
+###### modifications for pagespeed
+
 build --cxxopt="-std=c++14"
 build --cxxopt=-Wno-old-style-cast
 build --copt=-Wno-unused-const-variable
@@ -5,11 +133,14 @@ build --copt=-Wno-unused-parameter
 build --copt=-Wno-sign-compare
 build --copt=-Wno-implicit-fallthrough
 #build --copt=-Wno-inconsistent-missing-override
-# objcopy 2.31 doesn't like clang-7's output unless we pass in -fno-addrsig
+# objcopy 2.31 doesn't like 
+clang-7's output unless we pass in -fno-addrsig
 # https://github.com/travitch/whole-program-llvm/issues/75
 # not passing this in will make the scripts that rename symbols fail
-#build --copt=-fno-addrsig 
+build --copt=-fno-addrsig 
 
+build:clang-asan --linkopt -fno-sanitize=alignment	
+build:clang-asan --copt -fno-sanitize=alignment	
 
 test --test_env=REDIS_PORT=6379
 test --test_env=MEMCACHED_PORT=11211


### PR DESCRIPTION
- Allows running tsan/asan/msan
  (e.g.: `bazel test -c dbg --config=clang-asan //net/... //pagespeed/...`)
- Tweak for getting the merge of pagespeed_automatic.a to work with clang
  (though it looks like we may not need pagespeed_automatic.a)

The sanitizers detect a bunch of issues. So we may have some work here
to clean that up, ideally we'd have clean sanitizer runs so we can
enforce it stays clean in CI.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>