### PR TITLE
add jquery.3.5.1 - stable version for now

### DIFF
--- a/net/instaweb/genfiles/conf/pagespeed_libraries.conf
+++ b/net/instaweb/genfiles/conf/pagespeed_libraries.conf
@@ -1234,6 +1234,10 @@
     ModPagespeedLibrary 88059 tJmcu2pzqbMS9jXP915aU //ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js
     # jquery/3.4.1/jquery.js:
     ModPagespeedLibrary 141767 YMjN_PDe4cETVTWLoSfvI //ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js
+    # jquery/3.5.1/jquery.min.js
+    ModPagespeedLibrary 89390 A8biqtTJrtWLYHojdWr-v //ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js
+    # jquery/3.5.1/jquery.js
+    ModPagespeedLibrary 143466 O426e3rTpm6_x4uifvdZK //ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.js
     # jquerymobile/1.4.0/jquery.mobile.min.js:
     ModPagespeedLibrary 193066 pkv8dHWLVaOlDGcgh0PYe //ajax.googleapis.com/ajax/libs/jquerymobile/1.4.0/jquery.mobile.min.js
     # jquerymobile/1.4.0/jquery.mobile.js:


### PR DESCRIPTION
Hello,

Add jquery.3.5.1 as it is stable version now and previous versions have security concern.

https://blog.jquery.com/2020/05/04/jquery-3-5-1-released-fixing-a-regression/

Thanks,

Eric