### PR TITLE
TSAN/APR: Add APR patch in the bazel flow 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - sudo add-apt-repository -y ppa:git-core/ppa
   - sudo apt-get update -q
   - sudo apt-get install -q -y git
-  - sudo apt-get install pkg-config zip g++ zlib1g-dev unzip python3 ninja-build cmake gperf memcached apache2-dev
+  - sudo apt-get install pkg-config zip g++ zlib1g-dev unzip python3 ninja-build cmake gperf memcached apache2-dev python2
   - wget https://github.com/bazelbuild/bazel/releases/download/3.3.1/bazel-3.3.1-installer-linux-x86_64.sh
   - chmod +x bazel-3.3.1-installer-linux-x86_64.sh
   - ./bazel-3.3.1-installer-linux-x86_64.sh --user

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -434,6 +434,8 @@ cc_binary(
         strip_prefix = "apr-%s" % APR_COMMIT,
         url = "https://github.com/apache/apr/archive/%s.tar.gz" % APR_COMMIT,
         build_file_content = apr_build_rule,
+        patches = [ "apr.patch" ],
+        patch_args = ["-p1"],
         sha256 = "81f100b46670014b9ad62acaa2df653a225408a9d8d90c4727d592941952b0ec",
     )
 

--- a/external/apr.patch
+++ b/external/apr.patch
@@ -1,0 +1,37 @@
+diff --git a/memory/unix/apr_pools.c b/memory/unix/apr_pools.c
+index b9cdee7..025e435 100644
+--- a/memory/unix/apr_pools.c
++++ b/memory/unix/apr_pools.c
+@@ -300,15 +300,28 @@ apr_memnode_t *allocator_alloc(apr_allocator_t *allocator, apr_size_t in_size)
+         return NULL;
+     }
+ 
++// TODO(oschaaf): take a closer look at this. TSAN will complain
++// here about the read of allocator->max_index being unsafe.
++// For now make the complaints go away by grabbing a copy with the
++// allocator lock held.
++// START PATCH
++#if APR_HAS_THREADS
++    if (allocator->mutex) apr_thread_mutex_lock(allocator->mutex);
++#endif /* APR_HAS_THREADS */
++    apr_size_t test_index = allocator->max_index;
++#if APR_HAS_THREADS
++    if (allocator->mutex) apr_thread_mutex_unlock(allocator->mutex);
++#endif /* APR_HAS_THREADS */
++// END PATCH
++
+     /* First see if there are any nodes in the area we know
+      * our node will fit into.
+      */
+-    if (index <= allocator->max_index) {
+-#if APR_HAS_THREADS
++    if (index <= test_index) {
++    #if APR_HAS_THREADS
+         if (allocator->mutex)
+             apr_thread_mutex_lock(allocator->mutex);
+-#endif /* APR_HAS_THREADS */
+-
++    #endif /* APR_HAS_THREADS */
+         /* Walk the free list to see if there are
+          * any nodes on it of the requested size
+          *


### PR DESCRIPTION
Address TSAN complaints about read/write races for 
`allocator->max_index` go away. 

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>