### PR TITLE
Update to Envoy ff49762696b2e6ed3f408a22e1f7a1b7d2487318 (Oct 11th)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -430,32 +430,4 @@ try-import %workspace%/user.bazelrc
 try-import %workspace%/local_tsan.bazelrc
 
 ###### modifications for pagespeed
-build --linkopt -ldl
-
-# objcopy 2.31 doesn't like clang-7's output unless we pass in -fno-addrsig
-# https://github.com/travitch/whole-program-llvm/issues/75
-# not passing this in will make the scripts that rename symbols fail
-#build --copt=-fno-addrsig 
-
-build:clang-asan --linkopt=-fno-sanitize=alignment
-build:asan --copt=-fno-sanitize=alignment
-build:clang-asan --copt=-fno-omit-frame-pointer
-
-test --test_env=REDIS_PORT=6379
-test --test_env=MEMCACHED_PORT=11211
-test --test_env=HTTPS_TEST=1
-
-build --copt="-Iexternal/aprutil/include/"
-build --copt="-Iexternal/aprutil/include/private/"
-build --copt="-Iexternal/aprutil/include/arch/unix/"
-build --copt="-Iexternal/aprutil/"
-build --copt="-Ithird_party/aprutil/gen/arch/linux/x64/include/"
-build --copt="-Ithird_party/apr/gen/arch/linux/x64/include/"
-build --copt="-Iexternal/apr/include/"
-build --copt="-Iexternal/apr/include/arch/unix/"
-build --copt="-Iexternal/apr/"
-build --copt="-Iexternal/serf/include/"
-build --copt="-Iexternal/serf/"
-build --copt="-DPAGESPEED_SUPPORT_POSIX_SHARED_MEM=1"
-
-build --action_env=BAZEL_CXXOPTS="-std=c++17"
+try-import %workspace%/pagespeed.bazelrc

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,12 +1,3 @@
-# The following .bazelrc content is forked from the main Envoy repository.                  # unique
-# This is necessary since this needs to be available before we can access                   # unique
-# the Envoy repository contents via Bazel.                                                  # unique
-                                                                                            # unique
-build:clang-asan --test_timeout=900                                                         # unique
-build:clang-tsan --test_timeout=900                                                         # unique
-# See https://github.com/envoyproxy/nighthawk/issues/405                                    # unique
-build:macos --copt -UDEBUG                                                                  # unique
-                                                                                            # unique
 # Envoy specific Bazel build/test options.
 
 # Bazel doesn't need more than 200MB of memory for local build based on memory profiling:
@@ -23,8 +14,6 @@ run --color=yes
 
 build --color=yes
 build --workspace_status_command="bash bazel/get_workspace_status"
-# TODO: https://github.com/envoyproxy/envoy/issues/22758
-build --incompatible_use_platforms_repo_for_constraints=false
 build --incompatible_strict_action_env
 build --host_force_python=PY3
 build --java_runtime_version=remotejdk_11
@@ -49,7 +38,7 @@ common --experimental_allow_tags_propagation
 # (Workaround for https://github.com/bazelbuild/rules_foreign_cc/issues/421)
 build:linux --copt=-fPIC
 build:linux --copt=-Wno-deprecated-declarations
-build:linux --cxxopt=-std=c++17
+build:linux --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
 build:linux --conlyopt=-fexceptions
 build:linux --fission=dbg,opt
 build:linux --features=per_object_debug_info
@@ -109,11 +98,10 @@ build:clang-asan --linkopt --rtlib=compiler-rt
 build:clang-asan --linkopt --unwindlib=libgcc
 
 # macOS
-build:macos --cxxopt=-std=c++17
+build:macos --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
 build:macos --action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
 build:macos --host_action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
 build:macos --define tcmalloc=disabled
-build:macos --define wasm=disabled
 
 # macOS ASAN/UBSAN
 build:macos-asan --config=asan
@@ -192,7 +180,7 @@ build:coverage --strategy=CoverageReport=sandboxed,local
 build:coverage --experimental_use_llvm_covmap
 build:coverage --collect_code_coverage
 build:coverage --test_tag_filters=-nocoverage
