### PR TITLE
Travis: use bazelisk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,8 @@ before_install:
   - sudo add-apt-repository -y ppa:git-core/ppa
   - sudo apt-get update -q
   - sudo apt-get install -q -y git
-  - sudo apt-get install pkg-config zip g++ zlib1g-dev unzip python3 ninja-build cmake gperf memcached apache2-dev python2
-  - wget https://github.com/bazelbuild/bazel/releases/download/6.0.0-pre.20220720.3/bazel-6.0.0-pre.20220720.3-installer-linux-x86_64.sh
-  - chmod +x bazel-6.0.0-pre.20220720.3-installer-linux-x86_64.sh
-  - ./bazel-6.0.0-pre.20220720.3-installer-linux-x86_64.sh --user
+  - sudo apt-get install pkg-config zip g++ zlib1g-dev unzip python3 ninja-build cmake gperf memcached apache2-dev python2 npm
+  - sudo npm install -g @bazel/bazelisk
   - wget https://apt.llvm.org/llvm.sh
   - chmod +x llvm.sh
   - sudo ./llvm.sh 14


### PR DESCRIPTION
Instead of hard coding bazel versions, use bazelisk which will use .bazelversion.
That has the canonical version that we use.