### PR TITLE
Sort includes & encapsulate chromium/googleurl headers

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,7 +6,7 @@ AccessModifierOffset: -1
 ColumnLimit: 80
 DerivePointerAlignment: false
 PointerAlignment: Left
-SortIncludes: false
+SortIncludes: true
 # This excludes multi-line comments, and with that
 # we leave license banners as-is
 CommentPragmas: "."

--- a/net/instaweb/http/async_fetch_test.cc
+++ b/net/instaweb/http/async_fetch_test.cc
@@ -31,8 +31,6 @@
 namespace net_instaweb {
 namespace {
 
-const char kUrl[] = "http://www.example.com/";
-
 class TestSharedAsyncFetch : public SharedAsyncFetch {
  public:
   explicit TestSharedAsyncFetch(AsyncFetch* base_fetch)

--- a/net/instaweb/http/http_value_test.cc
+++ b/net/instaweb/http/http_value_test.cc
@@ -29,10 +29,6 @@
 #include "pagespeed/kernel/http/http_names.h"
 #include "pagespeed/kernel/http/response_headers.h"
 
-namespace {
-const int kMaxSize = 100;
-}
-
 namespace net_instaweb {
 
 class HTTPValueTest : public testing::Test {

--- a/net/instaweb/rewriter/beacon_critical_images_finder_test.cc
+++ b/net/instaweb/rewriter/beacon_critical_images_finder_test.cc
@@ -42,8 +42,6 @@ namespace net_instaweb {
 
 namespace {
 
-const char kRequestUrl[] = "http://www.example.com";
-
 class BeaconCriticalImagesFinderTest : public CriticalImagesFinderTestBase {
  public:
   CriticalImagesFinder* finder() override { return finder_; }

--- a/net/instaweb/rewriter/critical_finder_support_util_test.cc
+++ b/net/instaweb/rewriter/critical_finder_support_util_test.cc
@@ -29,8 +29,6 @@
 namespace net_instaweb {
 namespace {
 
-const int kSupportInterval = 10;
-
 class CriticalFinderSupportUtilTest : public RewriteTestBase {
  protected:
   CriticalFinderSupportUtilTest() {}

--- a/net/instaweb/rewriter/csp.cc
+++ b/net/instaweb/rewriter/csp.cc
@@ -388,7 +388,7 @@ bool CspSourceExpression::ParseBase64(StringPiece input) {
 
 bool CspSourceExpression::HasDefaultPortForScheme(const GoogleUrl& url) {
   int url_scheme_port = GoogleUrl::DefaultPortForScheme(url.Scheme());
-  if (url_scheme_port == url::PORT_UNSPECIFIED) {
+  if (GoogleUrl::isPortGurlUnspecified(url_scheme_port)) {
     return false;
   }
 

--- a/net/instaweb/rewriter/css_embedded_config_test.cc
+++ b/net/instaweb/rewriter/css_embedded_config_test.cc
@@ -32,7 +32,6 @@
 
 namespace {
 
-const char kBikePngFile[] = "BikeCrashIcn.png";
 const char kCuppaPngFile[] = "Cuppa.png";
 const char kDummyContent[] = "Invalid PNG but it does not matter for this test";
 const char kPuzzleJpgFile[] = "Puzzle.jpg";

--- a/net/instaweb/rewriter/url_input_resource.cc
+++ b/net/instaweb/rewriter/url_input_resource.cc
@@ -65,7 +65,8 @@ UrlInputResource::UrlInputResource(RewriteDriver* rewrite_driver,
   set_is_authorized_domain(is_authorized_domain);
   if (!is_authorized_domain) {
     GoogleUrl tmp_url(url);
-    if (tmp_url.IsWebValid() && tmp_url.IntPort() == url::PORT_UNSPECIFIED) {
+    if (tmp_url.IsWebValid() &&
+        GoogleUrl::isPortGurlUnspecified(tmp_url.IntPort())) {
       // Note: Port 80 and 443 are considered as "unspecified" ports for http
       // and https respectively, so we will allow URLs that carry the
       // expected port numbers wrt the protocols.

--- a/net/instaweb/rewriter/url_input_resource_test.cc
+++ b/net/instaweb/rewriter/url_input_resource_test.cc
@@ -298,14 +298,17 @@ struct PortTest {
 TEST_F(UrlInputResourceTest, IntPort) {
   const PortTest port_tests[] = {
       // http
-      {"http://www.google.com/", 80, url::PORT_UNSPECIFIED},
-      {"http://www.google.com:80/", 80, url::PORT_UNSPECIFIED},
+      {"http://www.google.com/", 80, GoogleUrl::getGurlUnspecifiedPortNumber()},
+      {"http://www.google.com:80/", 80,
+       GoogleUrl::getGurlUnspecifiedPortNumber()},
       {"http://www.google.com:443/", 443, 443},
       {"http://www.google.com:1234/", 1234, 1234},
 
       // https
-      {"https://www.google.com/", 443, url::PORT_UNSPECIFIED},
-      {"https://www.google.com:443/", 443, url::PORT_UNSPECIFIED},
+      {"https://www.google.com/", 443,
+       GoogleUrl::getGurlUnspecifiedPortNumber()},
+      {"https://www.google.com:443/", 443,
+       GoogleUrl::getGurlUnspecifiedPortNumber()},
       {"https://www.google.com:80/", 80, 80},
       {"https://www.google.com:1234/", 1234, 1234},
   };

--- a/pagespeed/apache/mod_instaweb.cc
+++ b/pagespeed/apache/mod_instaweb.cc
@@ -43,7 +43,9 @@
 #include "pagespeed/apache/header_util.h"
 #include "pagespeed/apache/instaweb_context.h"
 #include "pagespeed/apache/instaweb_handler.h"
+// clang-format off
 #include "pagespeed/apache/mod_instaweb.h"
+// clang-format on
 #include "pagespeed/kernel/base/basictypes.h"
 #include "pagespeed/kernel/base/message_handler.h"
 #include "pagespeed/kernel/base/scoped_ptr.h"

--- a/pagespeed/controller/rpc_handler_test.cc
+++ b/pagespeed/controller/rpc_handler_test.cc
@@ -22,7 +22,9 @@
 #include "pagespeed/controller/grpc_server_test.h"
 #include "pagespeed/controller/grpc_test.grpc.pb.h"
 #include "pagespeed/controller/grpc_test.pb.h"
+// clang-format off
 #include "pagespeed/controller/rpc_handler.h"
+// clang-format on
 #include "pagespeed/kernel/base/gmock.h"
 #include "pagespeed/kernel/base/gtest.h"
 #include "pagespeed/kernel/base/proto_matcher.h"

--- a/pagespeed/kernel/base/fast_wildcard_group_speed_test.cc
+++ b/pagespeed/kernel/base/fast_wildcard_group_speed_test.cc
@@ -24,7 +24,9 @@
 #include "pagespeed/kernel/base/string.h"
 #include "pagespeed/kernel/base/string_util.h"
 #include "pagespeed/kernel/base/wildcard_group.h"
+// clang-format off
 #include "pagespeed/kernel/base/benchmark.h"
+// clang-format on
 
 //
 // (8 X 2262 MHz CPUs); 2012/07/11-19:20:51

--- a/pagespeed/kernel/base/file_system_speed_test.cc
+++ b/pagespeed/kernel/base/file_system_speed_test.cc
@@ -24,7 +24,9 @@
 #include "pagespeed/kernel/base/string.h"
 #include "pagespeed/kernel/base/string_util.h"
 #include "pagespeed/kernel/base/string_writer.h"
+// clang-format off
 #include "pagespeed/kernel/base/benchmark.h"
+// clang-format on
 
 // Running the speed test:
 //   src/out/Release/mod_pagespeed_speed_test .File

--- a/pagespeed/kernel/base/string_multi_map_speed_test.cc
+++ b/pagespeed/kernel/base/string_multi_map_speed_test.cc
@@ -23,7 +23,9 @@
 #include "pagespeed/kernel/base/basictypes.h"
 #include "pagespeed/kernel/base/string_multi_map.h"
 #include "pagespeed/kernel/base/string_util.h"
+// clang-format off
 #include "pagespeed/kernel/base/benchmark.h"
+// clang-format on
 
 //
 // .../src/out/Release/mod_pagespeed_speed_test "BM_Sanitize*

--- a/pagespeed/kernel/base/string_util.h
+++ b/pagespeed/kernel/base/string_util.h
@@ -22,28 +22,24 @@
 
 #include <cctype>  // for isascii
 #include <cstddef>
+#include <cstdlib>  // NOLINT
+#include <iostream>
 #include <map>
 #include <set>
+#include <string>  // NOLINT
 #include <vector>
 
-#include <iostream>
-
+#include "absl/strings/internal/memutil.h"  // StripAsciiWhitespace
+#include "absl/strings/match.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
-#include "absl/strings/internal/memutil.h"  // StripAsciiWhitespace
-#include "absl/strings/match.h"
-
-#include "pagespeed/kernel/base/basictypes.h"
-#include "pagespeed/kernel/base/string.h"
-
+#include "base/logging.h"
 #include "fmt/format.h"
 #include "fmt/printf.h"
-#include "base/logging.h"
-
-#include <cstdlib>  // NOLINT
-#include <string>   // NOLINT
+#include "pagespeed/kernel/base/basictypes.h"
+#include "pagespeed/kernel/base/string.h"
 
 static const int32 kint32max = 0x7FFFFFFF;
 static const int32 kint32min = -kint32max - 1;

--- a/pagespeed/kernel/cache/compressed_cache_speed_test.cc
+++ b/pagespeed/kernel/cache/compressed_cache_speed_test.cc
@@ -48,7 +48,9 @@
 #include "pagespeed/kernel/util/platform.h"
 #include "pagespeed/kernel/util/simple_random.h"
 #include "pagespeed/kernel/util/simple_stats.h"
+// clang-format off
 #include "pagespeed/kernel/base/benchmark.h"
+// clang-format on
 
 namespace {
 

--- a/pagespeed/kernel/cache/lru_cache_speed_test.cc
+++ b/pagespeed/kernel/cache/lru_cache_speed_test.cc
@@ -45,7 +45,9 @@
 #include "pagespeed/kernel/base/string_util.h"
 #include "pagespeed/kernel/cache/lru_cache.h"
 #include "pagespeed/kernel/util/simple_random.h"
+// clang-format off
 #include "pagespeed/kernel/base/benchmark.h"
+// clang-format on
 
 namespace {
 

--- a/pagespeed/kernel/http/google_url.cc
+++ b/pagespeed/kernel/http/google_url.cc
@@ -63,7 +63,7 @@ GoogleUrl::GoogleUrl(const GoogleUrl& base, const char* str) {
   Reset(base, str);
 }
 
-GoogleUrl::~GoogleUrl() { deleteGurlInternal(); }
+GoogleUrl::~GoogleUrl() { setGurlInternal(nullptr); }
 
 void GoogleUrl::Swap(GoogleUrl* google_url) {
   gurl_->Swap(google_url->gurl_);
@@ -82,15 +82,18 @@ void GoogleUrl::Init() {
 }
 
 bool GoogleUrl::ResolveHelper(const GURL& base, const std::string& url) {
-  deleteGurlInternal();
-  gurl_ = new GURL(base.Resolve(url));
-  Init();
+  setGurlInternal(new GURL(base.Resolve(url)));
   return gurl_->is_valid();
 }
 
-void GoogleUrl::deleteGurlInternal() {
+void GoogleUrl::setGurlInternal(GURL* gurl) {
   if (gurl_ != nullptr) {
     delete gurl_;
+  }
+  if (gurl != nullptr) {
+    gurl_ = gurl;
+    Init();
+  } else {
     gurl_ = nullptr;
     is_web_valid_ = false;
     is_web_or_data_valid_ = false;
@@ -110,24 +113,16 @@ bool GoogleUrl::Reset(const GoogleUrl& base, const char* str) {
 }
 
 bool GoogleUrl::Reset(StringPiece new_value) {
-  deleteGurlInternal();
-  gurl_ = new GURL(new_value.as_string());
-  Init();
+  setGurlInternal(new GURL(new_value.as_string()));
   return gurl_->is_valid();
 }
 
 bool GoogleUrl::Reset(const GoogleUrl& new_value) {
-  deleteGurlInternal();
-  gurl_ = new GURL(*new_value.gurl_);
-  Init();
+  setGurlInternal(new GURL(*new_value.gurl_));
   return gurl_->is_valid();
 }
 
-void GoogleUrl::Clear() {
-  deleteGurlInternal();
-  gurl_ = new GURL();
-  Init();
-}
+void GoogleUrl::Clear() { setGurlInternal(new GURL()); }
 
 bool GoogleUrl::IsWebValid() const {
   DCHECK(is_web_valid_ ==

--- a/pagespeed/kernel/http/google_url.cc
+++ b/pagespeed/kernel/http/google_url.cc
@@ -26,24 +26,30 @@
 #include <string>
 
 #include "base/logging.h"
-////#include "strings/stringpiece_utils.h"
 #include "pagespeed/kernel/base/string.h"
 #include "pagespeed/kernel/base/string_util.h"
 #include "pagespeed/kernel/http/query_params.h"
+#include "url/gurl.h"
+#include "url/url_parse_internal.h"
+#include "url/url_util.h"
 
 namespace net_instaweb {
 
 const size_t GoogleUrl::npos = std::string::npos;
 
-GoogleUrl::GoogleUrl() : gurl_() { Init(); }
+GoogleUrl::GoogleUrl() : gurl_(new GURL()) { Init(); }
 
-GoogleUrl::GoogleUrl(const GURL& gurl) : gurl_(gurl) { Init(); }
+GoogleUrl::GoogleUrl(const GURL& gurl) : gurl_(new GURL(gurl)) { Init(); }
 
-GoogleUrl::GoogleUrl(const GoogleString& spec) : gurl_(spec) { Init(); }
+GoogleUrl::GoogleUrl(const GoogleString& spec) : gurl_(new GURL(spec)) {
+  Init();
+}
 
-GoogleUrl::GoogleUrl(StringPiece sp) : gurl_(sp.as_string()) { Init(); }
+GoogleUrl::GoogleUrl(StringPiece sp) : gurl_(new GURL(sp.as_string())) {
+  Init();
+}
 
-GoogleUrl::GoogleUrl(const char* str) : gurl_(str) { Init(); }
+GoogleUrl::GoogleUrl(const char* str) : gurl_(new GURL(str)) { Init(); }
 
 // The following three constructors create a new GoogleUrl by resolving the
 // String(Piece) against the base.
@@ -57,8 +63,10 @@ GoogleUrl::GoogleUrl(const GoogleUrl& base, const char* str) {
   Reset(base, str);
 }
 
+GoogleUrl::~GoogleUrl() { deleteGurlInternal(); }
+
 void GoogleUrl::Swap(GoogleUrl* google_url) {
-  gurl_.Swap(&google_url->gurl_);
+  gurl_->Swap(google_url->gurl_);
   bool old_is_web_valid = is_web_valid_;
   bool old_is_web_or_data_valid = is_web_or_data_valid_;
   is_web_valid_ = google_url->is_web_valid_;
@@ -68,60 +76,73 @@ void GoogleUrl::Swap(GoogleUrl* google_url) {
 }
 
 void GoogleUrl::Init() {
-  is_web_valid_ = gurl_.is_valid() && (SchemeIs("http") || SchemeIs("https"));
+  is_web_valid_ = gurl_->is_valid() && (SchemeIs("http") || SchemeIs("https"));
   is_web_or_data_valid_ =
-      is_web_valid_ || (gurl_.is_valid() && SchemeIs("data"));
+      is_web_valid_ || (gurl_->is_valid() && SchemeIs("data"));
 }
 
 bool GoogleUrl::ResolveHelper(const GURL& base, const std::string& url) {
-  gurl_ = base.Resolve(url);
+  deleteGurlInternal();
+  gurl_ = new GURL(base.Resolve(url));
   Init();
-  return gurl_.is_valid();
+  return gurl_->is_valid();
+}
+
+void GoogleUrl::deleteGurlInternal() {
+  if (gurl_ != nullptr) {
+    delete gurl_;
+    gurl_ = nullptr;
+    is_web_valid_ = false;
+    is_web_or_data_valid_ = false;
+  }
 }
 
 bool GoogleUrl::Reset(const GoogleUrl& base, const GoogleString& str) {
-  return ResolveHelper(base.gurl_, str);
+  return ResolveHelper(*base.gurl_, str);
 }
 
 bool GoogleUrl::Reset(const GoogleUrl& base, StringPiece sp) {
-  return ResolveHelper(base.gurl_, sp.as_string());
+  return ResolveHelper(*base.gurl_, sp.as_string());
 }
 
 bool GoogleUrl::Reset(const GoogleUrl& base, const char* str) {
-  return ResolveHelper(base.gurl_, str);
+  return ResolveHelper(*base.gurl_, str);
 }
 
 bool GoogleUrl::Reset(StringPiece new_value) {
-  gurl_ = GURL(new_value.as_string());
+  deleteGurlInternal();
+  gurl_ = new GURL(new_value.as_string());
   Init();
-  return gurl_.is_valid();
+  return gurl_->is_valid();
 }
 
 bool GoogleUrl::Reset(const GoogleUrl& new_value) {
-  gurl_ = GURL(new_value.gurl_);
+  deleteGurlInternal();
+  gurl_ = new GURL(*new_value.gurl_);
   Init();
-  return gurl_.is_valid();
+  return gurl_->is_valid();
 }
 
 void GoogleUrl::Clear() {
-  gurl_ = GURL();
+  deleteGurlInternal();
+  gurl_ = new GURL();
   Init();
 }
 
 bool GoogleUrl::IsWebValid() const {
   DCHECK(is_web_valid_ ==
-         (gurl_.is_valid() && (SchemeIs("http") || SchemeIs("https"))));
+         (gurl_->is_valid() && (SchemeIs("http") || SchemeIs("https"))));
   return is_web_valid_;
 }
 
 bool GoogleUrl::IsWebOrDataValid() const {
   DCHECK(is_web_or_data_valid_ ==
-         (gurl_.is_valid() &&
+         (gurl_->is_valid() &&
           (SchemeIs("http") || SchemeIs("https") || SchemeIs("data"))));
   return is_web_or_data_valid_;
 }
 
-bool GoogleUrl::IsAnyValid() const { return gurl_.is_valid(); }
+bool GoogleUrl::IsAnyValid() const { return gurl_->is_valid(); }
 
 GoogleUrl* GoogleUrl::CopyAndAddQueryParam(StringPiece unescaped_name,
                                            StringPiece unescaped_value) const {
@@ -144,7 +165,7 @@ GoogleUrl* GoogleUrl::CopyAndAddEscapedQueryParam(
   url::Component query;
   query.len = query_params_string.size();
   replace_query.SetQuery(query_params_string.c_str(), query);
-  GoogleUrl* result = new GoogleUrl(gurl_.ReplaceComponents(replace_query));
+  GoogleUrl* result = new GoogleUrl(gurl_->ReplaceComponents(replace_query));
   return result;
 }
 
@@ -173,7 +194,7 @@ size_t GoogleUrl::LeafEndPosition(const GURL& gurl) {
 
 // Returns the offset at which the leaf ends in valid url spec.
 // If there is no path, steps backward until valid end is found.
-size_t GoogleUrl::LeafEndPosition() const { return LeafEndPosition(gurl_); }
+size_t GoogleUrl::LeafEndPosition() const { return LeafEndPosition(*gurl_); }
 
 size_t GoogleUrl::LeafStartPosition(const GURL& gurl) {
   url::Parsed parsed = gurl.parsed_for_possibly_invalid_spec();
@@ -188,7 +209,9 @@ size_t GoogleUrl::LeafStartPosition(const GURL& gurl) {
 
 // Returns the offset at which the leaf starts in the fully
 // qualified spec.
-size_t GoogleUrl::LeafStartPosition() const { return LeafStartPosition(gurl_); }
+size_t GoogleUrl::LeafStartPosition() const {
+  return LeafStartPosition(*gurl_);
+}
 
 size_t GoogleUrl::PathStartPosition(const GURL& gurl) {
   const std::string& spec = gurl.spec();
@@ -203,15 +226,17 @@ size_t GoogleUrl::PathStartPosition(const GURL& gurl) {
 }
 
 // Find the start of the path, includes '/'
-size_t GoogleUrl::PathStartPosition() const { return PathStartPosition(gurl_); }
+size_t GoogleUrl::PathStartPosition() const {
+  return PathStartPosition(*gurl_);
+}
 
 StringPiece GoogleUrl::AllExceptQuery() const {
-  if (!gurl_.is_valid()) {
-    LOG(DFATAL) << "Invalid URL: " << gurl_.possibly_invalid_spec();
+  if (!gurl_->is_valid()) {
+    LOG(DFATAL) << "Invalid URL: " << gurl_->possibly_invalid_spec();
     return StringPiece();
   }
 
-  const std::string& spec = gurl_.possibly_invalid_spec();
+  const std::string& spec = gurl_->possibly_invalid_spec();
   size_t leaf_end = LeafEndPosition();
   if (leaf_end == npos) {
     return StringPiece();
@@ -221,15 +246,15 @@ StringPiece GoogleUrl::AllExceptQuery() const {
 }
 
 StringPiece GoogleUrl::AllAfterQuery() const {
-  if (!gurl_.is_valid()) {
-    LOG(DFATAL) << "Invalid URL: " << gurl_.possibly_invalid_spec();
+  if (!gurl_->is_valid()) {
+    LOG(DFATAL) << "Invalid URL: " << gurl_->possibly_invalid_spec();
     return StringPiece();
   }
 
-  const std::string& spec = gurl_.possibly_invalid_spec();
-  url::Parsed parsed = gurl_.parsed_for_possibly_invalid_spec();
+  const std::string& spec = gurl_->possibly_invalid_spec();
+  url::Parsed parsed = gurl_->parsed_for_possibly_invalid_spec();
   size_t query_end;
-  if (gurl_.has_query()) {
+  if (gurl_->has_query()) {
     query_end = parsed.query.end();
   } else {
     query_end = LeafEndPosition();
@@ -247,8 +272,8 @@ StringPiece GoogleUrl::AllAfterQuery() const {
 // it's a ? so I believe this implies that the first ? has to delimit
 // the query string.
 StringPiece GoogleUrl::AllExceptLeaf() const {
-  if (!gurl_.is_valid()) {
-    LOG(DFATAL) << "Invalid URL: " << gurl_.possibly_invalid_spec();
+  if (!gurl_->is_valid()) {
+    LOG(DFATAL) << "Invalid URL: " << gurl_->possibly_invalid_spec();
     return StringPiece();
   }
 
@@ -258,13 +283,13 @@ StringPiece GoogleUrl::AllExceptLeaf() const {
     return StringPiece();
   } else {
     size_t after_last_slash = last_slash + 1;
-    return StringPiece(gurl_.spec().data(), after_last_slash);
+    return StringPiece(gurl_->spec().data(), after_last_slash);
   }
 }
 
 StringPiece GoogleUrl::LeafWithQuery() const {
-  if (!gurl_.is_valid()) {
-    LOG(DFATAL) << "Invalid URL: " << gurl_.possibly_invalid_spec();
+  if (!gurl_->is_valid()) {
+    LOG(DFATAL) << "Invalid URL: " << gurl_->possibly_invalid_spec();
     return StringPiece();
   }
 
@@ -274,15 +299,15 @@ StringPiece GoogleUrl::LeafWithQuery() const {
     return StringPiece();
   } else {
     size_t after_last_slash = last_slash + 1;
-    const std::string& spec = gurl_.spec();
+    const std::string& spec = gurl_->spec();
     return StringPiece(spec.data() + after_last_slash,
                        spec.size() - after_last_slash);
   }
 }
 
 StringPiece GoogleUrl::LeafSansQuery() const {
-  if (!gurl_.is_valid()) {
-    LOG(DFATAL) << "Invalid URL: " << gurl_.possibly_invalid_spec();
+  if (!gurl_->is_valid()) {
+    LOG(DFATAL) << "Invalid URL: " << gurl_->possibly_invalid_spec();
     return StringPiece();
   }
 
@@ -291,12 +316,12 @@ StringPiece GoogleUrl::LeafSansQuery() const {
     return StringPiece();
   }
   size_t after_last_slash = leaf_start + 1;
-  const std::string& spec = gurl_.spec();
+  const std::string& spec = gurl_->spec();
   size_t leaf_length = spec.size() - after_last_slash;
-  if (!gurl_.has_query()) {
+  if (!gurl_->has_query()) {
     return StringPiece(spec.data() + after_last_slash, leaf_length);
   }
-  url::Parsed parsed = gurl_.parsed_for_possibly_invalid_spec();
+  url::Parsed parsed = gurl_->parsed_for_possibly_invalid_spec();
   if (!parsed.query.is_valid()) {
     return StringPiece();
   } else {
@@ -308,8 +333,8 @@ StringPiece GoogleUrl::LeafSansQuery() const {
 
 // For "http://a.com/b/c/d?e=f/g returns "http://a.com" without trailing slash
 StringPiece GoogleUrl::Origin() const {
-  if (!gurl_.is_valid()) {
-    LOG(DFATAL) << "Invalid URL: " << gurl_.possibly_invalid_spec();
+  if (!gurl_->is_valid()) {
+    LOG(DFATAL) << "Invalid URL: " << gurl_->possibly_invalid_spec();
     return StringPiece();
   }
 
@@ -317,14 +342,14 @@ StringPiece GoogleUrl::Origin() const {
   if (origin_size == npos) {
     return StringPiece();
   } else {
-    return StringPiece(gurl_.spec().data(), origin_size);
+    return StringPiece(gurl_->spec().data(), origin_size);
   }
 }
 
 // For "http://a.com/b/c/d?e=f/g returns "/b/c/d?e=f/g" including leading slash
 StringPiece GoogleUrl::PathAndLeaf() const {
-  if (!gurl_.is_valid()) {
-    LOG(DFATAL) << "Invalid URL: " << gurl_.possibly_invalid_spec();
+  if (!gurl_->is_valid()) {
+    LOG(DFATAL) << "Invalid URL: " << gurl_->possibly_invalid_spec();
     return StringPiece();
   }
 
@@ -332,7 +357,7 @@ StringPiece GoogleUrl::PathAndLeaf() const {
   if (origin_size == npos) {
     return StringPiece();
   } else {
-    const std::string& spec = gurl_.spec();
+    const std::string& spec = gurl_->spec();
     return StringPiece(spec.data() + origin_size, spec.size() - origin_size);
   }
 }
@@ -340,8 +365,8 @@ StringPiece GoogleUrl::PathAndLeaf() const {
 // For "http://a.com/b/c/d/g.html?q=v" returns "/b/c/d/" including leading and
 // trailing slashes.
 StringPiece GoogleUrl::PathSansLeaf() const {
-  if (!gurl_.is_valid()) {
-    LOG(DFATAL) << "Invalid URL: " << gurl_.possibly_invalid_spec();
+  if (!gurl_->is_valid()) {
+    LOG(DFATAL) << "Invalid URL: " << gurl_->possibly_invalid_spec();
     return StringPiece();
   }
 
@@ -352,22 +377,22 @@ StringPiece GoogleUrl::PathSansLeaf() const {
     return StringPiece();
   } else {
     size_t after_last_slash = leaf_start + 1;
-    return StringPiece(gurl_.spec().data() + path_start,
+    return StringPiece(gurl_->spec().data() + path_start,
                        after_last_slash - path_start);
   }
 }
 
 StringPiece GoogleUrl::NetPath() const {
-  if (!gurl_.is_valid()) {
-    LOG(DFATAL) << "Invalid URL: " << gurl_.possibly_invalid_spec();
+  if (!gurl_->is_valid()) {
+    LOG(DFATAL) << "Invalid URL: " << gurl_->possibly_invalid_spec();
     return StringPiece();
   }
 
-  if (!gurl_.has_scheme()) {
+  if (!gurl_->has_scheme()) {
     return Spec();
   }
-  const std::string& spec = gurl_.possibly_invalid_spec();
-  url::Parsed parsed = gurl_.parsed_for_possibly_invalid_spec();
+  const std::string& spec = gurl_->possibly_invalid_spec();
+  url::Parsed parsed = gurl_->parsed_for_possibly_invalid_spec();
   // Just remove scheme and : from beginning of URL.
   return StringPiece(spec.data() + parsed.scheme.end() + 1,
                      spec.size() - parsed.scheme.end() - 1);
@@ -376,92 +401,92 @@ StringPiece GoogleUrl::NetPath() const {
 // Extracts the filename portion of the path and returns it. The filename
 // is everything after the last slash in the path. This may be empty.
 GoogleString GoogleUrl::ExtractFileName() const {
-  if (!gurl_.is_valid()) {
-    LOG(DFATAL) << "Invalid URL: " << gurl_.possibly_invalid_spec();
+  if (!gurl_->is_valid()) {
+    LOG(DFATAL) << "Invalid URL: " << gurl_->possibly_invalid_spec();
     return "";
   }
 
-  return gurl_.ExtractFileName();
+  return gurl_->ExtractFileName();
 }
 
 StringPiece GoogleUrl::Host() const {
-  if (!gurl_.is_valid()) {
-    LOG(DFATAL) << "Invalid URL: " << gurl_.possibly_invalid_spec();
+  if (!gurl_->is_valid()) {
+    LOG(DFATAL) << "Invalid URL: " << gurl_->possibly_invalid_spec();
     return StringPiece();
   }
 
-  if (!gurl_.has_host()) {
+  if (!gurl_->has_host()) {
     return StringPiece();
   }
-  url::Parsed parsed = gurl_.parsed_for_possibly_invalid_spec();
+  url::Parsed parsed = gurl_->parsed_for_possibly_invalid_spec();
   // Just remove scheme and : from beginning of URL.
-  return StringPiece(gurl_.spec().data() + parsed.host.begin, parsed.host.len);
+  return StringPiece(gurl_->spec().data() + parsed.host.begin, parsed.host.len);
 }
 
 StringPiece GoogleUrl::HostAndPort() const {
-  if (!gurl_.is_valid()) {
-    LOG(DFATAL) << "Invalid URL: " << gurl_.possibly_invalid_spec();
+  if (!gurl_->is_valid()) {
+    LOG(DFATAL) << "Invalid URL: " << gurl_->possibly_invalid_spec();
     return StringPiece();
   }
 
-  if (!gurl_.has_host()) {
+  if (!gurl_->has_host()) {
     return StringPiece();
   }
-  url::Parsed parsed = gurl_.parsed_for_possibly_invalid_spec();
-  return StringPiece(gurl_.spec().data() + parsed.host.begin,
+  url::Parsed parsed = gurl_->parsed_for_possibly_invalid_spec();
+  return StringPiece(gurl_->spec().data() + parsed.host.begin,
                      parsed.host.len + parsed.port.len + 1);  // Yes, it works.
 }
 
 StringPiece GoogleUrl::PathSansQuery() const {
-  if (!gurl_.is_valid()) {
-    LOG(DFATAL) << "Invalid URL: " << gurl_.possibly_invalid_spec();
+  if (!gurl_->is_valid()) {
+    LOG(DFATAL) << "Invalid URL: " << gurl_->possibly_invalid_spec();
     return StringPiece();
   }
 
-  url::Parsed parsed = gurl_.parsed_for_possibly_invalid_spec();
+  url::Parsed parsed = gurl_->parsed_for_possibly_invalid_spec();
   size_t path_start = PathStartPosition();
   if (path_start == npos || !parsed.path.is_valid()) {
     return StringPiece();
   } else {
-    return StringPiece(gurl_.spec().data() + path_start, parsed.path.len);
+    return StringPiece(gurl_->spec().data() + path_start, parsed.path.len);
   }
 }
 
 StringPiece GoogleUrl::Query() const {
-  if (!gurl_.is_valid()) {
-    LOG(DFATAL) << "Invalid URL: " << gurl_.possibly_invalid_spec();
+  if (!gurl_->is_valid()) {
+    LOG(DFATAL) << "Invalid URL: " << gurl_->possibly_invalid_spec();
     return StringPiece();
   }
 
-  if (!gurl_.has_query()) {
+  if (!gurl_->has_query()) {
     return StringPiece();
   }
-  url::Parsed parsed = gurl_.parsed_for_possibly_invalid_spec();
-  return StringPiece(gurl_.spec().data() + parsed.query.begin,
+  url::Parsed parsed = gurl_->parsed_for_possibly_invalid_spec();
+  return StringPiece(gurl_->spec().data() + parsed.query.begin,
                      parsed.query.len);
 }
 
 StringPiece GoogleUrl::Scheme() const {
-  if (!gurl_.is_valid()) {
-    LOG(DFATAL) << "Invalid URL: " << gurl_.possibly_invalid_spec();
+  if (!gurl_->is_valid()) {
+    LOG(DFATAL) << "Invalid URL: " << gurl_->possibly_invalid_spec();
     return StringPiece();
   }
 
-  if (!gurl_.has_scheme()) {
+  if (!gurl_->has_scheme()) {
     return StringPiece();
   }
-  url::Parsed parsed = gurl_.parsed_for_possibly_invalid_spec();
-  return StringPiece(gurl_.spec().data() + parsed.scheme.begin,
+  url::Parsed parsed = gurl_->parsed_for_possibly_invalid_spec();
+  return StringPiece(gurl_->spec().data() + parsed.scheme.begin,
                      parsed.scheme.len);
 }
 
 StringPiece GoogleUrl::Spec() const {
-  const std::string& spec = gurl_.spec();
+  const std::string& spec = gurl_->spec();
   return StringPiece(spec.data(), spec.size());
 }
 
 StringPiece GoogleUrl::UncheckedSpec() const {
-  const std::string& spec = gurl_.possibly_invalid_spec();
+  const std::string& spec = gurl_->possibly_invalid_spec();
   return StringPiece(spec.data(), spec.size());
 }
 
@@ -670,5 +695,38 @@ GoogleString GoogleUrl::CanonicalizePath(StringPiece path) {
   output.Complete();
   return buffer.substr(out_range.begin, out_range.len);
 }
+
+const char* GoogleUrl::spec_c_str() const {
+  return gurl_->possibly_invalid_spec().c_str();
+}
+
+int GoogleUrl::IntPort() const { return gurl_->IntPort(); }
+
+int GoogleUrl::EffectiveIntPort() const { return gurl_->EffectiveIntPort(); }
+
+bool GoogleUrl::is_empty() const { return gurl_->is_empty(); }
+bool GoogleUrl::has_scheme() const { return gurl_->has_scheme(); }
+bool GoogleUrl::has_path() const { return gurl_->has_path(); }
+bool GoogleUrl::has_query() const { return gurl_->has_query(); }
+
+bool GoogleUrl::SchemeIs(const char* lower_ascii_scheme) const {
+  return gurl_->SchemeIs(lower_ascii_scheme);
+}
+bool GoogleUrl::SchemeIs(StringPiece lower_ascii_scheme) const {
+  return gurl_->SchemeIs(lower_ascii_scheme.as_string().c_str());
+}
+
+bool GoogleUrl::operator==(const GoogleUrl& other) const {
+  return *gurl_ == *other.gurl_;
+}
+bool GoogleUrl::operator!=(const GoogleUrl& other) const {
+  return *gurl_ != *other.gurl_;
+}
+
+bool GoogleUrl::isPortGurlUnspecified(int port) {
+  return port == url::PORT_UNSPECIFIED;
+}
+
+int GoogleUrl::getGurlUnspecifiedPortNumber() { return url::PORT_UNSPECIFIED; }
 
 }  // namespace net_instaweb

--- a/pagespeed/kernel/http/google_url.cc
+++ b/pagespeed/kernel/http/google_url.cc
@@ -76,9 +76,15 @@ void GoogleUrl::Swap(GoogleUrl* google_url) {
 }
 
 void GoogleUrl::Init() {
-  is_web_valid_ = gurl_->is_valid() && (SchemeIs("http") || SchemeIs("https"));
-  is_web_or_data_valid_ =
-      is_web_valid_ || (gurl_->is_valid() && SchemeIs("data"));
+  if (gurl_ == nullptr) {
+    is_web_valid_ = false;
+    is_web_or_data_valid_ = false;
+  } else {
+    is_web_valid_ =
+        gurl_->is_valid() && (SchemeIs("http") || SchemeIs("https"));
+    is_web_or_data_valid_ =
+        is_web_valid_ || (gurl_->is_valid() && SchemeIs("data"));
+  }
 }
 
 bool GoogleUrl::ResolveHelper(const GURL& base, const std::string& url) {
@@ -87,17 +93,9 @@ bool GoogleUrl::ResolveHelper(const GURL& base, const std::string& url) {
 }
 
 void GoogleUrl::setGurlInternal(GURL* gurl) {
-  if (gurl_ != nullptr) {
-    delete gurl_;
-  }
-  if (gurl != nullptr) {
-    gurl_ = gurl;
-    Init();
-  } else {
-    gurl_ = nullptr;
-    is_web_valid_ = false;
-    is_web_or_data_valid_ = false;
-  }
+  delete gurl_;
+  gurl_ = gurl;
+  Init();
 }
 
 bool GoogleUrl::Reset(const GoogleUrl& base, const GoogleString& str) {

--- a/pagespeed/kernel/http/google_url.h
+++ b/pagespeed/kernel/http/google_url.h
@@ -258,7 +258,7 @@ class GoogleUrl {
 
   // Resolves a URL against a base. Returns whether the resolution worked.
   inline bool ResolveHelper(const GURL& base, const std::string& path_and_leaf);
-  void deleteGurlInternal();
+  void setGurlInternal(GURL* gurl);
 
   GURL* gurl_{nullptr};
   bool is_web_valid_{false};

--- a/pagespeed/kernel/http/google_url.h
+++ b/pagespeed/kernel/http/google_url.h
@@ -27,9 +27,8 @@
 #include "pagespeed/kernel/base/basictypes.h"
 #include "pagespeed/kernel/base/string.h"
 #include "pagespeed/kernel/base/string_util.h"
-#include "url/gurl.h"
-#include "url/url_parse_internal.h"
-#include "url/url_util.h"
+
+class GURL;
 
 namespace net_instaweb {
 
@@ -53,6 +52,7 @@ class GoogleUrl {
   GoogleUrl(const GoogleUrl& base, StringPiece relative);
   GoogleUrl(const GoogleUrl& base, const char* relative);
   GoogleUrl();
+  ~GoogleUrl();
 
   void Swap(GoogleUrl* google_url);
 
@@ -156,37 +156,31 @@ class GoogleUrl {
   // It is illegal to call this for invalid urls (check IsWebValid() first).
   StringPiece Spec() const;
 
-  // Returns gurl_.spec_ without checking to see if it's valid or empty.
+  // Returns gurl_->spec_ without checking to see if it's valid or empty.
   StringPiece UncheckedSpec() const;
 
   // This method is primarily for printf purposes.
-  const char* spec_c_str() const {
-    return gurl_.possibly_invalid_spec().c_str();
-  }
+  const char* spec_c_str() const;
 
-  int IntPort() const { return gurl_.IntPort(); }
+  int IntPort() const;
 
   // Returns the effective port number, which is dependent on the scheme.
-  int EffectiveIntPort() const { return gurl_.EffectiveIntPort(); }
+  int EffectiveIntPort() const;
 
   // Returns the default port for given scheme, or url::PORT_UNSPECIFIED
   // if the scheme isn't recognized. Scheme is expected to be in lowercase.
   static int DefaultPortForScheme(StringPiece scheme);
 
-  bool is_empty() const { return gurl_.is_empty(); }
-  bool has_scheme() const { return gurl_.has_scheme(); }
-  bool has_path() const { return gurl_.has_path(); }
-  bool has_query() const { return gurl_.has_query(); }
+  bool is_empty() const;
+  bool has_scheme() const;
+  bool has_path() const;
+  bool has_query() const;
 
-  bool SchemeIs(const char* lower_ascii_scheme) const {
-    return gurl_.SchemeIs(lower_ascii_scheme);
-  }
+  bool SchemeIs(const char* lower_ascii_scheme) const;
 
   // TODO(nforman): get GURL to take a StringPiece so we don't have to do
   // any copying.
-  bool SchemeIs(StringPiece lower_ascii_scheme) const {
-    return gurl_.SchemeIs(lower_ascii_scheme.as_string().c_str());
-  }
+  bool SchemeIs(StringPiece lower_ascii_scheme) const;
 
   // Find out how relative the URL string is.
   static UrlRelativity FindRelativity(StringPiece url);
@@ -200,8 +194,8 @@ class GoogleUrl {
                          const GoogleUrl& base_url) const;
 
   // Defiant equality operator!
-  bool operator==(const GoogleUrl& other) const { return gurl_ == other.gurl_; }
-  bool operator!=(const GoogleUrl& other) const { return gurl_ != other.gurl_; }
+  bool operator==(const GoogleUrl& other) const;
+  bool operator!=(const GoogleUrl& other) const;
 
   // Unescape a query parameter, converting all %XX to the the actual char 0xXX.
   // This also converts '+' to ' ' which is valid only in query parameters.
@@ -240,6 +234,9 @@ class GoogleUrl {
   // what's in %-encoded form and what isn't as GoogleUrl does.
   static GoogleString CanonicalizePath(StringPiece path);
 
+  static bool isPortGurlUnspecified(int port);
+  static int getGurlUnspecifiedPortNumber();
+
  private:
   // Returned by *Position methods when that position is not well-defined.
   static const size_t npos;
@@ -261,10 +258,11 @@ class GoogleUrl {
 
   // Resolves a URL against a base. Returns whether the resolution worked.
   inline bool ResolveHelper(const GURL& base, const std::string& path_and_leaf);
+  void deleteGurlInternal();
 
-  GURL gurl_;
-  bool is_web_valid_;
-  bool is_web_or_data_valid_;
+  GURL* gurl_{nullptr};
+  bool is_web_valid_{false};
+  bool is_web_or_data_valid_{false};
 
   DISALLOW_COPY_AND_ASSIGN(GoogleUrl);
 };  // class GoogleUrl

--- a/pagespeed/kernel/http/google_url_test.cc
+++ b/pagespeed/kernel/http/google_url_test.cc
@@ -28,6 +28,7 @@
 #include "pagespeed/kernel/base/string.h"
 #include "pagespeed/kernel/base/string_util.h"
 #include "pagespeed/kernel/util/simple_random.h"
+#include "url/gurl.h"
 
 namespace {
 
@@ -688,7 +689,8 @@ TEST_F(GoogleUrlTest, Sanitize) {
 }
 
 TEST_F(GoogleUrlTest, DefaultPortForScheme) {
-  EXPECT_EQ(url::PORT_UNSPECIFIED, GoogleUrl::DefaultPortForScheme("chipmunk"));
+  EXPECT_TRUE(GoogleUrl::isPortGurlUnspecified(
+      GoogleUrl::DefaultPortForScheme("chipmunk")));
   EXPECT_EQ(80, GoogleUrl::DefaultPortForScheme("http"));
   EXPECT_EQ(443, GoogleUrl::DefaultPortForScheme("https"));
   EXPECT_EQ(80, GoogleUrl::DefaultPortForScheme("ws"));

--- a/pagespeed/kernel/util/url_escaper_speed_test.cc
+++ b/pagespeed/kernel/util/url_escaper_speed_test.cc
@@ -28,9 +28,11 @@
 // can be misleading.  When contemplating an algorithm change, always do
 // interleaved runs with the old & new algorithm.
 
-#include "pagespeed/kernel/util/url_escaper.h"
-#include "pagespeed/kernel/base/benchmark.h"
 #include "pagespeed/kernel/base/string.h"
+#include "pagespeed/kernel/util/url_escaper.h"
+// clang-format off
+#include "pagespeed/kernel/base/benchmark.h"
+// clang-format on
 
 using net_instaweb::UrlEscaper::EncodeToUrlSegment;
 


### PR DESCRIPTION
Refactors GoogleUrl to not expose gurl.h & friends outside of
google_url.cc. Switches to use `GURL*` instead of `GURL` internally,
introducing the need for memory management of that.

This fixes another bunch of warnings, and makes it viable to turn
include sorting on with a few exceptions, annotated in code.

Signed-off-by: Otto van der Schaaf <oschaaf@we-amp.com>