-build:coverage --instrumentation_filter="//source(?!/common/quic/platform)[/:],//include[/:],//contrib(?!/.*/test)[/:]"
+build:coverage --instrumentation_filter="//source(?!/common/quic/platform)[/:],//envoy[/:],//contrib(?!/.*/test)[/:]"
 build:test-coverage --test_arg="-l trace"
 build:fuzz-coverage --config=plain-fuzzer
 build:fuzz-coverage --run_under=@envoy//bazel/coverage:fuzz_coverage_wrapper.sh
@@ -299,7 +287,7 @@ build:remote-clang-cl --config=rbe-toolchain-clang-cl
 
 # Docker sandbox
 # NOTE: Update this from https://github.com/envoyproxy/envoy-build-tools/blob/main/toolchains/rbe_toolchains_config.bzl#L8
-build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:3de483a98c5e24973e710b4f97b2dabcd3cb621f
+build:docker-sandbox --experimental_docker_image=envoyproxy/envoy-build-ubuntu:b0ff77ae3f25b0bf595f9b8bba46b489723ab446
 build:docker-sandbox --spawn_strategy=docker
 build:docker-sandbox --strategy=Javac=docker
 build:docker-sandbox --strategy=Closure=docker

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -13,8 +13,8 @@ load(":aprutil.bzl", "aprutil_build_rule")
 load(":serf.bzl", "serf_build_rule")
 load(":closure_compiler.bzl", "closure_library_rules")
 
-ENVOY_COMMIT = "1a79dd654d0502816511bc4f43d26a71b9a144a0"  # Sep 12th, 2022
-ENVOY_SHA = "8f9582b0c2975feb1a920a964a85e2ec47d34c1790fac2f56f18566438617c99"
+ENVOY_COMMIT = "ff49762696b2e6ed3f408a22e1f7a1b7d2487318"  # Oct 11th, 2022
+ENVOY_SHA = "ff8303892364ec1be7e5be13e112bc45309aee2bc4da5c4ff035885367f24795"
 
 BROTLI_COMMIT = "d6d98957ca8ccb1ef45922e978bb10efca0ea541"
 BROTLI_SHA = "ba8be5d701b369f86d14f3701c81d6bf6c6c34015c183ff98352c12ea5f5226b"

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -13,8 +13,8 @@ load(":aprutil.bzl", "aprutil_build_rule")
 load(":serf.bzl", "serf_build_rule")
 load(":closure_compiler.bzl", "closure_library_rules")
 
-ENVOY_COMMIT = "dc168055154a99d10a2b170e8da078c6e8d001f3"  # Aug 29th, 2022
-ENVOY_SHA = "b8cb775ffdae81b734ad9d15dce3af381facd17a28e477d0ba2837c56c2f667c"
+ENVOY_COMMIT = "1a79dd654d0502816511bc4f43d26a71b9a144a0"  # Sep 12th, 2022
+ENVOY_SHA = "8f9582b0c2975feb1a920a964a85e2ec47d34c1790fac2f56f18566438617c99"
 
 BROTLI_COMMIT = "d6d98957ca8ccb1ef45922e978bb10efca0ea541"
 BROTLI_SHA = "ba8be5d701b369f86d14f3701c81d6bf6c6c34015c183ff98352c12ea5f5226b"

--- a/pagespeed.bazelrc
+++ b/pagespeed.bazelrc
@@ -23,4 +23,8 @@ build --copt="-Iexternal/serf/include/"
 build --copt="-Iexternal/serf/"
 build --copt="-DPAGESPEED_SUPPORT_POSIX_SHARED_MEM=1"
 
+build --action_env=ABSL_LEGACY_THREAD_ANNOTATIONS=1
+build --copt="-DABSL_LEGACY_THREAD_ANNOTATIONS=1"
+build --cxxopt="-DABSL_LEGACY_THREAD_ANNOTATIONS=1"
+
 build --action_env=BAZEL_CXXOPTS="-std=c++17"

