### PR TITLE
Sanitizers tests + fixes

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -255,5 +255,92 @@
                 "isDefault": true
             }
         },
+<<<<<<< Updated upstream
+=======
+        {
+            "label": "test envoy filter",
+            "type": "shell",
+            "command": " bazel test pagespeed/envoy:http_filter_integration_test",
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "group": {
+                "kind" : "test",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "build envoy filter",
+            "type": "shell",
+            "command": " bazel build pagespeed/envoy:envoy",
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "group": {
+                "kind" : "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "build envoy filter debug",
+            "type": "shell",
+            "command": " bazel build -c dbg pagespeed/envoy:envoy",
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "group": {
+                "kind" : "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "build envoy filter opt",
+            "type": "shell",
+            "command": " bazel build -c opt pagespeed/envoy:envoy",
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "group": {
+                "kind" : "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "asan test",
+            "type": "shell",
+            "command": "bazel test -c dbg --config=clang-asan //net/... //pagespeed/...",
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "group": {
+                "kind" : "test",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "msan test",
+            "type": "shell",
+            "command": "bazel test -c dbg --config=clang-msan //net/... //pagespeed/...",
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "group": {
+                "kind" : "test",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "tsan test",
+            "type": "shell",
+            "command": "bazel test -c dbg --config=clang-tsan //net/... //pagespeed/...",
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "group": {
+                "kind" : "test",
+                "isDefault": true
+            }
+        },
+>>>>>>> Stashed changes
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -255,8 +255,6 @@
                 "isDefault": true
             }
         },
-<<<<<<< Updated upstream
-=======
         {
             "label": "test envoy filter",
             "type": "shell",
@@ -341,6 +339,5 @@
                 "isDefault": true
             }
         },
->>>>>>> Stashed changes
     ]
 }

--- a/pagespeed/kernel/base/atomic_bool.h
+++ b/pagespeed/kernel/base/atomic_bool.h
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 
 #ifndef PAGESPEED_KERNEL_BASE_ATOMIC_BOOL_H_
 #define PAGESPEED_KERNEL_BASE_ATOMIC_BOOL_H_
@@ -33,28 +32,21 @@ namespace net_instaweb {
 // incomprehensible  ways; most of the time, you probably want to use a mutex
 // instead.
 class AtomicBool {
- public:
+public:
   // Guaranteed to be initialized to false.
-  AtomicBool() {
-    set_value(false);
-  }
+  AtomicBool() { set_value(false); }
 
   ~AtomicBool() {}
 
-  bool value() const {
-    return value_;
-  }
+  bool value() const { return value_.load(std::memory_order::memory_order_acquire); }
 
-  void set_value(bool v) {
-    value_ = v;
-  }
+  void set_value(bool v) { value_.store(v, std::memory_order_release); }
 
- private:
+private:
   std::atomic<bool> value_;
   DISALLOW_COPY_AND_ASSIGN(AtomicBool);
 };
 
+} // namespace net_instaweb
 
-}  // namespace net_instaweb
-
-#endif  // PAGESPEED_KERNEL_BASE_ATOMIC_BOOL_H_
+#endif // PAGESPEED_KERNEL_BASE_ATOMIC_BOOL_H_

--- a/pagespeed/kernel/base/atomic_int32.h
+++ b/pagespeed/kernel/base/atomic_int32.h
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 
 #ifndef PAGESPEED_KERNEL_BASE_ATOMIC_INT32_H_
 #define PAGESPEED_KERNEL_BASE_ATOMIC_INT32_H_
@@ -75,39 +74,27 @@ namespace net_instaweb {
 // (increment, CompareAndSwap) occur as atomic actions.
 
 class AtomicInt32 {
- public:
-  explicit AtomicInt32(int32 value) {
-    set_value(value);
-  }
-  AtomicInt32() {
-    set_value(0);
-  }
+public:
+  explicit AtomicInt32(int32 value) { set_value(value); }
+  AtomicInt32() { set_value(0); }
   ~AtomicInt32() {}
 
   // Return the value currently stored.  Has acquire semantics (see above).
-  int32 value() const {
-    return value_;
-  }
+  int32 value() const { return value_.load(std::memory_order::memory_order_acquire); }
 
   // Store value.  Has release semantics (see above).
-  void set_value(int32 value) {
-    value_ = value;
-  }
+  void set_value(int32 value) { value_.store(value, std::memory_order_release); }
 
   // Atomically add an amount to the value currently stored, return the new
   // value. Has *no ordering semantics* with respect to operations on other
   // memory locations.
   int32 NoBarrierIncrement(int32 amount) {
-    value_ += amount;
-    return value_;
+    return amount + value_.fetch_add(amount, std::memory_order_relaxed);
   }
 
   // Atomically add an amount to the value stored, return the new value.
   // Provides a full barrier --- both acquire and release.
-  int32 BarrierIncrement(int32 amount) {
-    value_ += amount;
-    return value_;
-  }
+  int32 BarrierIncrement(int32 amount) { return amount + value_.fetch_add(amount); }
 
   // Atomic compare and swap.  If current value == expected_value, atomically
   // replace it with new_value.  Return the original value regardless of whether
@@ -120,17 +107,16 @@ class AtomicInt32 {
   // semantics, use the value() method and validate its result when you
   // CompareAndSwap.
   int32 CompareAndSwap(int32 expected_value, int32 new_value) {
-    return value_.compare_exchange_strong(expected_value, new_value, std::memory_order::memory_order_acquire);
+    value_.compare_exchange_strong(expected_value, new_value, std::memory_order_release,
+                                          std::memory_order_relaxed);
     return expected_value;
-    //base::subtle::Release_CompareAndSwap(
-    //    &value_, expected_value, new_value);
   }
 
- private:
-  std::atomic<int32_t> value_;
+private:
+  std::atomic<int32> value_;
   DISALLOW_COPY_AND_ASSIGN(AtomicInt32);
 };
- 
-}  // namespace net_instaweb
 
-#endif  // PAGESPEED_KERNEL_BASE_ATOMIC_INT32_H_
+} // namespace net_instaweb
+
+#endif // PAGESPEED_KERNEL_BASE_ATOMIC_INT32_H_

