### PR TITLE
Get CI functional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
     - BIT_FLAG=
 
 script:
-  - bazel test --test_env=REDIS_PORT=6379 --test_env=MEMCACHED_PORT=11211 -c dbg //test/...
+  - bazel test --test_env=REDIS_PORT=6379 --test_env=MEMCACHED_PORT=11211 -c dbg  --test_output=streamed //test/...
 
 after_failure:
   - cat build.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,19 @@ before_install:
   - sudo apt-get update -q
   - sudo apt-get install -q -y git
   - sudo apt-get install pkg-config zip g++ zlib1g-dev unzip python3 ninja-build cmake gperf memcached apache2-dev python2 clang-10
-  - wget https://github.com/bazelbuild/bazel/releases/download/4.1.0/bazel-4.1.0-installer-linux-x86_64.sh
-  - chmod +x bazel-4.1.0-installer-linux-x86_64.sh
-  - ./bazel-4.1.0-installer-linux-x86_64.sh --user
+  - wget https://github.com/bazelbuild/bazel/releases/download/6.0.0-pre.20220720.3/bazel-6.0.0-pre.20220720.3-installer-linux-x86_64.sh
+  - chmod +x bazel-6.0.0-pre.20220720.3-installer-linux-x86_64.sh
+  - ./bazel-6.0.0-pre.20220720.3-installer-linux-x86_64.sh --user
+  - wget https://apt.llvm.org/llvm.sh
+  - chmod +x llvm.sh
+  - ./llvm.sh 14
   - sudo service memcached start
   - sudo service redis-server start
 env:
   global:
     - MAKEFLAGS=-j3
-    - CXX=clang++-10
-    - CC=clang-10
+    - CXX=clang++-14
+    - CC=clang-14
   matrix:
     - BIT_FLAG=
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,13 @@ before_install:
   - sudo add-apt-repository -y ppa:git-core/ppa
   - sudo apt-get update -q
   - sudo apt-get install -q -y git
-  - sudo apt-get install pkg-config zip g++ zlib1g-dev unzip python3 ninja-build cmake gperf memcached apache2-dev python2 clang-10
+  - sudo apt-get install pkg-config zip g++ zlib1g-dev unzip python3 ninja-build cmake gperf memcached apache2-dev python2
   - wget https://github.com/bazelbuild/bazel/releases/download/6.0.0-pre.20220720.3/bazel-6.0.0-pre.20220720.3-installer-linux-x86_64.sh
   - chmod +x bazel-6.0.0-pre.20220720.3-installer-linux-x86_64.sh
   - ./bazel-6.0.0-pre.20220720.3-installer-linux-x86_64.sh --user
   - wget https://apt.llvm.org/llvm.sh
   - chmod +x llvm.sh
-  - ./llvm.sh 14
+  - sudo ./llvm.sh 14
   - sudo service memcached start
   - sudo service redis-server start
 env:

--- a/test/pagespeed/system/serf_url_async_fetcher_test.cc
+++ b/test/pagespeed/system/serf_url_async_fetcher_test.cc
@@ -675,14 +675,14 @@ TEST_F(SerfUrlAsyncFetcherTest, TestHttpsFailsForSelfSignedCert) {
   ValidateMonitoringStats(0, 1);
 }
 
-TEST_F(SerfUrlAsyncFetcherTest, TestHttpsSucceedsForGoogleCom) {
+TEST_F(SerfUrlAsyncFetcherTest, TestHttpsSucceedsForMPS) {
   serf_url_async_fetcher_->SetHttpsOptions("enable");
   EXPECT_TRUE(serf_url_async_fetcher_->SupportsHttps());
   // If you're here chances are that this test broke. It is fairly brittle and depends
   // on the target page not changing it's response, which it actually does every year or so.
   // In any case, don't worry about having to change this; the goal is to test basic fetching
   // capabilities over https.
-  TestHttpsSucceeds("https://about.google/", "<!DOCTYPE html>");
+  TestHttpsSucceeds("https://www.modpagespeed.com/", "<!--");
   ValidateMonitoringStats(1, 0);
 }
 


### PR DESCRIPTION
PR to iterate on getting CI functional again. It broke, but also needs some love to work with the new Envoy update:
- update the bazel and clang/llvm versions we use.