--- a/pagespeed.bazelrc
+++ b/pagespeed.bazelrc
@@ -1,0 +1,26 @@
+# modifications for pagespeed over Envoy's stock config
+
+build --linkopt -ldl
+
+build:clang-asan --linkopt=-fno-sanitize=alignment
+build:asan --copt=-fno-sanitize=alignment
+build:clang-asan --copt=-fno-omit-frame-pointer
+
+test --test_env=REDIS_PORT=6379
+test --test_env=MEMCACHED_PORT=11211
+test --test_env=HTTPS_TEST=1
+
+build --copt="-Iexternal/aprutil/include/"
+build --copt="-Iexternal/aprutil/include/private/"
+build --copt="-Iexternal/aprutil/include/arch/unix/"
+build --copt="-Iexternal/aprutil/"
+build --copt="-Ithird_party/aprutil/gen/arch/linux/x64/include/"
+build --copt="-Ithird_party/apr/gen/arch/linux/x64/include/"
+build --copt="-Iexternal/apr/include/"
+build --copt="-Iexternal/apr/include/arch/unix/"
+build --copt="-Iexternal/apr/"
+build --copt="-Iexternal/serf/include/"
+build --copt="-Iexternal/serf/"
+build --copt="-DPAGESPEED_SUPPORT_POSIX_SHARED_MEM=1"
+
+build --action_env=BAZEL_CXXOPTS="-std=c++17"

--- a/pagespeed/envoy/log_message_handler.cc
+++ b/pagespeed/envoy/log_message_handler.cc
@@ -37,21 +37,23 @@ class Logger : public Envoy::Logger::Loggable<Envoy::Logger::Id::main> {
     // TODO(oschaaf): if log level is fatal we need to do more:
     // - if debugging, break
     // - else log stack trace.
-    StringPiece message = str;
-    absl::ConsumeSuffix(&message, "\n");
+    // TODO(oschaaf): fmt started complaining about StringPiece as an input.
+    // We need to strip the newline, but not introduce memory copying here.
+    //StringPiece message = str;
+    //absl::ConsumeSuffix(&message, "\n");
     constexpr char preamble[] = "[pagespeed %s] %s";
     switch (severity) {
       case logging::LOG_INFO:
-        ENVOY_LOG(info, preamble, net_instaweb::kModPagespeedVersion, message);
+        ENVOY_LOG(info, preamble, net_instaweb::kModPagespeedVersion, str);
       case logging::LOG_WARNING:
-        ENVOY_LOG(warn, preamble, net_instaweb::kModPagespeedVersion, message);
+        ENVOY_LOG(warn, preamble, net_instaweb::kModPagespeedVersion, str);
       case logging::LOG_ERROR:
-        ENVOY_LOG(error, preamble, net_instaweb::kModPagespeedVersion, message);
+        ENVOY_LOG(error, preamble, net_instaweb::kModPagespeedVersion, str);
       case logging::LOG_FATAL:
         ENVOY_LOG(critical, preamble, net_instaweb::kModPagespeedVersion,
-                  message);
+                  str);
       default:  // For VLOG(s)
-        ENVOY_LOG(debug, preamble, net_instaweb::kModPagespeedVersion, message);
+        ENVOY_LOG(debug, preamble, net_instaweb::kModPagespeedVersion, str);
     }
     return true;
   }

--- a/pagespeed/kernel/base/thread_annotations.h
+++ b/pagespeed/kernel/base/thread_annotations.h
@@ -18,7 +18,7 @@
  */
 
 #pragma once
-
+#define ABSL_LEGACY_THREAD_ANNOTATIONS 1
 #include "absl/base/thread_annotations.h"
 
 // TODO(oschaaf): move this out of here.


### PR DESCRIPTION
- sync .bazelrc
- Note: needed to define ABSL_LEGACY_THREAD_ANNOTATIONS.
Looks like some of absl's annotations have been renamed
- fmt started complaining about StringPiece as an input.
Needed to tweak logging and introduce some tech debt to
strip newlines at the end of the log line without adding
memory copying
- created a specific .bazelrc for our project to keep the top level .bazelrc as 
close to Envoy's as possible.