--- a/third_party/css_parser/src/util/utf8/internal/unicodetext.cc
+++ b/third_party/css_parser/src/util/utf8/internal/unicodetext.cc
@@ -147,7 +147,11 @@ void UnicodeText::Repr::clear() {
 
 void UnicodeText::Repr::Copy(const char* data, int size) {
   resize(size);
-  memcpy(data_, data, size);
+  // XXX(oschaaf): sanitizer fix -> can't pass nullptr as the first arg.
+  // data_ will be null here when size == 0
+  if (size) {
+    memcpy(data_, data, size);
+  }
 }
 
 void UnicodeText::Repr::TakeOwnershipOf(char* data, int size, int capacity) {

--- a/third_party/css_parser/src/webutil/css/value.cc
+++ b/third_party/css_parser/src/webutil/css/value.cc
@@ -45,6 +45,7 @@ const char* const Value::kDimensionUnitText[] = {
 
 Value::Value(ValueType ty)
     : type_(ty),
+      unit_(Unit::EM),
       color_(0, 0, 0) {
   DCHECK(ty == COMMA || ty == DEFAULT || ty == UNKNOWN);
 }
@@ -52,6 +53,7 @@ Value::Value(ValueType ty)
 Value::Value(double num, const UnicodeText& unit)
     : type_(NUMBER),
       num_(num),
+      unit_(Unit::EM),
       color_(0, 0, 0) {
   unit_ = UnitFromText(unit.utf8_data(), unit.utf8_length());
   if (unit_ == OTHER)
@@ -62,12 +64,13 @@ Value::Value(double num, Unit unit)
     : type_(NUMBER),
       num_(num),
       unit_(unit),
-      color_(0, 0, 0)  {
+      color_(0, 0, 0) {
   DCHECK_NE(unit, OTHER);
 }
 
 Value::Value(ValueType ty, const UnicodeText& str)
     : type_(ty),
+      unit_(Unit::EM),
       str_(str),
       color_(0, 0, 0) {
   DCHECK(ty == STRING || ty == URI);
@@ -75,6 +78,7 @@ Value::Value(ValueType ty, const UnicodeText& str)
 
 Value::Value(const Identifier& identifier)
     : type_(IDENT),
+      unit_(Unit::EM),
       identifier_(identifier),
       color_(0, 0, 0) {
 }
@@ -82,13 +86,15 @@ Value::Value(const Identifier& identifier)
 Value::Value(const Identifier::Ident ident)
     : type_(IDENT),
       identifier_(Identifier(ident)),
-      color_(0, 0, 0) {
+      color_(0, 0, 0),
+      unit_(Unit::EM) {
 }
 
 Value::Value(ValueType ty, FunctionParameters* params)
     : type_(ty),
       params_(params),
-      color_(0, 0, 0) {
+      color_(0, 0, 0),
+      unit_(Unit::EM) {
   DCHECK(params != NULL);
   DCHECK(ty == RECT);
 }
@@ -97,13 +103,15 @@ Value::Value(const UnicodeText& func, FunctionParameters* params)
     : type_(FUNCTION),
       str_(func),
       params_(params),
-      color_(0, 0, 0) {
+      color_(0, 0, 0),
+      unit_(Unit::EM) {
   DCHECK(params != NULL);
 }
 
 Value::Value(HtmlColor c)
     : type_(COLOR),
-      color_(c) {
+      color_(c),
+      unit_(Unit::EM) {
 }
 
 Value::Value(const Value& other)


### PR DESCRIPTION
- Adds sanitizer test runs to .vscode tasks
- tsan: Fixes AtomicInt32 & AtomicBool (which I broke earlier)
- ubsan: Fixes trying to cast some enums with out-of-spec values.
- ubsan: Fixes an instance of passing null as the first arg to memcpy

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>